### PR TITLE
소셜 로그인 엔드포인트 분리 및 REST Docs 개선

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -11,37 +11,37 @@
 
 == 사용자(User)
 
-=== 소셜 로그인
+=== 소셜 로그인 (카카오, 네이버)
 `POST /api/users/social/login`
 
-카카오, 네이버, 애플 소셜 로그인을 처리합니다.
+카카오, 네이버 소셜 로그인을 처리합니다. Access Token 기반 인증을 사용합니다.
 
-==== 로그인 상태 (LoginStatus)
+==== 온보딩 상태 (OnboardingStatus)
 
-응답의 `loginStatus` 필드는 사용자가 다음에 어떤 화면으로 이동해야 하는지를 나타냅니다.
+응답의 `onboardingStatus` 필드는 사용자가 다음에 어떤 화면으로 이동해야 하는지를 나타냅니다.
 
 [cols="1,3,2"]
 |===
 |상태 |설명 |다음 화면
 
-|`NEEDS_CONSENT`
-|개인정보 수집 및 이용 동의가 필요한 상태 (최초 가입)
-|동의 화면
+|`NEEDS_NICKNAME`
+|닉네임 설정이 필요한 상태 (최초 가입 첫 단계)
+|닉네임 설정 화면
+
+|`NEEDS_AGREEMENT`
+|개인정보 수집 및 이용 동의가 필요한 상태 (두 번째 단계)
+|개인정보 동의 화면
 
 |`NEEDS_ONBOARDING`
-|개인정보 동의는 완료했으나, 온보딩(앱 사용법 안내)이 필요한 상태
+|온보딩 화면 확인이 필요한 상태 (세 번째 단계)
 |온보딩 화면
-
-|`NEEDS_NICKNAME`
-|온보딩은 완료했으나, 닉네임 설정이 필요한 상태
-|닉네임 설정 화면
 
 |`COMPLETED`
 |모든 설정이 완료된 상태 (정상 로그인)
 |메인 화면
 |===
 
-NOTE: 클라이언트는 `loginStatus` 값에 따라 적절한 화면으로 사용자를 안내해야 합니다.
+NOTE: 온보딩은 NEEDS_NICKNAME → NEEDS_AGREEMENT → NEEDS_ONBOARDING → COMPLETED 순서로 진행됩니다.
 
 ==== 요청 필드
 include::{snippets}/user-social-login/request-fields.adoc[]
@@ -55,38 +55,78 @@ include::{snippets}/user-social-login/http-response.adoc[]
 ==== 응답 필드
 include::{snippets}/user-social-login/response-fields.adoc[]
 
-=== 개인정보 동의
-`POST /api/users/me/consent`
+=== 애플 로그인
+`POST /api/users/apple/login`
 
-개인정보 수집 및 이용에 동의합니다. (인증 필요)
+애플 소셜 로그인을 처리합니다. ID Token (JWT) 기반 인증을 사용합니다.
+
+==== 온보딩 상태 (OnboardingStatus)
+
+응답의 `onboardingStatus` 필드는 사용자가 다음에 어떤 화면으로 이동해야 하는지를 나타냅니다.
+
+[cols="1,3,2"]
+|===
+|상태 |설명 |다음 화면
+
+|`NEEDS_NICKNAME`
+|닉네임 설정이 필요한 상태 (최초 가입 첫 단계)
+|닉네임 설정 화면
+
+|`NEEDS_AGREEMENT`
+|개인정보 수집 및 이용 동의가 필요한 상태 (두 번째 단계)
+|개인정보 동의 화면
+
+|`NEEDS_ONBOARDING`
+|온보딩 화면 확인이 필요한 상태 (세 번째 단계)
+|온보딩 화면
+
+|`COMPLETED`
+|모든 설정이 완료된 상태 (정상 로그인)
+|메인 화면
+|===
+
+NOTE: 애플은 ID Token을 사용하며, JWKS 기반 서명 검증을 수행합니다.
 
 ==== 요청 필드
-include::{snippets}/user-consent/request-fields.adoc[]
+include::{snippets}/user-apple-login/request-fields.adoc[]
 
 ==== HTTP 요청 예시
-include::{snippets}/user-consent/http-request.adoc[]
+include::{snippets}/user-apple-login/http-request.adoc[]
 
 ==== HTTP 응답 예시
-include::{snippets}/user-consent/http-response.adoc[]
+include::{snippets}/user-apple-login/http-response.adoc[]
 
 ==== 응답 필드
-include::{snippets}/user-consent/response-fields.adoc[]
+include::{snippets}/user-apple-login/response-fields.adoc[]
 
-=== 온보딩 완료
-`POST /api/users/me/onboarding`
+=== 닉네임 중복 체크
+`GET /api/users/nickname/check`
 
-온보딩을 완료합니다. (인증 필요)
+닉네임 사용 가능 여부를 실시간으로 확인합니다. (인증 불필요)
 
-==== HTTP 요청 예시
-include::{snippets}/user-onboarding/http-request.adoc[]
+==== 사용 가능한 닉네임
 
-==== HTTP 응답 예시
-include::{snippets}/user-onboarding/http-response.adoc[]
+===== HTTP 요청 예시
+include::{snippets}/user-nickname-check-available/http-request.adoc[]
 
-==== 응답 필드
-include::{snippets}/user-onboarding/response-fields.adoc[]
+===== HTTP 응답 예시
+include::{snippets}/user-nickname-check-available/http-response.adoc[]
 
-=== 닉네임 설정
+===== 응답 필드
+include::{snippets}/user-nickname-check-available/response-fields.adoc[]
+
+==== 이미 사용 중인 닉네임
+
+===== HTTP 요청 예시
+include::{snippets}/user-nickname-check-unavailable/http-request.adoc[]
+
+===== HTTP 응답 예시
+include::{snippets}/user-nickname-check-unavailable/http-response.adoc[]
+
+===== 응답 필드
+include::{snippets}/user-nickname-check-unavailable/response-fields.adoc[]
+
+=== 닉네임 설정 (온보딩 1단계)
 `POST /api/users/me/nickname`
 
 닉네임을 최초로 설정합니다. (인증 필요)
@@ -103,10 +143,41 @@ include::{snippets}/user-nickname-set/http-response.adoc[]
 ==== 응답 필드
 include::{snippets}/user-nickname-set/response-fields.adoc[]
 
+=== 개인정보 동의 (온보딩 2단계)
+`POST /api/users/me/consent`
+
+개인정보 수집 및 이용에 동의합니다. (인증 필요)
+
+==== 요청 필드
+include::{snippets}/user-consent/request-fields.adoc[]
+
+==== HTTP 요청 예시
+include::{snippets}/user-consent/http-request.adoc[]
+
+==== HTTP 응답 예시
+include::{snippets}/user-consent/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/user-consent/response-fields.adoc[]
+
+=== 온보딩 완료 (온보딩 3단계)
+`POST /api/users/me/onboarding`
+
+온보딩 화면 확인을 완료합니다. (인증 필요)
+
+==== HTTP 요청 예시
+include::{snippets}/user-onboarding/http-request.adoc[]
+
+==== HTTP 응답 예시
+include::{snippets}/user-onboarding/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/user-onboarding/response-fields.adoc[]
+
 === 닉네임 수정
 `PATCH /api/users/me/nickname`
 
-닉네임을 변경합니다. (인증 필요)
+기존 닉네임을 변경합니다. (인증 필요)
 
 ==== 요청 필드
 include::{snippets}/user-nickname-update/request-fields.adoc[]
@@ -120,24 +191,7 @@ include::{snippets}/user-nickname-update/http-response.adoc[]
 ==== 응답 필드
 include::{snippets}/user-nickname-update/response-fields.adoc[]
 
-=== FCM 토큰 등록
-`POST /api/users/me/fcm-tokens`
-
-FCM 푸시 알림을 위한 토큰을 등록합니다. (인증 필요)
-
-==== 요청 필드
-include::{snippets}/user-fcm-token-register/request-fields.adoc[]
-
-==== HTTP 요청 예시
-include::{snippets}/user-fcm-token-register/http-request.adoc[]
-
-==== HTTP 응답 예시
-include::{snippets}/user-fcm-token-register/http-response.adoc[]
-
-==== 응답 필드
-include::{snippets}/user-fcm-token-register/response-fields.adoc[]
-
-=== 계정 탈퇴
+=== 회원 탈퇴
 `DELETE /api/users/me`
 
 회원 탈퇴를 처리합니다. (인증 필요)

--- a/src/main/java/basakan/fryday/common/config/SecurityConfig.java
+++ b/src/main/java/basakan/fryday/common/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/users/social/login").permitAll()
+                        .requestMatchers("/api/users/apple/login").permitAll()
                         .requestMatchers("/api/users/token/refresh").permitAll()
                         .requestMatchers("/api/users/nickname/check").permitAll()
                         .requestMatchers("/docs/**").permitAll()

--- a/src/main/java/basakan/fryday/controller/user/UserController.java
+++ b/src/main/java/basakan/fryday/controller/user/UserController.java
@@ -1,6 +1,7 @@
 package basakan.fryday.controller.user;
 
 import basakan.fryday.common.response.MessageResponse;
+import basakan.fryday.controller.user.request.AppleLoginRequest;
 import basakan.fryday.controller.user.request.SocialLoginRequest;
 import basakan.fryday.controller.user.response.SocialLoginResponse;
 import basakan.fryday.controller.user.response.NicknameCheckResponse;
@@ -25,8 +26,18 @@ public class UserController {
 
     private final UserAppService userAppService;
 
+    /**
+     * 카카오, 네이버 소셜 로그인
+     */
     @PostMapping("/social/login")
     public ResponseEntity<SocialLoginResponse> socialLogin(@Valid @RequestBody SocialLoginRequest request) {
+        SocialLoginDto result = userAppService.socialLogin(request.toServiceDto());
+        SocialLoginResponse response = SocialLoginResponse.from(result);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/apple/login")
+    public ResponseEntity<SocialLoginResponse> appleLogin(@Valid @RequestBody AppleLoginRequest request) {
         SocialLoginDto result = userAppService.socialLogin(request.toServiceDto());
         SocialLoginResponse response = SocialLoginResponse.from(result);
         return ResponseEntity.ok(response);

--- a/src/main/java/basakan/fryday/controller/user/request/AppleLoginRequest.java
+++ b/src/main/java/basakan/fryday/controller/user/request/AppleLoginRequest.java
@@ -3,40 +3,34 @@ package basakan.fryday.controller.user.request;
 import basakan.fryday.domain.user.AuthProvider;
 import basakan.fryday.service.auth.dto.SocialLoginServiceDto;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * 카카오, 네이버 소셜 로그인 요청
- * (애플 로그인은 AppleLoginRequest 사용)
- */
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class SocialLoginRequest {
+public class AppleLoginRequest {
 
-    @NotNull(message = "Provider는 필수입니다 (KAKAO, NAVER)")
-    private AuthProvider provider;  // KAKAO, NAVER만 허용
+    @NotBlank(message = "ID Token은 필수입니다")
+    private String idToken;
 
-    @NotBlank(message = "Access Token은 필수입니다")
-    private String accessToken;
+    private String authorizationCode;  // 선택, Refresh Token 갱신 시 사용
 
     @NotBlank(message = "DeviceId는 필수입니다")
     private String deviceId;
 
     private String deviceType;  // iOS, Android, Web
 
-    private String deviceName;  // "iPhone 14 Pro", "Galaxy S23" 등
+    private String deviceName;  // "iPhone 14 Pro", "iPad Pro" 등
 
     private String fcmToken;
 
     public SocialLoginServiceDto toServiceDto() {
         return new SocialLoginServiceDto(
-                provider,
-                accessToken,
-                null,  // idToken은 카카오/네이버에서 사용하지 않음
+                AuthProvider.APPLE,
+                null,  // accessToken은 사용하지 않음
+                idToken,
                 deviceId,
                 deviceType,
                 deviceName,

--- a/src/test/java/basakan/fryday/controller/user/UserControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/user/UserControllerTest.java
@@ -50,13 +50,12 @@ class UserControllerTest extends RestDocsSupport {
     private JwtTokenProvider jwtTokenProvider;
 
     @Test
-    @DisplayName("소셜 로그인 API - 신규 사용자")
+    @DisplayName("소셜 로그인 API (카카오, 네이버) - 신규 사용자")
     void socialLogin_NewUser() throws Exception {
         // given
         SocialLoginRequest request = new SocialLoginRequest(
                 AuthProvider.KAKAO,
                 "kakao-access-token-123",
-                null,
                 "device-id-123",
                 "iOS",
                 "iPhone 14 Pro",
@@ -88,9 +87,66 @@ class UserControllerTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.refreshToken").exists())
                 .andDo(document("user-social-login",
                         requestFields(
-                                fieldWithPath("provider").type(JsonFieldType.STRING).description("소셜 로그인 제공자 (KAKAO, NAVER, APPLE)"),
+                                fieldWithPath("provider").type(JsonFieldType.STRING).description("소셜 로그인 제공자 (KAKAO, NAVER)"),
                                 fieldWithPath("accessToken").type(JsonFieldType.STRING).description("소셜 제공자로부터 받은 Access Token"),
-                                fieldWithPath("idToken").type(JsonFieldType.STRING).description("Apple 로그인 시 필요한 ID Token (선택)").optional(),
+                                fieldWithPath("deviceId").type(JsonFieldType.STRING).description("디바이스 고유 ID"),
+                                fieldWithPath("deviceType").type(JsonFieldType.STRING).description("디바이스 타입 (iOS, Android, Web)").optional(),
+                                fieldWithPath("deviceName").type(JsonFieldType.STRING).description("디바이스 이름").optional(),
+                                fieldWithPath("fcmToken").type(JsonFieldType.STRING).description("FCM 푸시 토큰").optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("onboardingStatus").type(JsonFieldType.STRING).description("온보딩 상태 (NEEDS_NICKNAME, NEEDS_AGREEMENT, NEEDS_ONBOARDING, COMPLETED)"),
+                                fieldWithPath("accessToken").type(JsonFieldType.STRING).description("JWT Access Token"),
+                                fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("JWT Refresh Token"),
+                                fieldWithPath("deviceId").type(JsonFieldType.STRING).description("디바이스 ID"),
+                                fieldWithPath("user.id").type(JsonFieldType.NUMBER).description("사용자 ID"),
+                                fieldWithPath("user.provider").type(JsonFieldType.STRING).description("소셜 로그인 제공자"),
+                                fieldWithPath("user.role").type(JsonFieldType.STRING).description("사용자 권한 (USER, ADMIN)"),
+                                fieldWithPath("user.nickname").type(JsonFieldType.STRING).description("사용자 닉네임").optional()
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("애플 로그인 API - 신규 사용자")
+    void appleLogin_NewUser() throws Exception {
+        // given
+        AppleLoginRequest request = new AppleLoginRequest(
+                "eyJraWQiOiJXNldjT0tC...",  // Apple ID Token
+                "c1234567890abc",            // Authorization Code (optional)
+                "device-id-123",
+                "iOS",
+                "iPhone 14 Pro",
+                "fcm-token-abc"
+        );
+
+        SocialLoginDto mockDto = SocialLoginDto.builder()
+                .userId(1L)
+                .provider(AuthProvider.APPLE)
+                .onboardingStatus(OnboardingStatus.NEEDS_AGREEMENT)
+                .role(User.Role.USER)
+                .nickname(null)
+                .accessToken("jwt-access-token")
+                .refreshToken("jwt-refresh-token")
+                .deviceId("device-id-123")
+                .build();
+
+        given(userAppService.socialLogin(any()))
+                .willReturn(mockDto);
+
+        // when & then
+        mockMvc.perform(post("/api/users/apple/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.onboardingStatus").value("NEEDS_AGREEMENT"))
+                .andExpect(jsonPath("$.accessToken").exists())
+                .andExpect(jsonPath("$.refreshToken").exists())
+                .andDo(document("user-apple-login",
+                        requestFields(
+                                fieldWithPath("idToken").type(JsonFieldType.STRING).description("Apple ID Token (JWT)"),
+                                fieldWithPath("authorizationCode").type(JsonFieldType.STRING).description("Apple Authorization Code (선택)").optional(),
                                 fieldWithPath("deviceId").type(JsonFieldType.STRING).description("디바이스 고유 ID"),
                                 fieldWithPath("deviceType").type(JsonFieldType.STRING).description("디바이스 타입 (iOS, Android, Web)").optional(),
                                 fieldWithPath("deviceName").type(JsonFieldType.STRING).description("디바이스 이름").optional(),

--- a/src/test/resources/org/springframework/restdocs/templates/asciidoctor/query-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/asciidoctor/query-parameters.snippet
@@ -1,0 +1,10 @@
+|===
+|Parameter|Required|Description
+
+{{#parameters}}
+|`+{{name}}+`
+|{{#optional}}선택{{/optional}}{{^optional}}**필수**{{/optional}}
+|{{description}}
+
+{{/parameters}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
@@ -1,0 +1,11 @@
+|===
+|Path|Type|Required|Description
+
+{{#fields}}
+|`+{{path}}+`
+|`+{{type}}+`
+|{{#optional}}선택{{/optional}}{{^optional}}**필수**{{/optional}}
+|{{description}}
+
+{{/fields}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/asciidoctor/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/asciidoctor/response-fields.snippet
@@ -1,0 +1,10 @@
+|===
+|Path|Type|Description
+
+{{#fields}}
+|`+{{path}}+`
+|`+{{type}}+`
+|{{description}}
+
+{{/fields}}
+|===


### PR DESCRIPTION
 ## 📌 Related Issue
- Closes #22 

## Summary
- 애플 로그인과 카카오/네이버 로그인을 별도 엔드포인트로 분리 (인증 방식 차이)
- REST Docs 명세서를 현재 코드에 정확히 맞춰 최신화
- REST Docs에 필수/선택 필드 표기 추가 (커스텀 템플릿 적용)

## 주요 변경사항

### 1. 애플 로그인 엔드포인트 분리
- `POST /api/users/social/login` → 카카오, 네이버 전용 (Access Token 기반)
- `POST /api/users/apple/login` → 애플 전용 (ID Token 기반)
- AppleLoginRequest.java 추가
- SocialLoginRequest에서 Apple 제거
- SecurityConfig에 애플 로그인 permitAll 추가

### 2. REST Docs 명세서 최신화
- OnboardingStatus 순서 수정: NEEDS_NICKNAME → NEEDS_AGREEMENT → NEEDS_ONBOARDING → COMPLETED
- LoginStatus → OnboardingStatus로 이름 변경 (코드와 일치)
- 존재하지 않는 NEEDS_CONSENT 제거
- 닉네임 중복 체크 API 문서 추가
- 온보딩 단계별 구분 명시 (1, 2, 3단계)

### 3. REST Docs 커스텀 템플릿 추가
- 요청 필드: Required 컬럼 추가 (필수/선택 명확히 표기)
- 응답 필드: Required 없이 Path, Type, Description만 표시
- 쿼리 파라미터: Required 표기 추가
- 프로젝트 전체에 자동 적용되는 공통 템플릿

## Test plan
- [x] UserControllerTest 테스트 통과
- [x] 전체 테스트 스위트 통과
- [x] 빌드 성공 확인
- [x] REST Docs 문서 생성 확인
- [x] 애플 로그인 스니펫 생성 확인
- [x] 필수/선택 표기 정상 출력 확인

## 기술적 세부사항
- 카카오/네이버: Access Token 기반 인증
- 애플: ID Token (JWT) 기반 인증, JWKS 서명 검증
- REST Docs 템플릿 위치: `src/test/resources/org/springframework/restdocs/templates/asciidoctor/`