### PR TITLE
Agreement 필드명 변경 (marketingAgreed → pushNotificationAgreed)

### DIFF
--- a/src/main/java/basakan/fryday/controller/user/UserController.java
+++ b/src/main/java/basakan/fryday/controller/user/UserController.java
@@ -63,7 +63,7 @@ public class UserController {
 
     @PostMapping("/me/consent")
     public ResponseEntity<MessageResponse> agreeConsent(@Valid @RequestBody ConsentRequest request) {
-        userAppService.agreeConsent(request.privacyRequired(), request.marketingOptional());
+        userAppService.agreeConsent(request.privacyRequired(), request.pushNotificationOptional());
         return ResponseEntity.ok(new MessageResponse("개인정보 수집 및 이용에 동의하였습니다."));
     }
 

--- a/src/main/java/basakan/fryday/controller/user/request/ConsentRequest.java
+++ b/src/main/java/basakan/fryday/controller/user/request/ConsentRequest.java
@@ -6,6 +6,6 @@ public record ConsentRequest(
         @AssertTrue(message = "개인정보 수집 및 이용 동의는 필수입니다.")
         boolean privacyRequired,
 
-        boolean marketingOptional
+        boolean pushNotificationOptional
 ) {
 }

--- a/src/main/java/basakan/fryday/domain/user/Agreement.java
+++ b/src/main/java/basakan/fryday/domain/user/Agreement.java
@@ -20,26 +20,30 @@ public class Agreement extends BaseEntity {
     @Column(nullable = false)
     private boolean privacyAgreed = false;
 
-    @Column(nullable = false)
-    private boolean marketingAgreed = false;
+    @Column(name = "push_notification_agreed", nullable = false)
+    private boolean pushNotificationAgreed = false;
 
     @Builder
-    private Agreement(User user, boolean privacyAgreed, boolean marketingAgreed) {
+    private Agreement(User user, boolean privacyAgreed, boolean pushNotificationAgreed) {
         this.user = user;
         this.privacyAgreed = privacyAgreed;
-        this.marketingAgreed = marketingAgreed;
+        this.pushNotificationAgreed = pushNotificationAgreed;
     }
 
-    public static Agreement create(User user, boolean privacyAgreed, boolean marketingAgreed) {
+    public static Agreement create(User user, boolean privacyAgreed, boolean pushNotificationAgreed) {
         return Agreement.builder()
                 .user(user)
                 .privacyAgreed(privacyAgreed)
-                .marketingAgreed(marketingAgreed)
+                .pushNotificationAgreed(pushNotificationAgreed)
                 .build();
     }
 
-    public void updateConsent(boolean privacyAgreed, boolean marketingAgreed) {
+    public void updateConsent(boolean privacyAgreed, boolean pushNotificationAgreed) {
         this.privacyAgreed = privacyAgreed;
-        this.marketingAgreed = marketingAgreed;
+        this.pushNotificationAgreed = pushNotificationAgreed;
+    }
+
+    public void updatePushNotificationAgreement(boolean agreed) {
+        this.pushNotificationAgreed = agreed;
     }
 }

--- a/src/main/java/basakan/fryday/service/user/UserAppService.java
+++ b/src/main/java/basakan/fryday/service/user/UserAppService.java
@@ -40,14 +40,14 @@ public class UserAppService {
     private final UserDeviceReadService userDeviceReadService;
     private final UserDeviceWriteService userDeviceWriteService;
 
-    public void agreeConsent(boolean privacyRequired, boolean marketingOptional) {
+    public void agreeConsent(boolean privacyRequired, boolean pushNotificationOptional) {
         Long userId = UserContext.getCurrentUserId();
         User user = userReadService.findById(userId);
 
         Agreement agreement = userReadService.findAgreementByUser(user)
-                .orElseGet(() -> Agreement.create(user, privacyRequired, marketingOptional));
+                .orElseGet(() -> Agreement.create(user, privacyRequired, pushNotificationOptional));
 
-        userWriteService.agreeConsent(user, agreement, privacyRequired, marketingOptional);
+        userWriteService.agreeConsent(user, agreement, privacyRequired, pushNotificationOptional);
     }
 
     public void completeOnboarding() {

--- a/src/main/java/basakan/fryday/service/user/UserWriteService.java
+++ b/src/main/java/basakan/fryday/service/user/UserWriteService.java
@@ -20,8 +20,8 @@ public class UserWriteService {
     private final AgreementJpaRepository agreementRepository;
     private final basakan.fryday.service.fcm.UserDeviceWriteService userDeviceWriteService;
 
-    public void agreeConsent(User user, Agreement agreement, boolean privacyAgreed, boolean marketingAgreed) {
-        agreement.updateConsent(privacyAgreed, marketingAgreed);
+    public void agreeConsent(User user, Agreement agreement, boolean privacyAgreed, boolean pushNotificationAgreed) {
+        agreement.updateConsent(privacyAgreed, pushNotificationAgreed);
         agreementRepository.save(agreement);
         user.completeAgreementStep();
         userJpaRepository.save(user);

--- a/src/test/java/basakan/fryday/controller/user/UserControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/user/UserControllerTest.java
@@ -184,7 +184,7 @@ class UserControllerTest extends RestDocsSupport {
                 .andDo(document("user-consent",
                         requestFields(
                                 fieldWithPath("privacyRequired").type(JsonFieldType.BOOLEAN).description("개인정보 수집 및 이용 동의 (필수)"),
-                                fieldWithPath("marketingOptional").type(JsonFieldType.BOOLEAN).description("마케팅 수신 동의 (선택)")
+                                fieldWithPath("pushNotificationOptional").type(JsonFieldType.BOOLEAN).description("푸시 알림 수신 동의 (선택)")
                         ),
                         responseFields(
                                 fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")


### PR DESCRIPTION
## 변경 사항
Agreement 엔티티의 필드명을 마케팅 수신 동의에서 푸시 알림 수신 동의로 변경

### 주요 수정 내용
- Agreement.java: `marketingAgreed` → `pushNotificationAgreed` 필드명 변경
- ConsentRequest.java: `marketingOptional` → `pushNotificationOptional` DTO 필드명 변경
- UserWriteService, UserAppService, UserController: 메서드 파라미터명 변경
- UserControllerTest: REST Docs 문서화 수정

### 변경 이유
FryDay 서비스는 마케팅 수신 동의가 불필요합니다 (이메일, SMS 발송 안 함)
실제 필요한 동의 항목:
1. 개인정보 수집 및 이용 동의 (필수)
2. 푸시 알림 수신 동의 (선택)

### 테스트
- ✅ 빌드 성공