### PR TITLE
#7 Todo, 항목 수정, 카테고리 기능

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -47,20 +47,55 @@ include::{snippets}/todo-toggle/response-fields.adoc[]
 
 투두의 메모를 생성 및 수정합니다.
 
-=== 요청 필드
+==== 요청 필드
 include::{snippets}/todo-update-memo/request-fields.adoc[]
 
-=== 경로 파라미터
+==== 경로 파라미터
 include::{snippets}/todo-update-memo/path-parameters.adoc[]
 
-=== HTTP 요청 예시
+==== HTTP 요청 예시
 include::{snippets}/todo-update-memo/http-request.adoc[]
 
-=== HTTP 응답 예시
+==== HTTP 응답 예시
 include::{snippets}/todo-update-memo/http-response.adoc[]
 
-=== 응답 필드
+==== 응답 필드
 include::{snippets}/todo-update-memo/response-fields.adoc[]
+
+=== 투두 삭제
+`DELETE /api/todos/{todoId}`
+
+기존 투두를 삭제합니다.
+
+==== 경로 파라미터
+include::{snippets}/todo-delete/path-parameters.adoc[]
+
+==== HTTP 요청 예시
+include::{snippets}/todo-delete/http-request.adoc[]
+
+==== HTTP 응답 예시
+include::{snippets}/todo-delete/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/todo-delete/response-fields.adoc[]
+
+
+=== 탄 투두 오늘로 가져오기
+`POST /api/todos/{todoId}/bring-to-today`
+
+탄 투두를 오늘 날짜로 가져옵니다.
+
+==== 경로 파라미터
+include::{snippets}/todo-bring-to-today/path-parameters.adoc[]
+
+==== HTTP 요청 예시
+include::{snippets}/todo-bring-to-today/http-request.adoc[]
+
+==== HTTP 응답 예시
+include::{snippets}/todo-bring-to-today/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/todo-bring-to-today/response-fields.adoc[]
 
 
 == 카테고리(Category)

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -149,6 +149,21 @@ include::{snippets}/todo-update-date/http-response.adoc[]
 ==== 응답 필드
 include::{snippets}/todo-update-date/response-fields.adoc[]
 
+=== 투두 순서 변경
+`PATCH /api/todos/order`
+
+투두의 순서를 변경합니다.
+
+==== 요청 필드
+include::{snippets}/todo-reorder/request-fields.adoc[]
+==== HTTP 요청 예시
+include::{snippets}/todo-reorder/http-request.adoc[]
+==== HTTP 응답 예시
+include::{snippets}/todo-reorder/http-response.adoc[]
+==== 응답 필드
+include::{snippets}/todo-reorder/response-fields.adoc[]
+
+
 == 카테고리(Category)
 
 === 카테고리 생성
@@ -197,3 +212,20 @@ include::{snippets}/category-delete/http-request.adoc[]
 
 ==== HTTP 응답 예시
 include::{snippets}/category-delete/http-response.adoc[]
+
+=== 카테고리 순서 변경
+`PATCH /api/categories/order`
+
+카테고리의 순서를 변경합니다.
+
+==== 요청 필드
+include::{snippets}/category-reorder/request-fields.adoc[]
+
+==== HTTP 요청 예시
+include::{snippets}/category-reorder/http-request.adoc[]
+
+==== HTTP 응답 예시
+include::{snippets}/category-reorder/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/category-reorder/response-fields.adoc[]

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -42,6 +42,26 @@ include::{snippets}/todo-toggle/http-response.adoc[]
 ==== 응답 필드
 include::{snippets}/todo-toggle/response-fields.adoc[]
 
+=== 투두 메모
+`PATCH /api/todos/{todoId}/memo`
+
+투두의 메모를 생성 및 수정합니다.
+
+=== 요청 필드
+include::{snippets}/todo-update-memo/request-fields.adoc[]
+
+=== 경로 파라미터
+include::{snippets}/todo-update-memo/path-parameters.adoc[]
+
+=== HTTP 요청 예시
+include::{snippets}/todo-update-memo/http-request.adoc[]
+
+=== HTTP 응답 예시
+include::{snippets}/todo-update-memo/http-response.adoc[]
+
+=== 응답 필드
+include::{snippets}/todo-update-memo/response-fields.adoc[]
+
 
 == 카테고리(Category)
 

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -97,6 +97,39 @@ include::{snippets}/todo-bring-to-today/http-response.adoc[]
 ==== 응답 필드
 include::{snippets}/todo-bring-to-today/response-fields.adoc[]
 
+=== 내일로 미루기
+`POST /api/todos/{todoId}/postpone-to-tomorrow`
+
+투두를 내일로 미룹니다.
+
+==== 경로 파라미터
+include::{snippets}/todo-postpone-tomorrow/path-parameters.adoc[]
+
+==== HTTP 요청 예시
+include::{snippets}/todo-postpone-tomorrow/http-request.adoc[]
+
+==== HTTP 응답 예시
+include::{snippets}/todo-postpone-tomorrow/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/todo-postpone-tomorrow/response-fields.adoc[]
+
+=== 투두 오늘 하기
+`POST /api/todos/{todoId}/today`
+
+투두를 오늘 날짜로 변경합니다.
+
+==== 경로 파라미터
+include::{snippets}/todo-move-today/path-parameters.adoc[]
+
+==== HTTP 요청 예시
+include::{snippets}/todo-move-today/http-request.adoc[]
+
+==== HTTP 응답 예시
+include::{snippets}/todo-move-today/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/todo-move-today/response-fields.adoc[]
 
 == 카테고리(Category)
 

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -131,6 +131,24 @@ include::{snippets}/todo-move-today/http-response.adoc[]
 ==== 응답 필드
 include::{snippets}/todo-move-today/response-fields.adoc[]
 
+=== 투두 날짜 변경
+`PATCH /api/todos/{todoId}/date`
+
+투두의 날짜를 변경합니다.
+
+==== 요청 바디
+include::{snippets}/todo-update-date/request-body.adoc[]
+==== 요청 필드
+include::{snippets}/todo-update-date/request-fields.adoc[]
+==== 경로 파라미터
+include::{snippets}/todo-update-date/path-parameters.adoc[]
+==== HTTP 요청 예시
+include::{snippets}/todo-update-date/http-request.adoc[]
+==== HTTP 응답 예시
+include::{snippets}/todo-update-date/http-response.adoc[]
+==== 응답 필드
+include::{snippets}/todo-update-date/response-fields.adoc[]
+
 == 카테고리(Category)
 
 === 카테고리 생성

--- a/src/main/java/basakan/fryday/common/ErrorCode.java
+++ b/src/main/java/basakan/fryday/common/ErrorCode.java
@@ -19,7 +19,8 @@ public enum ErrorCode {
     CATEGORY_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "카테고리 개수는 최대 6개까지 생성할 수 있습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
 
-    TODO_NOT_FOUND(HttpStatus.NOT_FOUND, "투두를 찾을 수 없습니다.");
+    TODO_NOT_FOUND(HttpStatus.NOT_FOUND, "투두를 찾을 수 없습니다."),
+    CANNOT_DELETE_FAILED_TODO(HttpStatus.BAD_REQUEST, "타버린(미완료) 투두는 삭제할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/basakan/fryday/common/ErrorCode.java
+++ b/src/main/java/basakan/fryday/common/ErrorCode.java
@@ -21,7 +21,8 @@ public enum ErrorCode {
 
     TODO_NOT_FOUND(HttpStatus.NOT_FOUND, "투두를 찾을 수 없습니다."),
     CANNOT_DELETE_FAILED_TODO(HttpStatus.BAD_REQUEST, "타버린(미완료) 투두는 삭제할 수 없습니다."),
-    TODO_NOT_TODAY(HttpStatus.BAD_REQUEST, "오늘 날짜의 투두만 내일로 미룰 수 있습니다.");
+    TODO_NOT_TODAY(HttpStatus.BAD_REQUEST, "오늘 날짜의 투두만 내일로 미룰 수 있습니다."),
+    PAST_DATE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "과거 날짜로 변경할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/basakan/fryday/common/ErrorCode.java
+++ b/src/main/java/basakan/fryday/common/ErrorCode.java
@@ -20,7 +20,8 @@ public enum ErrorCode {
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
 
     TODO_NOT_FOUND(HttpStatus.NOT_FOUND, "투두를 찾을 수 없습니다."),
-    CANNOT_DELETE_FAILED_TODO(HttpStatus.BAD_REQUEST, "타버린(미완료) 투두는 삭제할 수 없습니다.");
+    CANNOT_DELETE_FAILED_TODO(HttpStatus.BAD_REQUEST, "타버린(미완료) 투두는 삭제할 수 없습니다."),
+    TODO_NOT_TODAY(HttpStatus.BAD_REQUEST, "오늘 날짜의 투두만 내일로 미룰 수 있습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/basakan/fryday/controller/CategoryController.java
+++ b/src/main/java/basakan/fryday/controller/CategoryController.java
@@ -4,6 +4,7 @@ import basakan.fryday.controller.dto.CategoryCreateRequest;
 import basakan.fryday.common.response.ApiResponse;
 import basakan.fryday.controller.dto.CategoryResponse;
 import basakan.fryday.controller.dto.CategoryUpdateRequest;
+import basakan.fryday.controller.dto.OrderUpdateRequest;
 import basakan.fryday.service.CategoryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +43,13 @@ public class CategoryController {
 
         categoryService.deleteCategory(categoryId, currentUserId);
         return ApiResponse.success(null, "카테고리가 삭제되었습니다.");
+    }
+
+    @PatchMapping("/reorder")
+    public ApiResponse<Void> updateCategoryOrder(@Valid @RequestBody OrderUpdateRequest request) {
+        Long currentUserId = 1L;
+        categoryService.reorderCategories(currentUserId, request);
+        return ApiResponse.success(null, "카테고리 순서가 변경되었습니다.");
     }
 }
 

--- a/src/main/java/basakan/fryday/controller/TodoController.java
+++ b/src/main/java/basakan/fryday/controller/TodoController.java
@@ -1,9 +1,6 @@
 package basakan.fryday.controller;
 
-import basakan.fryday.controller.dto.MemoResponse;
-import basakan.fryday.controller.dto.MemoRequest;
-import basakan.fryday.controller.dto.TodoResponse;
-import basakan.fryday.controller.dto.TodoSaveRequest;
+import basakan.fryday.controller.dto.*;
 import basakan.fryday.common.response.ApiResponse;
 import basakan.fryday.service.TodoService;
 import jakarta.validation.Valid;
@@ -73,5 +70,16 @@ public class TodoController {
 
         TodoResponse response = todoService.moveToToday(todoId, currentUserId);
         return ApiResponse.success(response, "오늘로 이동되었습니다.");
+    }
+
+    @PatchMapping("/{todoId}/date")
+    public ApiResponse<TodoResponse> updateTodoDate(
+            @PathVariable Long todoId,
+            @Valid @RequestBody TodoDateUpdateRequest request
+            ) {
+        Long currentUserId = 1L;
+
+        TodoResponse response = todoService.updateTodoDate(todoId, currentUserId, request);
+        return ApiResponse.success(response, "날짜가 변경되었습니다.");
     }
 }

--- a/src/main/java/basakan/fryday/controller/TodoController.java
+++ b/src/main/java/basakan/fryday/controller/TodoController.java
@@ -7,6 +7,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/todos")
@@ -76,10 +78,21 @@ public class TodoController {
     public ApiResponse<TodoResponse> updateTodoDate(
             @PathVariable Long todoId,
             @Valid @RequestBody TodoDateUpdateRequest request
-            ) {
+    ) {
         Long currentUserId = 1L;
 
         TodoResponse response = todoService.updateTodoDate(todoId, currentUserId, request);
         return ApiResponse.success(response, "날짜가 변경되었습니다.");
+    }
+
+    @PatchMapping("/reorder")
+    public ApiResponse<Void> reorderTodos(
+            @RequestParam LocalDate date,
+            @Valid @RequestBody OrderUpdateRequest request
+    ) {
+        Long currentUserId = 1L;
+
+        todoService.reorderTodos(currentUserId, date, request);
+        return ApiResponse.success(null, "투두 순서가 변경되었습니다.");
     }
 }

--- a/src/main/java/basakan/fryday/controller/TodoController.java
+++ b/src/main/java/basakan/fryday/controller/TodoController.java
@@ -1,5 +1,7 @@
 package basakan.fryday.controller;
 
+import basakan.fryday.controller.dto.MemoResponse;
+import basakan.fryday.controller.dto.MemoRequest;
 import basakan.fryday.controller.dto.TodoResponse;
 import basakan.fryday.controller.dto.TodoSaveRequest;
 import basakan.fryday.common.response.ApiResponse;
@@ -28,5 +30,16 @@ public class TodoController {
 
         TodoResponse response = todoService.toggleTodoCompletion(todoId, currentUserId);
         return ApiResponse.success(response);
+    }
+
+    @PatchMapping("/{todoId}/memo")
+    public ApiResponse<MemoResponse> updateMemo(
+            @PathVariable Long todoId,
+            @Valid @RequestBody MemoRequest request
+    ) {
+        Long currentUserId = 1L; // TODO: 실제 인증 로직이 구현되면 현재 사용자 ID를 가져오도록 수정 필요
+
+        MemoResponse response = todoService.updateMemo(todoId, currentUserId, request);
+        return ApiResponse.success(response, "메모가 저장되었습니다.");
     }
 }

--- a/src/main/java/basakan/fryday/controller/TodoController.java
+++ b/src/main/java/basakan/fryday/controller/TodoController.java
@@ -58,4 +58,20 @@ public class TodoController {
         TodoResponse response = todoService.bringTodoToToday(todoId, currentUserId);
         return ApiResponse.success(response, "투두가 오늘로 가져와졌습니다.");
     }
+
+    @PatchMapping("/{todoId}/tomorrow")
+    public ApiResponse<TodoResponse> postponeToTomorrow(@PathVariable Long todoId) {
+        Long currentUserId = 1L;
+
+        TodoResponse response = todoService.postponeToTomorrow(todoId, currentUserId);
+        return ApiResponse.success(response, "내일로 이동되었습니다.");
+    }
+
+    @PatchMapping("/{todoId}/today")
+    public ApiResponse<TodoResponse> moveToToday(@PathVariable Long todoId) {
+        Long currentUserId = 1L;
+
+        TodoResponse response = todoService.moveToToday(todoId, currentUserId);
+        return ApiResponse.success(response, "오늘로 이동되었습니다.");
+    }
 }

--- a/src/main/java/basakan/fryday/controller/TodoController.java
+++ b/src/main/java/basakan/fryday/controller/TodoController.java
@@ -42,4 +42,20 @@ public class TodoController {
         MemoResponse response = todoService.updateMemo(todoId, currentUserId, request);
         return ApiResponse.success(response, "메모가 저장되었습니다.");
     }
+
+    @DeleteMapping("/{todoId}")
+    public ApiResponse<Void> deleteTodo(@PathVariable Long todoId) {
+        Long currentUserId = 1L; // TODO: 실제 인증 로직이 구현되면 현재 사용자 ID를 가져오도록 수정 필요
+
+        todoService.deleteTodo(todoId, currentUserId);
+        return ApiResponse.success(null, "투두가 삭제되었습니다.");
+    }
+
+    @PostMapping("{todoId}/bring-to-today")
+    public ApiResponse<TodoResponse> bringTodoToToday(@PathVariable Long todoId) {
+        Long currentUserId = 1L; // TODO: 실제 인증 로직이 구현되면 현재 사용자 ID를 가져오도록 수정 필요
+
+        TodoResponse response = todoService.bringTodoToToday(todoId, currentUserId);
+        return ApiResponse.success(response, "투두가 오늘로 가져와졌습니다.");
+    }
 }

--- a/src/main/java/basakan/fryday/controller/dto/MemoRequest.java
+++ b/src/main/java/basakan/fryday/controller/dto/MemoRequest.java
@@ -1,0 +1,17 @@
+package basakan.fryday.controller.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemoRequest {
+
+    @Size(max = 300, message = "메모는 최대 300자까지 가능합니다.")
+    private String memo;
+
+    public MemoRequest(String memo) {
+        this.memo = memo;
+    }
+}

--- a/src/main/java/basakan/fryday/controller/dto/MemoResponse.java
+++ b/src/main/java/basakan/fryday/controller/dto/MemoResponse.java
@@ -1,0 +1,19 @@
+package basakan.fryday.controller.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MemoResponse {
+
+    private final Long todoId;
+    private final String memo;
+
+    public MemoResponse(Long todoId, String memo) {
+        this.todoId = todoId;
+        this.memo = memo;
+    }
+
+    public static MemoResponse from(Long todoId, String memo) {
+        return new MemoResponse(todoId, memo);
+    }
+}

--- a/src/main/java/basakan/fryday/controller/dto/OrderUpdateRequest.java
+++ b/src/main/java/basakan/fryday/controller/dto/OrderUpdateRequest.java
@@ -1,0 +1,19 @@
+package basakan.fryday.controller.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class OrderUpdateRequest {
+
+    @NotEmpty(message = "순서 변경할 ID 리스트는 필수입니다.")
+    private List<Long> ids;
+
+    public OrderUpdateRequest(List<Long> ids) {
+        this.ids = ids;
+    }
+}

--- a/src/main/java/basakan/fryday/controller/dto/TodoDateUpdateRequest.java
+++ b/src/main/java/basakan/fryday/controller/dto/TodoDateUpdateRequest.java
@@ -1,0 +1,22 @@
+package basakan.fryday.controller.dto;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class TodoDateUpdateRequest {
+
+    @NotNull(message = "변경할 날짜는 필수입니다.")
+    @FutureOrPresent(message = "과거 날짜로는 변경할 수 없습니다.")
+    private LocalDate date;
+
+    public TodoDateUpdateRequest(LocalDate date) {
+        this.date = date;
+    }
+}

--- a/src/main/java/basakan/fryday/controller/dto/TodoResponse.java
+++ b/src/main/java/basakan/fryday/controller/dto/TodoResponse.java
@@ -3,6 +3,8 @@ package basakan.fryday.controller.dto;
 import basakan.fryday.domain.Todo;
 import lombok.Getter;
 
+import java.time.LocalDate;
+
 @Getter
 public class TodoResponse {
 
@@ -11,6 +13,7 @@ public class TodoResponse {
     private final String status;
     private final Long categoryId;
     private final String memo;
+    private final LocalDate date;
 
     public TodoResponse(Todo todo) {
         this.id = todo.getId();
@@ -18,6 +21,7 @@ public class TodoResponse {
         this.status = todo.getStatus().name();
         this.categoryId = todo.getCategory().getId();
         this.memo = todo.getMemo();
+        this.date = todo.getDate();
     }
 
     public static TodoResponse from(Todo todo) {

--- a/src/main/java/basakan/fryday/controller/dto/TodoResponse.java
+++ b/src/main/java/basakan/fryday/controller/dto/TodoResponse.java
@@ -10,12 +10,14 @@ public class TodoResponse {
     private final String description;
     private final String status;
     private final Long categoryId;
+    private final String memo;
 
     public TodoResponse(Todo todo) {
         this.id = todo.getId();
         this.description = todo.getDescription();
         this.status = todo.getStatus().name();
         this.categoryId = todo.getCategory().getId();
+        this.memo = todo.getMemo();
     }
 
     public static TodoResponse from(Todo todo) {

--- a/src/main/java/basakan/fryday/domain/Category.java
+++ b/src/main/java/basakan/fryday/domain/Category.java
@@ -25,11 +25,15 @@ public class Category extends BaseEntity{
 
     private LocalDateTime deletedAt;
 
+    @Column(nullable = false)
+    private Long displayOrder;
+
     @Builder
-    public Category(String name, CategoryColor color, Long userId) {
+    public Category(String name, CategoryColor color, Long userId, Long displayOrder) {
         this.name = name;
         this.color = color;
         this.userId = userId;
+        this.displayOrder = displayOrder != null ? displayOrder : 0L;
     }
 
     public void update(String name, CategoryColor color) {
@@ -43,5 +47,9 @@ public class Category extends BaseEntity{
 
     public boolean isDeleted() {
         return this.deletedAt != null;
+    }
+
+    public void updateDisplayOrder(Long displayOrder) {
+        this.displayOrder = displayOrder;
     }
 }

--- a/src/main/java/basakan/fryday/domain/Todo.java
+++ b/src/main/java/basakan/fryday/domain/Todo.java
@@ -33,6 +33,9 @@ public class Todo extends BaseEntity {
 
     private LocalDate deletedAt;
 
+    @Column(nullable = false)
+    private Long displayOrder;
+
     public enum Status {
         IN_PROGRESS, // 튀기는 중(기본 상태)
         COMPLETED,   // 튀김(완료)
@@ -40,11 +43,12 @@ public class Todo extends BaseEntity {
     }
 
     @Builder
-    public Todo(String description, Category category, LocalDate date) {
+    public Todo(String description, Category category, LocalDate date, Long displayOrder) {
         this.description = description;
         this.status = Status.IN_PROGRESS;
         this.category = category;
         this.date = (date != null) ? date : LocalDate.now();
+        this.displayOrder = displayOrder != null ? displayOrder : 0L;
     }
 
     public void toggleCompletion() {
@@ -73,6 +77,10 @@ public class Todo extends BaseEntity {
 
     public void updateDate(LocalDate date) {
         this.date = date;
+    }
+
+    public void updateDisplayOrder(Long displayOrder) {
+        this.displayOrder = displayOrder;
     }
 
 }

--- a/src/main/java/basakan/fryday/domain/Todo.java
+++ b/src/main/java/basakan/fryday/domain/Todo.java
@@ -6,6 +6,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -29,6 +32,11 @@ public class Todo {
     @Column(length = 300)
     private String memo;
 
+    @Column(nullable = false)
+    private LocalDate date;
+
+    private LocalDate deletedAt;
+
     public enum Status {
         IN_PROGRESS, // 튀기는 중(기본 상태)
         COMPLETED,   // 튀김(완료)
@@ -36,10 +44,11 @@ public class Todo {
     }
 
     @Builder
-    public Todo(String description, Category category) {
+    public Todo(String description, Category category, LocalDate date) {
         this.description = description;
         this.status = Status.IN_PROGRESS;
         this.category = category;
+        this.date = (date != null) ? date : LocalDate.now();
     }
 
     public void toggleCompletion() {
@@ -52,6 +61,18 @@ public class Todo {
 
     public void updateMemo(String memo) {
         this.memo = memo;
+    }
+
+    public void delete() {
+        this.deletedAt = LocalDate.now();
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+
+    public boolean isFailed() {
+        return this.status == Status.FAILED;
     }
 
 }

--- a/src/main/java/basakan/fryday/domain/Todo.java
+++ b/src/main/java/basakan/fryday/domain/Todo.java
@@ -26,6 +26,9 @@ public class Todo {
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 
+    @Column(length = 300)
+    private String memo;
+
     public enum Status {
         IN_PROGRESS, // 튀기는 중(기본 상태)
         COMPLETED,   // 튀김(완료)
@@ -45,6 +48,10 @@ public class Todo {
         } else {
             this.status = Status.COMPLETED;
         }
+    }
+
+    public void updateMemo(String memo) {
+        this.memo = memo;
     }
 
 }

--- a/src/main/java/basakan/fryday/domain/Todo.java
+++ b/src/main/java/basakan/fryday/domain/Todo.java
@@ -75,4 +75,8 @@ public class Todo {
         return this.status == Status.FAILED;
     }
 
+    public void updateDate(LocalDate date) {
+        this.date = date;
+    }
+
 }

--- a/src/main/java/basakan/fryday/repository/CategoryRepository.java
+++ b/src/main/java/basakan/fryday/repository/CategoryRepository.java
@@ -2,6 +2,8 @@ package basakan.fryday.repository;
 
 import basakan.fryday.domain.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,5 +12,10 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     long countByUserIdAndDeletedAtIsNull(Long userId);
 
     Optional<Category> findByIdAndUserIdAndDeletedAtIsNull(Long id, Long userId);
+
+    @Query("SELECT MAX(c.displayOrder) FROM Category c WHERE c.userId = :userId AND c.deletedAt IS NULL")
+    Long findMaxDisplayOrder(@Param("userId") Long userId);
+
+    List<Category> findAllByUserIdAndDeletedAtIsNullOrderByDisplayOrderAsc(Long userId);
 }
 

--- a/src/main/java/basakan/fryday/repository/TodoRepository.java
+++ b/src/main/java/basakan/fryday/repository/TodoRepository.java
@@ -2,6 +2,15 @@ package basakan.fryday.repository;
 
 import basakan.fryday.domain.Todo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
+    List<Todo> findAllByCategory_UserIdAndDateAndDeletedAtIsNullOrderByDisplayOrderAsc(Long userId, LocalDate date);
+
+    @Query("SELECT MAX(t.displayOrder) FROM Todo t JOIN t.category c WHERE c.userId = :userId AND t.date = :date AND t.deletedAt IS NULL")
+    Long findMaxDisplayOrder(@Param("userId") Long userId, @Param("date") LocalDate date);
 }

--- a/src/main/java/basakan/fryday/service/CategoryService.java
+++ b/src/main/java/basakan/fryday/service/CategoryService.java
@@ -5,6 +5,8 @@ import basakan.fryday.common.ErrorCode;
 import basakan.fryday.common.exception.BusinessException;
 import basakan.fryday.controller.dto.CategoryResponse;
 import basakan.fryday.controller.dto.CategoryUpdateRequest;
+import basakan.fryday.controller.dto.OrderUpdateRequest;
+import basakan.fryday.domain.BaseEntity;
 import basakan.fryday.domain.Category;
 import basakan.fryday.domain.CategoryColor;
 import basakan.fryday.repository.CategoryRepository;
@@ -13,6 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -30,10 +34,14 @@ public class CategoryService {
             throw new BusinessException(ErrorCode.CATEGORY_LIMIT_EXCEEDED);
         }
 
+        Long maxOrder = categoryRepository.findMaxDisplayOrder(request.getUserId());
+        long nextOrder = (maxOrder == null) ? 1 : maxOrder + 1;
+
         Category category = Category.builder()
                 .name(request.getName())
                 .color(request.getColor())
                 .userId(request.getUserId())
+                .displayOrder(nextOrder)
                 .build();
 
         Category savedCategory = categoryRepository.save(category);
@@ -57,6 +65,23 @@ public class CategoryService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
 
         category.delete();
+    }
+
+    @Transactional
+    public void reorderCategories(Long userId, OrderUpdateRequest request) {
+        List<Long> idList = request.getIds();
+
+        List<Category> categories = categoryRepository.findAllByUserIdAndDeletedAtIsNullOrderByDisplayOrderAsc(userId);
+
+        Map<Long, Category> categoryMap = categories.stream()
+                .collect(Collectors.toMap(BaseEntity::getId, c -> c));
+
+        for (int i = 0; i < idList.size(); i++) {
+            Category category = categoryMap.get(idList.get(i));
+            if (category != null) {
+                category.updateDisplayOrder((long) (i + 1));
+            }
+        }
     }
 
     @Transactional

--- a/src/main/java/basakan/fryday/service/TodoService.java
+++ b/src/main/java/basakan/fryday/service/TodoService.java
@@ -2,10 +2,7 @@ package basakan.fryday.service;
 
 import basakan.fryday.common.ErrorCode;
 import basakan.fryday.common.exception.BusinessException;
-import basakan.fryday.controller.dto.MemoResponse;
-import basakan.fryday.controller.dto.MemoRequest;
-import basakan.fryday.controller.dto.TodoResponse;
-import basakan.fryday.controller.dto.TodoSaveRequest;
+import basakan.fryday.controller.dto.*;
 import basakan.fryday.domain.Category;
 import basakan.fryday.domain.Todo;
 import basakan.fryday.repository.CategoryRepository;
@@ -103,6 +100,20 @@ public class TodoService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
 
         todo.updateDate(LocalDate.now());
+
+        return TodoResponse.from(todo);
+    }
+
+    @Transactional
+    public TodoResponse updateTodoDate(Long todoId, Long userId, TodoDateUpdateRequest request) {
+        Todo todo = todoRepository.findById(todoId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        if (request.getDate().isBefore(LocalDate.now())) {
+            throw new BusinessException(ErrorCode.PAST_DATE_NOT_ALLOWED);
+        }
+
+        todo.updateDate(request.getDate());
 
         return TodoResponse.from(todo);
     }

--- a/src/main/java/basakan/fryday/service/TodoService.java
+++ b/src/main/java/basakan/fryday/service/TodoService.java
@@ -3,6 +3,7 @@ package basakan.fryday.service;
 import basakan.fryday.common.ErrorCode;
 import basakan.fryday.common.exception.BusinessException;
 import basakan.fryday.controller.dto.*;
+import basakan.fryday.domain.BaseEntity;
 import basakan.fryday.domain.Category;
 import basakan.fryday.domain.Todo;
 import basakan.fryday.repository.CategoryRepository;
@@ -12,6 +13,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +30,11 @@ public class TodoService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
 
         Todo todo = request.toEntity(category);
+
+        Long maxOrder = todoRepository.findMaxDisplayOrder(category.getUserId(), todo.getDate());
+        long nextOrder = (maxOrder == null) ? 1 : maxOrder + 1;
+
+        todo.updateDisplayOrder(nextOrder);
 
         Todo saveTodo = todoRepository.save(todo);
 
@@ -116,6 +125,23 @@ public class TodoService {
         todo.updateDate(request.getDate());
 
         return TodoResponse.from(todo);
+    }
+
+    @Transactional
+    public void reorderTodos(Long userId, LocalDate date, OrderUpdateRequest request) {
+        List<Long> idList = request.getIds();
+
+        List<Todo> todos = todoRepository.findAllByCategory_UserIdAndDateAndDeletedAtIsNullOrderByDisplayOrderAsc(userId, date);
+
+        Map<Long, Todo> todoMap = todos.stream()
+                .collect(Collectors.toMap(BaseEntity::getId, t -> t));
+
+        for (int i = 0; i < idList.size(); i++) {
+            Todo todo = todoMap.get(idList.get(i));
+            if (todo != null) {
+                todo.updateDisplayOrder((long) (i + 1));
+            }
+        }
     }
 
 }

--- a/src/main/java/basakan/fryday/service/TodoService.java
+++ b/src/main/java/basakan/fryday/service/TodoService.java
@@ -2,6 +2,8 @@ package basakan.fryday.service;
 
 import basakan.fryday.common.ErrorCode;
 import basakan.fryday.common.exception.BusinessException;
+import basakan.fryday.controller.dto.MemoResponse;
+import basakan.fryday.controller.dto.MemoRequest;
 import basakan.fryday.controller.dto.TodoResponse;
 import basakan.fryday.controller.dto.TodoSaveRequest;
 import basakan.fryday.domain.Category;
@@ -39,6 +41,16 @@ public class TodoService {
         todo.toggleCompletion();;
 
         return TodoResponse.from(todo);
+    }
+
+    @Transactional
+    public MemoResponse updateMemo(Long todoId, Long userId, MemoRequest request) {
+        Todo todo = todoRepository.findById(todoId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        todo.updateMemo(request.getMemo());
+
+        return MemoResponse.from(todo.getId(), todo.getMemo());
     }
 
 }

--- a/src/main/java/basakan/fryday/service/TodoService.java
+++ b/src/main/java/basakan/fryday/service/TodoService.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+
 @Service
 @RequiredArgsConstructor
 public class TodoService {
@@ -51,6 +53,34 @@ public class TodoService {
         todo.updateMemo(request.getMemo());
 
         return MemoResponse.from(todo.getId(), todo.getMemo());
+    }
+
+    @Transactional
+    public void deleteTodo(Long todoId, Long userId) {
+        Todo todo = todoRepository.findById(todoId)
+                .filter(t -> !t.isDeleted())
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        if (todo.isFailed()) {
+            throw new BusinessException(ErrorCode.CANNOT_DELETE_FAILED_TODO);
+        }
+
+        todoRepository.delete(todo);
+    }
+
+    @Transactional
+    public TodoResponse bringTodoToToday(Long todoId, Long userId) {
+        Todo originalTodo = todoRepository.findById(todoId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        Todo newTodo = Todo.builder()
+                .description(originalTodo.getDescription())
+                .category(originalTodo.getCategory())
+                .date(LocalDate.now())
+                .build();
+
+        Todo saveTodo = todoRepository.save(newTodo);
+        return TodoResponse.from(saveTodo);
     }
 
 }

--- a/src/main/java/basakan/fryday/service/TodoService.java
+++ b/src/main/java/basakan/fryday/service/TodoService.java
@@ -83,4 +83,28 @@ public class TodoService {
         return TodoResponse.from(saveTodo);
     }
 
+    @Transactional
+    public TodoResponse postponeToTomorrow(Long todoId, Long userId) {
+        Todo todo = todoRepository.findById(todoId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        if (!todo.getDate().equals(LocalDate.now())) {
+            throw new BusinessException(ErrorCode.TODO_NOT_TODAY);
+        }
+
+        todo.updateDate(LocalDate.now().plusDays(1));
+
+        return TodoResponse.from(todo);
+    }
+
+    @Transactional
+    public TodoResponse moveToToday(Long todoId, Long userId) {
+        Todo todo = todoRepository.findById(todoId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        todo.updateDate(LocalDate.now());
+
+        return TodoResponse.from(todo);
+    }
+
 }

--- a/src/test/java/basakan/fryday/controller/CategoryControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/CategoryControllerTest.java
@@ -4,6 +4,7 @@ import basakan.fryday.RestDocsSupport;
 import basakan.fryday.controller.dto.CategoryCreateRequest;
 import basakan.fryday.controller.dto.CategoryResponse;
 import basakan.fryday.controller.dto.CategoryUpdateRequest;
+import basakan.fryday.controller.dto.OrderUpdateRequest;
 import basakan.fryday.domain.Category;
 import basakan.fryday.domain.CategoryColor;
 import basakan.fryday.service.CategoryService;
@@ -14,13 +15,14 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.util.ReflectionTestUtils.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -137,6 +139,31 @@ class CategoryControllerTest extends RestDocsSupport {
                                 fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
                                 fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
                                 fieldWithPath("data").type(JsonFieldType.NULL).description("데이터 (없음)").optional(),
+                                fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("카테고리 순서 변경")
+    void reorderCategories() throws Exception {
+        // given
+        List<Long> newOrderIds = List.of(3L, 1L, 2L);
+        OrderUpdateRequest request = new OrderUpdateRequest(newOrderIds);
+
+        // when & then
+        mockMvc.perform(patch("/api/categories/reorder")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("category-reorder",
+                        requestFields(
+                                fieldWithPath("ids").type(JsonFieldType.ARRAY).description("변경할 순서대로 나열된 카테고리 ID 리스트")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
                                 fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
                         )
                 ));

--- a/src/test/java/basakan/fryday/controller/TodoControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/TodoControllerTest.java
@@ -17,6 +17,8 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDate;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -79,6 +81,7 @@ class TodoControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.description").type(JsonFieldType.STRING).description("할 일 내용"),
                                 fieldWithPath("data.status").type(JsonFieldType.STRING).description("상태 (IN_PROGRESS, COMPLETED, FAILED)"),
                                 fieldWithPath("data.categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
+                                fieldWithPath("data.memo").type(JsonFieldType.STRING).description("메모").optional(),
 
                                 fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
                         )
@@ -120,6 +123,7 @@ class TodoControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.description").type(JsonFieldType.STRING).description("할 일 내용"),
                                 fieldWithPath("data.status").type(JsonFieldType.STRING).description("변경 후 상태 (IN_PROGRESS <-> COMPLETED)"),
                                 fieldWithPath("data.categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
+                                fieldWithPath("data.memo").type(JsonFieldType.STRING).description("메모").optional(),
 
                                 fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
                         )
@@ -159,6 +163,74 @@ class TodoControllerTest extends RestDocsSupport {
 
                                 fieldWithPath("data.todoId").type(JsonFieldType.NUMBER).description("투두 ID"),
                                 fieldWithPath("data.memo").type(JsonFieldType.STRING).description("저장된 메모 내용"),
+
+                                fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("투두 삭제 API")
+    void deleteTodo() throws Exception {
+        // given
+        Long todoId = 1L;
+
+        // when & then
+        mockMvc.perform(delete("/api/todos/{todoId}", todoId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("todo-delete",
+                        pathParameters(
+                                parameterWithName("todoId").description("삭제할 투두 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("지난 투두 오늘로 가져오기 API")
+    void bringTodoToToday() throws Exception {
+        // given
+        Long originalTodoId = 99L; // 과거의 투두 ID
+        Long newTodoId = 100L;     // 새로 생성될 투두 ID
+
+        Category mockCategory = Category.builder().name("요리").color(CategoryColor.BR).userId(1L).build();
+        ReflectionTestUtils.setField(mockCategory, "id", 1L);
+
+        Todo newMockTodo = Todo.builder()
+                .description("양파 썰기") // 내용은 그대로
+                .category(mockCategory)
+                .date(LocalDate.now())    // 날짜는 오늘
+                .build();
+        ReflectionTestUtils.setField(newMockTodo, "id", newTodoId);
+
+        // Service Mocking
+        given(todoService.bringTodoToToday(anyLong(), anyLong()))
+                .willReturn(TodoResponse.from(newMockTodo));
+
+        // when & then
+        mockMvc.perform(post("/api/todos/{todoId}/bring-to-today", originalTodoId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("todo-bring-to-today",
+                        pathParameters(
+                                parameterWithName("todoId").description("가져올 과거의 투두 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("새로 생성된 투두 ID"),
+                                fieldWithPath("data.description").type(JsonFieldType.STRING).description("할 일 내용"),
+                                fieldWithPath("data.status").type(JsonFieldType.STRING).description("상태 (초기화됨: IN_PROGRESS)"),
+                                fieldWithPath("data.categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
+                                fieldWithPath("data.memo").type(JsonFieldType.NULL).description("메모 (초기엔 없음)").optional(),
 
                                 fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
                         )

--- a/src/test/java/basakan/fryday/controller/TodoControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/TodoControllerTest.java
@@ -1,6 +1,8 @@
 package basakan.fryday.controller;
 
 import basakan.fryday.RestDocsSupport;
+import basakan.fryday.common.ErrorCode;
+import basakan.fryday.common.exception.BusinessException;
 import basakan.fryday.controller.dto.MemoRequest;
 import basakan.fryday.controller.dto.MemoResponse;
 import basakan.fryday.controller.dto.TodoResponse;
@@ -28,6 +30,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(TodoController.class)
@@ -82,6 +85,7 @@ class TodoControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.status").type(JsonFieldType.STRING).description("상태 (IN_PROGRESS, COMPLETED, FAILED)"),
                                 fieldWithPath("data.categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
                                 fieldWithPath("data.memo").type(JsonFieldType.STRING).description("메모").optional(),
+                                fieldWithPath("data.date").type(JsonFieldType.STRING).description("투두 날짜"),
 
                                 fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
                         )
@@ -124,6 +128,7 @@ class TodoControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.status").type(JsonFieldType.STRING).description("변경 후 상태 (IN_PROGRESS <-> COMPLETED)"),
                                 fieldWithPath("data.categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
                                 fieldWithPath("data.memo").type(JsonFieldType.STRING).description("메모").optional(),
+                                fieldWithPath("data.date").type(JsonFieldType.STRING).description("투두 날짜"),
 
                                 fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
                         )
@@ -231,6 +236,118 @@ class TodoControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.status").type(JsonFieldType.STRING).description("상태 (초기화됨: IN_PROGRESS)"),
                                 fieldWithPath("data.categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
                                 fieldWithPath("data.memo").type(JsonFieldType.NULL).description("메모 (초기엔 없음)").optional(),
+                                fieldWithPath("data.date").type(JsonFieldType.STRING).description("투두 날짜 (오늘 날짜)"),
+
+                                fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("투두 내일 하기 (날짜 미루기)")
+    void postponeToTomorrow() throws Exception {
+        // given
+        Long todoId = 1L;
+        LocalDate tomorrow = LocalDate.now().plusDays(1);
+
+        Category mockCategory = Category.builder().name("요리").color(CategoryColor.BR).userId(1L).build();
+        ReflectionTestUtils.setField(mockCategory, "id", 1L);
+
+        Todo mockTodo = Todo.builder()
+                .description("양파 썰기")
+                .category(mockCategory)
+                .date(tomorrow)
+                .build();
+        ReflectionTestUtils.setField(mockTodo, "id", todoId);
+
+        given(todoService.postponeToTomorrow(anyLong(), anyLong()))
+                .willReturn(TodoResponse.from(mockTodo));
+
+        // when & then
+        mockMvc.perform(patch("/api/todos/{todoId}/tomorrow", todoId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("todo-postpone-tomorrow",
+                        pathParameters(
+                                parameterWithName("todoId").description("미룰 투두 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("투두 ID"),
+                                fieldWithPath("data.description").type(JsonFieldType.STRING).description("할 일 내용"),
+                                fieldWithPath("data.status").type(JsonFieldType.STRING).description("상태"),
+                                fieldWithPath("data.categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
+                                fieldWithPath("data.memo").type(JsonFieldType.STRING).description("메모").optional(),
+
+                                fieldWithPath("data.date").type(JsonFieldType.STRING).description("변경 후 날짜 (내일)"),
+
+                                fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("투두 내일 하기 실패 - 오늘 날짜가 아닌 경우")
+    void postponeToTomorrow_Fail_NotToday() throws Exception {
+        // given
+        Long todoId = 1L;
+
+        // Mocking: Service가 예외를 던지도록 설정
+        given(todoService.postponeToTomorrow(anyLong(), anyLong()))
+                .willThrow(new BusinessException(ErrorCode.TODO_NOT_TODAY));
+
+        // when & then
+        mockMvc.perform(patch("/api/todos/{todoId}/tomorrow", todoId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("오늘 날짜의 투두만 내일로 미룰 수 있습니다."));
+    }
+
+    @Test
+    @DisplayName("투두 오늘 하기 (날짜 당기기)")
+    void moveToToday() throws Exception {
+        // given
+        Long todoId = 1L;
+        LocalDate today = LocalDate.now();
+
+        // Mocking: 날짜가 오늘로 변경된 투두 응답
+        Category mockCategory = Category.builder().name("요리").color(CategoryColor.BR).userId(1L).build();
+        ReflectionTestUtils.setField(mockCategory, "id", 1L);
+
+        Todo mockTodo = Todo.builder()
+                .description("양파 썰기")
+                .category(mockCategory)
+                .date(today)
+                .build();
+        ReflectionTestUtils.setField(mockTodo, "id", todoId);
+
+        given(todoService.moveToToday(anyLong(), anyLong()))
+                .willReturn(TodoResponse.from(mockTodo));
+
+        // when & then
+        mockMvc.perform(patch("/api/todos/{todoId}/today", todoId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("todo-move-today",
+                        pathParameters(
+                                parameterWithName("todoId").description("가져올 투두 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("투두 ID"),
+                                fieldWithPath("data.description").type(JsonFieldType.STRING).description("할 일 내용"),
+                                fieldWithPath("data.status").type(JsonFieldType.STRING).description("상태"),
+                                fieldWithPath("data.categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
+                                fieldWithPath("data.memo").type(JsonFieldType.STRING).description("메모").optional(),
+
+                                fieldWithPath("data.date").type(JsonFieldType.STRING).description("변경 후 날짜 (오늘)"),
 
                                 fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
                         )

--- a/src/test/java/basakan/fryday/controller/TodoControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/TodoControllerTest.java
@@ -1,6 +1,8 @@
 package basakan.fryday.controller;
 
 import basakan.fryday.RestDocsSupport;
+import basakan.fryday.controller.dto.MemoRequest;
+import basakan.fryday.controller.dto.MemoResponse;
 import basakan.fryday.controller.dto.TodoResponse;
 import basakan.fryday.controller.dto.TodoSaveRequest;
 import basakan.fryday.domain.Category;
@@ -19,7 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
@@ -118,6 +120,45 @@ class TodoControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.description").type(JsonFieldType.STRING).description("할 일 내용"),
                                 fieldWithPath("data.status").type(JsonFieldType.STRING).description("변경 후 상태 (IN_PROGRESS <-> COMPLETED)"),
                                 fieldWithPath("data.categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
+
+                                fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("투두 메모 API")
+    void updateMemo() throws Exception {
+        // given
+        Long todoId = 1L;
+        String memoContent = "튀김옷 꼼꼼히 입히기";
+        MemoRequest request = new MemoRequest(memoContent);
+
+        MemoResponse mockResponse = MemoResponse.from(todoId, memoContent);
+
+        // Mocking: Service 호출 시 위의 가짜 객체 반환
+        given(todoService.updateMemo(anyLong(), anyLong(), any(MemoRequest.class)))
+                .willReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(patch("/api/todos/{todoId}/memo", todoId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("todo-update-memo",
+                        pathParameters(
+                                parameterWithName("todoId").description("메모를 수정할 투두 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("memo").type(JsonFieldType.STRING).description("수정할 메모 내용")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+
+                                fieldWithPath("data.todoId").type(JsonFieldType.NUMBER).description("투두 ID"),
+                                fieldWithPath("data.memo").type(JsonFieldType.STRING).description("저장된 메모 내용"),
 
                                 fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
                         )

--- a/src/test/java/basakan/fryday/controller/TodoControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/TodoControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -24,8 +25,7 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -395,6 +395,36 @@ class TodoControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
                                 fieldWithPath("data.memo").type(JsonFieldType.STRING).description("메모").optional(),
                                 fieldWithPath("data.date").type(JsonFieldType.STRING).description("변경된 날짜"),
+                                fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("투두 순서 변경")
+    void reorderTodos() throws Exception {
+        // given
+        LocalDate targetDate = LocalDate.of(2025, 11, 26);
+        List<Long> newOrderIds = List.of(3L, 1L, 2L); // 3번->1등, 1번->2등, 2번->3등
+        OrderUpdateRequest request = new OrderUpdateRequest(newOrderIds);
+
+        // when & then
+        mockMvc.perform(patch("/api/todos/reorder")
+                        .param("date", String.valueOf(targetDate))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("todo-reorder",
+                        queryParameters(
+                                parameterWithName("date").description("순서를 변경할 날짜 (YYYY-MM-DD)")
+                        ),
+                        requestFields(
+                                fieldWithPath("ids").type(JsonFieldType.ARRAY).description("변경된 순서대로 나열된 투두 ID 리스트")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
                                 fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
                         )
                 ));

--- a/src/test/java/basakan/fryday/controller/TodoControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/TodoControllerTest.java
@@ -3,10 +3,7 @@ package basakan.fryday.controller;
 import basakan.fryday.RestDocsSupport;
 import basakan.fryday.common.ErrorCode;
 import basakan.fryday.common.exception.BusinessException;
-import basakan.fryday.controller.dto.MemoRequest;
-import basakan.fryday.controller.dto.MemoResponse;
-import basakan.fryday.controller.dto.TodoResponse;
-import basakan.fryday.controller.dto.TodoSaveRequest;
+import basakan.fryday.controller.dto.*;
 import basakan.fryday.domain.Category;
 import basakan.fryday.domain.CategoryColor;
 import basakan.fryday.domain.Todo;
@@ -349,6 +346,55 @@ class TodoControllerTest extends RestDocsSupport {
 
                                 fieldWithPath("data.date").type(JsonFieldType.STRING).description("변경 후 날짜 (오늘)"),
 
+                                fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("투두 날짜 변경")
+    void updateTodoDate() throws Exception {
+        // given
+        Long todoId = 1L;
+        LocalDate futureDate = LocalDate.now().plusDays(5); // 5일 뒤로 변경
+        TodoDateUpdateRequest request = new TodoDateUpdateRequest(futureDate);
+
+        // Mocking
+        Category mockCategory = Category.builder().name("요리").color(CategoryColor.BR).userId(1L).build();
+        ReflectionTestUtils.setField(mockCategory, "id", 1L);
+        Todo mockTodo = Todo.builder()
+                .description("장보기")
+                .category(mockCategory)
+                .date(futureDate) // 변경된 날짜
+                .build();
+        ReflectionTestUtils.setField(mockTodo, "id", todoId);
+
+        given(todoService.updateTodoDate(anyLong(), anyLong(), any(TodoDateUpdateRequest.class)))
+                .willReturn(TodoResponse.from(mockTodo));
+
+        // when & then
+        mockMvc.perform(patch("/api/todos/{todoId}/date", todoId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("todo-update-date",
+                        pathParameters(
+                                parameterWithName("todoId").description("수정할 투두 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("date").type(JsonFieldType.STRING).description("변경할 날짜 (YYYY-MM-DD, 오늘 이후만 가능)")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                // data 필드 검증
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("투두 ID"),
+                                fieldWithPath("data.description").type(JsonFieldType.STRING).description("할 일 내용"),
+                                fieldWithPath("data.status").type(JsonFieldType.STRING).description("상태"),
+                                fieldWithPath("data.categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
+                                fieldWithPath("data.memo").type(JsonFieldType.STRING).description("메모").optional(),
+                                fieldWithPath("data.date").type(JsonFieldType.STRING).description("변경된 날짜"),
                                 fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
                         )
                 ));


### PR DESCRIPTION
## 📌 Related Issue
- close: #7

## 🚀 Description

투두 및 카테고리 관리 기능을 확장하여 메모 기능, 날짜 관리, 순서 변경 등의 API를 추가

### 1. 투두 메모 API (Ad-004)
- **엔드포인트**: `PATCH /api/todos/{todoId}/memo`
- 투두에 메모를 생성 및 수정할 수 있는 기능 추가
- 메모는 최대 300자까지 저장 가능

### 2. 투두 삭제 API (Ad-002)
- **엔드포인트**: `DELETE /api/todos/{todoId}`
- 탐(FAILED) 상태의 투두는 삭제 불가능하도록 검증 로직 추가

### 3. 탄 투두 오늘로 가져오기 API (Todo-006)
- **엔드포인트**: `POST /api/todos/{todoId}/bring-to-today`
- 탐 상태의 투두를 오늘 날짜로 복사하여 새로운 투두로 생성

### 4. 투두 날짜 관리 API (Ad-006, Ad-007)
- **내일로 미루기**: `PATCH /api/todos/{todoId}/tomorrow`
  - 오늘 날짜의 투두를 내일로 이동
- **오늘로 이동**: `PATCH /api/todos/{todoId}/today`
  - 투두를 오늘 날짜로 변경
- **날짜 변경**: `PATCH /api/todos/{todoId}/date`
  - 투두의 날짜를 지정한 날짜로 변경 (과거 날짜는 불가능)

### 5. 투두 순서 변경 API
- **엔드포인트**: `PATCH /api/todos/reorder?date={date}`
- 특정 날짜의 투두들의 순서를 변경
- `displayOrder` 필드를 활용하여 순서 관리

### 6. 카테고리 순서 변경 API
- **엔드포인트**: `PATCH /api/categories/reorder`
- 카테고리들의 순서를 변경
- `displayOrder` 필드를 활용하여 순서 관리

### 7. BaseEntity 추가

## 📢 Notes
- `Todo-003`은 투두, 카테고리 조회 API 구현하면서 개발 예정
