### PR TITLE
투두 일일 정책 스케줄러 구현

### DIFF
--- a/src/main/java/basakan/fryday/domain/todo/Todo.java
+++ b/src/main/java/basakan/fryday/domain/todo/Todo.java
@@ -40,6 +40,9 @@ public class Todo extends BaseEntity {
     @Column(name = "recurrence_id")
     private Long recurrenceId;
 
+    @Column(nullable = false)
+    private Boolean isBurnt = false;
+
     public enum Status {
         IN_PROGRESS, // 미완료 (체크 안 됨)
         COMPLETED    // 완료 (체크 됨)
@@ -53,6 +56,7 @@ public class Todo extends BaseEntity {
         this.date = (date != null) ? date : LocalDate.now();
         this.displayOrder = displayOrder != null ? displayOrder : 0L;
         this.recurrenceId = recurrenceId;
+        this.isBurnt = false;
     }
 
     public void toggleCompletion() {

--- a/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
@@ -2,6 +2,7 @@ package basakan.fryday.repository.todo;
 
 import basakan.fryday.domain.todo.Todo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -25,4 +26,9 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
             "WHERE t.category.id = :categoryId AND t.date = :date AND t.deletedAt IS NULL " +
             "ORDER BY t.displayOrder ASC")
     List<Todo> findAllByCategoryIdAndDate(@Param("categoryId") Long categoryId, @Param("date") LocalDate date);
+
+    // 특정 날짜의 미완료 투두를 탄 튀김 상태로 일괄 업데이트
+    @Modifying
+    @Query("UPDATE Todo t SET t.isBurnt = true WHERE t.date = :date AND t.status = :status AND t.deletedAt IS NULL")
+    int updateBurntStatusByDate(@Param("date") LocalDate date, @Param("status") Todo.Status status);
 }

--- a/src/main/java/basakan/fryday/scheduler/BurntTodoScheduler.java
+++ b/src/main/java/basakan/fryday/scheduler/BurntTodoScheduler.java
@@ -1,0 +1,41 @@
+package basakan.fryday.scheduler;
+
+import basakan.fryday.domain.todo.Todo;
+import basakan.fryday.repository.todo.TodoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+/**
+ * 투두 일일 정책 스케줄러
+ * - 매일 자정(00:00)에 실행
+ * - 어제 날짜의 미완료 투두를 "탄 튀김" 처리
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BurntTodoScheduler {
+
+    private final TodoRepository todoRepository;
+
+    /**
+     * 매일 자정 실행 (서울 시간 기준)
+     * Cron 표현식: "초 분 시 일 월 요일"
+     * "0 0 0 * * *" = 매일 00시 00분 00초
+     */
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void processBurntTodos() {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        log.info("Burnt Todo Processing start: {}", yesterday);
+
+        // 어제 날짜의 미완료 투두를 탄 튀김 상태로 일괄 업데이트 (벌크 UPDATE)
+        int burntCount = todoRepository.updateBurntStatusByDate(yesterday, Todo.Status.IN_PROGRESS);
+
+        log.info("Burnt Todo Processing end: totalBurnt={}", burntCount);
+    }
+}


### PR DESCRIPTION
## 📌 Related Issue
- Related to: #26 

## 🚀 Description
매일 자정에 실행되는 투두 일일 정책 스케줄러를 구현했습니다.

### 주요 변경사항
- **Todo 엔티티**: `isBurnt` 필드 추가 (탄 튀김 여부)
- **BurntTodoScheduler**: 매일 00:00 (Asia/Seoul) 실행
- **TodoRepository**: 벌크 UPDATE 쿼리 추가

### 동작 방식
1. 매일 자정 00:00에 자동 실행
2. 어제 날짜(`date = yesterday`)이면서 미완료 상태(`status = IN_PROGRESS`)인 투두 조회
3. 삭제되지 않은(`deletedAt IS NULL`) 투두만 대상
4. 벌크 UPDATE 쿼리로 `isBurnt = true` 일괄 업데이트

### 성능 최적화
- ❌ Before(최초 설계): SELECT 조회 → 메모리 로드 → N번의 UPDATE
- ✅ After(최종 설계): 단일 벌크 UPDATE 쿼리로 처리

### 기술 스택
- `@Scheduled` (Spring Scheduling)
- `@Modifying` + `@Query` (JPA 벌크 UPDATE)
- Cron 표현식: `0 0 0 * * *`

## 📢 Notes
- 벌크 UPDATE 쿼리 사용으로 성능 최적화 (단일 쿼리)
- User 조회 없이 Todo만 직접 처리
- 탄 튀김 상태는 `isBurnt` 필드로 관리