### PR TITLE
#18 Ad-002, Ad-003, Todo-003 수정

### DIFF
--- a/src/main/java/basakan/fryday/controller/todo/TodoController.java
+++ b/src/main/java/basakan/fryday/controller/todo/TodoController.java
@@ -129,10 +129,10 @@ public class TodoController {
     }
 
     @PostMapping("/recurrence")
-    public ApiResponse<Void> createRecurringTodo(@Valid @RequestBody RecurrenceCreateRequest request) {
+    public ApiResponse<TodoResponse> createRecurringTodo(@Valid @RequestBody RecurrenceCreateRequest request) {
         Long currentUserId = 1L;
 
-        recurrenceService.createRecurrence(currentUserId, request);
-        return ApiResponse.success(null, "반복 투두가 생성되었습니다.");
+        TodoResponse response = recurrenceService.createRecurrence(currentUserId, request);
+        return ApiResponse.success(response, "반복 투두가 생성되었습니다.");
     }
 }

--- a/src/main/java/basakan/fryday/controller/todo/request/RecurrenceCreateRequest.java
+++ b/src/main/java/basakan/fryday/controller/todo/request/RecurrenceCreateRequest.java
@@ -25,7 +25,7 @@ public class RecurrenceCreateRequest {
     @NotNull(message = "시작일은 필수입니다.")
     private LocalDate startDate;
 
-    private LocalDate endDate; // null이면 무한 반복 (Rolling Window Strategy)
+    private LocalDate endDate;
 
     private LocalTime notificationTime;
 

--- a/src/main/java/basakan/fryday/controller/todo/request/RecurrenceCreateRequest.java
+++ b/src/main/java/basakan/fryday/controller/todo/request/RecurrenceCreateRequest.java
@@ -25,8 +25,7 @@ public class RecurrenceCreateRequest {
     @NotNull(message = "시작일은 필수입니다.")
     private LocalDate startDate;
 
-    @NotNull(message = "종료일은 필수입니다.")
-    private LocalDate endDate;
+    private LocalDate endDate; // null이면 무한 반복 (Rolling Window Strategy)
 
     private LocalTime notificationTime;
 

--- a/src/main/java/basakan/fryday/domain/todo/Recurrence.java
+++ b/src/main/java/basakan/fryday/domain/todo/Recurrence.java
@@ -36,14 +36,17 @@ public class Recurrence extends BaseEntity {
     @Column(nullable = false)
     private LocalDate startDate;
 
-    @Column(nullable = false)
     private LocalDate endDate;
 
     private LocalTime notificationTime;
 
+    @Column(nullable = false)
+    private LocalDate lastGeneratedDate;
+
     @Builder
     public Recurrence(long userId, long categoryId, String description, RecurrenceType type,
-                      String frequencyValues, LocalDate startDate, LocalDate endDate, LocalTime notificationTime) {
+                      String frequencyValues, LocalDate startDate, LocalDate endDate,
+                      LocalTime notificationTime, LocalDate lastGeneratedDate) {
         this.userId = userId;
         this.categoryId = categoryId;
         this.description = description;
@@ -52,5 +55,10 @@ public class Recurrence extends BaseEntity {
         this.startDate = startDate;
         this.endDate = endDate;
         this.notificationTime = notificationTime;
+        this.lastGeneratedDate = lastGeneratedDate;
+    }
+
+    public void updateLastGeneratedDate(LocalDate date) {
+        this.lastGeneratedDate = date;
     }
 }

--- a/src/main/java/basakan/fryday/domain/todo/Todo.java
+++ b/src/main/java/basakan/fryday/domain/todo/Todo.java
@@ -37,7 +37,8 @@ public class Todo extends BaseEntity {
     @Column(nullable = false)
     private Long displayOrder;
 
-    private long recurrenceId;
+    @Column(name = "recurrence_id")
+    private Long recurrenceId;
 
     public enum Status {
         IN_PROGRESS, // 미완료 (체크 안 됨)

--- a/src/main/java/basakan/fryday/repository/todo/RecurrenceRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/RecurrenceRepository.java
@@ -2,6 +2,14 @@ package basakan.fryday.repository.todo;
 
 import basakan.fryday.domain.todo.Recurrence;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface RecurrenceRepository extends JpaRepository<Recurrence, Long> {
+
+    @Query("SELECT r FROM Recurrence r WHERE r.endDate IS NULL AND r.lastGeneratedDate < :thresholdDate")
+    List<Recurrence> findRecurrencesToExtend(@Param("thresholdDate") LocalDate thresholdDate);
 }

--- a/src/main/java/basakan/fryday/scheduler/RecurrenceScheduler.java
+++ b/src/main/java/basakan/fryday/scheduler/RecurrenceScheduler.java
@@ -1,0 +1,120 @@
+package basakan.fryday.scheduler;
+
+import basakan.fryday.domain.category.Category;
+import basakan.fryday.domain.todo.Recurrence;
+import basakan.fryday.domain.todo.RecurrenceType;
+import basakan.fryday.domain.todo.Todo;
+import basakan.fryday.repository.CategoryRepository;
+import basakan.fryday.repository.todo.RecurrenceRepository;
+import basakan.fryday.repository.todo.TodoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RecurrenceScheduler {
+
+    private final RecurrenceRepository recurrenceRepository;
+    private final TodoRepository todoRepository;
+    private final CategoryRepository categoryRepository;
+
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    public void extendInfiniteRecurrences() {
+        LocalDate today = LocalDate.now();
+        
+        // 1달 미만 남았으면 확장
+        LocalDate thresholdDate = today.plusMonths(1);
+
+        List<Recurrence> targets = recurrenceRepository.findRecurrencesToExtend(thresholdDate);
+
+        log.info("Found {} recurrence rules to extend", targets.size());
+
+        for (Recurrence rule : targets) {
+            extendRecurrence(rule);
+        }
+    }
+
+    private void extendRecurrence(Recurrence rule) {
+        LocalDate startDate = rule.getLastGeneratedDate().plusDays(1);
+
+        LocalDate newLimitDate = startDate.plusYears(1);
+
+        List<Todo> newTodos = new ArrayList<>();
+        LocalDate current = startDate;
+
+        Category category = categoryRepository.findById(rule.getCategoryId())
+                .orElseThrow(() -> new IllegalStateException("Category not found: " + rule.getCategoryId()));
+
+        while (!current.isAfter(newLimitDate)) {
+            if (isMatch(rule, current)) {
+                Long maxOrder = todoRepository.findMaxDisplayOrder(rule.getUserId(), current);
+                long nextOrder = (maxOrder == null) ? 1 : maxOrder + 1;
+
+                Todo todo = Todo.builder()
+                        .description(rule.getDescription())
+                        .category(category)
+                        .date(current)
+                        .displayOrder(nextOrder)
+                        .recurrenceId(rule.getId())
+                        .build();
+                newTodos.add(todo);
+            }
+            current = current.plusDays(1);
+        }
+
+        todoRepository.saveAll(newTodos);
+
+        // 어디까지 생성했는지 업데이트 (다음 1년 동안은 스케줄러 대상에서 제외됨)
+        rule.updateLastGeneratedDate(newLimitDate);
+
+        log.info("Extended recurrence id={}, generated {} todos until={}", 
+                rule.getId(), newTodos.size(), newLimitDate);
+    }
+
+    private boolean isMatch(Recurrence recurrence, LocalDate date) {
+        RecurrenceType type = recurrence.getType();
+        String frequencyValuesStr = recurrence.getFrequencyValues();
+        
+        List<String> values = (frequencyValuesStr != null && !frequencyValuesStr.isEmpty())
+                ? Arrays.asList(frequencyValuesStr.split(","))
+                : null;
+
+        switch (type) {
+            case DAILY:
+                return true;
+
+            case WEEKLY:
+                if (values == null || values.isEmpty()) {
+                    return false;
+                }
+                return values.contains(date.getDayOfWeek().name());
+
+            case MONTHLY:
+                if (values == null || values.isEmpty()) {
+                    return false;
+                }
+                return values.contains(String.valueOf(date.getDayOfMonth()));
+
+            case YEARLY:
+                if (values == null || values.isEmpty()) {
+                    return false;
+                }
+                String monthDay = date.format(DateTimeFormatter.ofPattern("MM-dd"));
+                return values.contains(monthDay);
+
+            default:
+                return false;
+        }
+    }
+}

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
@@ -3,9 +3,9 @@ package basakan.fryday.service.todo;
 import basakan.fryday.common.ErrorCode;
 import basakan.fryday.common.exception.BusinessException;
 import basakan.fryday.controller.todo.request.RecurrenceCreateRequest;
+import basakan.fryday.controller.todo.response.TodoResponse;
 import basakan.fryday.domain.todo.Recurrence;
 import basakan.fryday.domain.todo.Todo;
-import basakan.fryday.repository.CategoryRepository;
 import basakan.fryday.repository.todo.RecurrenceRepository;
 import basakan.fryday.repository.todo.TodoRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,22 +23,34 @@ public class RecurrenceService {
 
     private final RecurrenceRepository recurrenceRepository;
     private final TodoRepository todoRepository;
-    private final CategoryRepository categoryRepository;
 
     @Transactional
-    public void createRecurrence(Long userId, RecurrenceCreateRequest request) {
+    public TodoResponse createRecurrence(Long userId, RecurrenceCreateRequest request) {
         Todo originalTodo = todoRepository.findById(request.getTodoId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        originalTodo.updateDate(request.getStartDate());
+
+        LocalDate today = LocalDate.now();
+        LocalDate generationStartDate = request.getStartDate().isBefore(today) ? today : request.getStartDate();
+        
+        // 종료일이 없으면 오늘부터 +1년까지만 생성
+        LocalDate limitDate = (request.getEndDate() != null)
+                ? request.getEndDate()
+                : today.plusYears(1);
 
         Recurrence recurrence = Recurrence.builder()
                 .userId(userId)
                 .categoryId(originalTodo.getCategory().getId())
                 .description(originalTodo.getDescription())
                 .type(request.getType())
-                .frequencyValues(String.join(",", request.getFrequencyValues()))
+                .frequencyValues(request.getFrequencyValues() != null 
+                        ? String.join(",", request.getFrequencyValues()) 
+                        : null)
                 .startDate(request.getStartDate())
-                .endDate(request.getEndDate())
+                .endDate(request.getEndDate()) // null이면 무한 반복
                 .notificationTime(request.getNotificationTime())
+                .lastGeneratedDate(limitDate)
                 .build();
 
         Recurrence savedRecurrence = recurrenceRepository.save(recurrence);
@@ -47,8 +59,8 @@ public class RecurrenceService {
 
         List<Todo> todoList = new ArrayList<>();
 
-        LocalDate currentDate = request.getStartDate();
-        LocalDate limitDate = request.getEndDate();
+        // 시작일부터 limitDate까지 투두 생성
+        LocalDate currentDate = generationStartDate.plusDays(1);
 
         while (!currentDate.isAfter(limitDate)) {
             if (isMatch(request, currentDate)) {
@@ -68,6 +80,7 @@ public class RecurrenceService {
         }
         todoRepository.saveAll(todoList);
 
+        return TodoResponse.from(originalTodo);
     }
 
     private boolean isMatch(RecurrenceCreateRequest request, LocalDate date) {

--- a/src/main/java/basakan/fryday/service/todo/TodoService.java
+++ b/src/main/java/basakan/fryday/service/todo/TodoService.java
@@ -76,10 +76,6 @@ public class TodoService {
                 .filter(t -> !t.isDeleted())
                 .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
 
-//        if (todo.isFailed()) {
-//            throw new BusinessException(ErrorCode.CANNOT_DELETE_FAILED_TODO);
-//        }
-
         todoRepository.delete(todo);
     }
 

--- a/src/main/java/basakan/fryday/service/todo/TodoService.java
+++ b/src/main/java/basakan/fryday/service/todo/TodoService.java
@@ -195,8 +195,8 @@ public class TodoService {
 
     private String resolveImageCode(CharacterStatus status) {
         if (status == CharacterStatus.CASE_D) {
-            // Case D일 때만 D1, D2 중 랜덤 반환
-            return Math.random() < 0.5 ? "d1_graphic" : "d2_graphic";
+            // Case E일 때만 e1, e2 중 랜덤 반환
+            return Math.random() < 0.5 ? "e1_graphic" : "e2_graphic";
         }
         return status.getImageCode();
     }

--- a/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
@@ -540,13 +540,30 @@ class TodoControllerTest extends RestDocsSupport {
     @DisplayName("투두 반복 설정 API")
     void createRecurringTodo() throws Exception {
         // given
+        Long todoId = 1L;
+        LocalDate startDate = LocalDate.of(2025, 12, 1);
+        
         RecurrenceCreateRequest request = new RecurrenceCreateRequest();
-        ReflectionTestUtils.setField(request, "todoId", 1L);
+        ReflectionTestUtils.setField(request, "todoId", todoId);
         ReflectionTestUtils.setField(request, "type", RecurrenceType.WEEKLY);
         ReflectionTestUtils.setField(request, "frequencyValues", List.of("MONDAY", "WEDNESDAY", "FRIDAY"));
-        ReflectionTestUtils.setField(request, "startDate", LocalDate.of(2025, 12, 1));
+        ReflectionTestUtils.setField(request, "startDate", startDate);
         ReflectionTestUtils.setField(request, "endDate", LocalDate.of(2025, 12, 31));
         ReflectionTestUtils.setField(request, "notificationTime", LocalTime.of(9, 0));
+
+        // Mocking: 반복 설정 후 원본 투두 응답 생성
+        Category mockCategory = Category.builder().name("요리").color(CategoryColor.BR).userId(1L).build();
+        ReflectionTestUtils.setField(mockCategory, "id", 1L);
+
+        Todo mockTodo = Todo.builder()
+                .description("양파 썰기")
+                .category(mockCategory)
+                .date(startDate) // 시작일로 업데이트됨
+                .build();
+        ReflectionTestUtils.setField(mockTodo, "id", todoId);
+
+        given(recurrenceService.createRecurrence(anyLong(), any(RecurrenceCreateRequest.class)))
+                .willReturn(TodoResponse.from(mockTodo));
 
         // when & then
         mockMvc.perform(post("/api/todos/recurrence")
@@ -560,13 +577,18 @@ class TodoControllerTest extends RestDocsSupport {
                                 fieldWithPath("type").type(JsonFieldType.STRING).description("반복 주기 (DAILY, WEEKLY, MONTHLY, YEARLY)"),
                                 fieldWithPath("frequencyValues").type(JsonFieldType.ARRAY).description("반복 상세 값 리스트 (요일, 날짜 등)"),
                                 fieldWithPath("startDate").type(JsonFieldType.STRING).description("반복 시작일 (YYYY-MM-DD)"),
-                                fieldWithPath("endDate").type(JsonFieldType.STRING).description("반복 종료일 (YYYY-MM-DD)"),
+                                fieldWithPath("endDate").type(JsonFieldType.STRING).description("반복 종료일 (YYYY-MM-DD, null이면 무한 반복 - Rolling Window)").optional(),
                                 fieldWithPath("notificationTime").type(JsonFieldType.STRING).description("알림 시간 (HH:mm)").optional()
                         ),
                         responseFields(
                                 fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
                                 fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
-                                fieldWithPath("data").type(JsonFieldType.NULL).description("데이터 (없음)").optional(),
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("원본 투두 ID"),
+                                fieldWithPath("data.description").type(JsonFieldType.STRING).description("할 일 내용"),
+                                fieldWithPath("data.status").type(JsonFieldType.STRING).description("상태 (IN_PROGRESS, COMPLETED)"),
+                                fieldWithPath("data.categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
+                                fieldWithPath("data.memo").type(JsonFieldType.STRING).description("메모").optional(),
+                                fieldWithPath("data.date").type(JsonFieldType.STRING).description("투두 날짜 (시작일로 업데이트됨)"),
                                 fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
                         )
                 ));

--- a/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
@@ -577,7 +577,7 @@ class TodoControllerTest extends RestDocsSupport {
                                 fieldWithPath("type").type(JsonFieldType.STRING).description("반복 주기 (DAILY, WEEKLY, MONTHLY, YEARLY)"),
                                 fieldWithPath("frequencyValues").type(JsonFieldType.ARRAY).description("반복 상세 값 리스트 (요일, 날짜 등)"),
                                 fieldWithPath("startDate").type(JsonFieldType.STRING).description("반복 시작일 (YYYY-MM-DD)"),
-                                fieldWithPath("endDate").type(JsonFieldType.STRING).description("반복 종료일 (YYYY-MM-DD, null이면 무한 반복 - Rolling Window)").optional(),
+                                fieldWithPath("endDate").type(JsonFieldType.STRING).description("반복 종료일 (YYYY-MM-DD, null이면 무한 반복)").optional(),
                                 fieldWithPath("notificationTime").type(JsonFieldType.STRING).description("알림 시간 (HH:mm)").optional()
                         ),
                         responseFields(


### PR DESCRIPTION
## 📌 Related Issue
- close: #18 #19 #20 

## 🚀 Description
### 투두 삭제
- 투두 삭제 시 즉시 삭제

### 투두 상태 표시
- 기존 case D가 랜덤하게 보이던 것에서 case E가 랜덤하게 보이게 변경

### 투두 반복 설정 기능
#### 1. 종료 날짜 Optional 처리
- `RecurrenceCreateRequest.endDate`를 Optional로 변경
- 종료 날짜가 없으면 오늘부터 +1년까지만 생성

#### 2. 스케줄러 자동 확장 기능
- `RecurrenceScheduler` 구현
- 매일 새벽 3시 실행 (`@Scheduled(cron = "0 0 3 * * *")`)
- 종료일이 없는 반복 규칙 중 생성된 투두가 1달 미만 남은 경우 자동으로 1년치 추가 생성

## 📢 Notes
### `Recurrence`와 `Todo`의 관계

1. 관계의 방향성: `Todo` -> `Recurrence` 단방향 참조
   - `Recurrence`는 자신이 생성한 수많은 `Todo`를 알 필요가 없도록 설계
   - 반대로 `Todo`는 자신이 어떤 규칙에 의해 생성되었는지 알 수 있도록 `recurrenceId`를 가짐

2. 간접 참조 적용
   - `Todo` 엔티티에서 `Recurrence`를 객체(`@ManyToOne`)로 참조하지 않고, **Long recurrenceId**만 저장
   - 이유:
      - 모든 투두가 반복이 있지는 않음. 그렇기 때문에 불필요한 연관관계 매핑과 조인 절감
      - 반복 규칙이 삭제되더라도 과거의 투두 기록은 유지되어야 함.

3. `Recurrence`의 독립성
   - `Recurrence` 엔티티는 `todoId`(원본)를 참조하지 않고, `categoryId`와 `description`을 자체 컬럼으로 저장하도록 설계 
   - 이유: 사용자가 반복 설정의 기준이 된 `원본 투두`를 삭제하더라도, 반복 규칙은 온전한 정보를 가지고 미래의 투두를 계속 생성할 수 있음.
