### PR TITLE
푸시 알림 시스템 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	// Firebase Cloud Messaging
+	implementation 'com.google.firebase:firebase-admin:9.4.2'
+
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/basakan/fryday/common/config/FcmConfig.java
+++ b/src/main/java/basakan/fryday/common/config/FcmConfig.java
@@ -1,0 +1,64 @@
+package basakan.fryday.common.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Firebase Cloud Messaging 설정
+ * - Firebase Admin SDK 초기화
+ * - firebase-adminsdk.json 파일 로드 (로컬 테스트용)
+ * - 프로덕션: 환경변수 또는 Secret Manager 사용 권장
+ */
+@Slf4j
+@Configuration
+public class FcmConfig {
+
+    @Value("${fcm.enabled:false}")
+    private boolean fcmEnabled;
+
+    @Value("${fcm.credentials.path:firebase-adminsdk.json}")
+    private String credentialsPath;
+
+    @PostConstruct
+    public void initialize() {
+        if (!fcmEnabled) {
+            log.warn("FCM is disabled. Push notifications will not be sent.");
+            return;
+        }
+
+        try {
+            ClassPathResource resource = new ClassPathResource(credentialsPath);
+
+            if (!resource.exists()) {
+                log.error("FCM credentials file not found: {}", credentialsPath);
+                log.error("Push notifications will not work. Please add {} to src/main/resources/", credentialsPath);
+                return;
+            }
+
+            InputStream serviceAccount = resource.getInputStream();
+
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options);
+                log.info("Firebase Admin SDK initialized successfully");
+            } else {
+                log.info("Firebase Admin SDK already initialized");
+            }
+
+        } catch (IOException e) {
+            log.error("Failed to initialize Firebase Admin SDK", e);
+        }
+    }
+}

--- a/src/main/java/basakan/fryday/common/service/push/FcmPushService.java
+++ b/src/main/java/basakan/fryday/common/service/push/FcmPushService.java
@@ -1,0 +1,98 @@
+package basakan.fryday.common.service.push;
+
+import basakan.fryday.domain.user.User;
+import basakan.fryday.domain.user.UserDevice;
+import basakan.fryday.repository.auth.UserDeviceRepository;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmPushService implements PushService {
+
+    private static final int MAX_RETRIES = 1;
+    private static final long RETRY_DELAY_MS = 500L;
+
+    private final UserDeviceRepository userDeviceRepository;
+
+    @Value("${fcm.enabled:false}")
+    private boolean fcmEnabled;
+
+    @Override
+    public void sendToUser(User user, String title, String body) {
+        if (!fcmEnabled) {
+            log.warn("FCM is disabled. Skipping push notification for userId={}", user.getId());
+            return;
+        }
+
+        List<UserDevice> devices = userDeviceRepository.findAllByUserIdAndIsActiveTrue(user.getId());
+
+        if (devices.isEmpty()) {
+            log.warn("No active devices found for userId={}", user.getId());
+            return;
+        }
+
+        for (UserDevice device : devices) {
+            if (device.getFcmToken() != null && !device.getFcmToken().isEmpty()) {
+                sendToToken(device.getFcmToken(), title, body);
+            }
+        }
+    }
+
+    @Override
+    public void sendToToken(String fcmToken, String title, String body) {
+        if (!fcmEnabled) {
+            log.warn("FCM is disabled. Skipping push notification");
+            return;
+        }
+
+        if (fcmToken == null || fcmToken.isEmpty()) {
+            log.warn("FCM token is null or empty. Cannot send notification.");
+            return;
+        }
+
+        int attempt = 0;
+
+        while (true) {
+            try {
+                Message message = Message.builder()
+                        .setToken(fcmToken)
+                        .setNotification(Notification.builder()
+                                .setTitle(title)
+                                .setBody(body)
+                                .build())
+                        .build();
+
+                String response = FirebaseMessaging.getInstance().send(message);
+                log.info("Push notification sent successfully: response={}", response);
+                return;
+
+            } catch (FirebaseMessagingException e) {
+                attempt++;
+
+                if (attempt > MAX_RETRIES) {
+                    log.error("Push notification failed after {} retries: error={}", MAX_RETRIES, e.getMessage(), e);
+                    return;
+                }
+
+                log.warn("Push notification failed (attempt {}/{}), retrying...", attempt, MAX_RETRIES);
+
+                try {
+                    Thread.sleep(RETRY_DELAY_MS);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/basakan/fryday/common/service/push/PushService.java
+++ b/src/main/java/basakan/fryday/common/service/push/PushService.java
@@ -1,0 +1,28 @@
+package basakan.fryday.common.service.push;
+
+import basakan.fryday.domain.user.User;
+
+/**
+ * 푸시 알림 발송 인터페이스
+ * - 구현체: FcmPushService (FCM Admin SDK 사용)
+ */
+public interface PushService {
+
+    /**
+     * 특정 사용자에게 푸시 알림 발송
+     *
+     * @param user  알림 수신 사용자
+     * @param title 알림 제목
+     * @param body  알림 내용
+     */
+    void sendToUser(User user, String title, String body);
+
+    /**
+     * 특정 FCM 토큰으로 푸시 알림 발송
+     *
+     * @param fcmToken FCM 토큰
+     * @param title    알림 제목
+     * @param body     알림 내용
+     */
+    void sendToToken(String fcmToken, String title, String body);
+}

--- a/src/main/java/basakan/fryday/controller/todo/TodoAlarmController.java
+++ b/src/main/java/basakan/fryday/controller/todo/TodoAlarmController.java
@@ -1,0 +1,35 @@
+package basakan.fryday.controller.todo;
+
+import basakan.fryday.common.response.MessageResponse;
+import basakan.fryday.common.security.UserContext;
+import basakan.fryday.controller.todo.request.TodoAlarmRequest;
+import basakan.fryday.service.todo.TodoAlarmService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/todos")
+@RequiredArgsConstructor
+public class TodoAlarmController {
+
+    private final TodoAlarmService todoAlarmService;
+
+    @PostMapping("/{todoId}/alarm")
+    public ResponseEntity<MessageResponse> setTodoAlarm(
+            @PathVariable Long todoId,
+            @Valid @RequestBody TodoAlarmRequest request
+    ) {
+        Long userId = UserContext.getCurrentUserId();
+        todoAlarmService.setTodoAlarm(todoId, userId, request.notifyAt());
+        return ResponseEntity.ok(new MessageResponse("알림이 성공적으로 설정되었습니다."));
+    }
+
+    @DeleteMapping("/{todoId}/alarm")
+    public ResponseEntity<MessageResponse> deleteTodoAlarm(@PathVariable Long todoId) {
+        Long userId = UserContext.getCurrentUserId();
+        todoAlarmService.deleteTodoAlarm(todoId, userId);
+        return ResponseEntity.ok(new MessageResponse("알림이 성공적으로 삭제되었습니다."));
+    }
+}

--- a/src/main/java/basakan/fryday/controller/todo/request/TodoAlarmRequest.java
+++ b/src/main/java/basakan/fryday/controller/todo/request/TodoAlarmRequest.java
@@ -1,0 +1,11 @@
+package basakan.fryday.controller.todo.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+public record TodoAlarmRequest(
+        @NotNull(message = "알림 시간은 필수입니다.")
+        LocalDateTime notifyAt
+) {
+}

--- a/src/main/java/basakan/fryday/controller/todo/request/TodoSaveRequest.java
+++ b/src/main/java/basakan/fryday/controller/todo/request/TodoSaveRequest.java
@@ -7,6 +7,8 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor
 public class TodoSaveRequest {
@@ -16,6 +18,8 @@ public class TodoSaveRequest {
 
     @NotNull
     private Long categoryId;
+
+    private LocalDateTime notifyAt;
 
     public TodoSaveRequest(String description, Long categoryId) {
         this.categoryId = categoryId;

--- a/src/main/java/basakan/fryday/controller/user/UserController.java
+++ b/src/main/java/basakan/fryday/controller/user/UserController.java
@@ -12,6 +12,7 @@ import basakan.fryday.controller.user.request.SetNicknameRequest;
 import basakan.fryday.controller.user.request.UpdateNicknameRequest;
 import basakan.fryday.controller.user.request.UpdateFcmTokenRequest;
 import basakan.fryday.controller.user.request.LogoutRequest;
+import basakan.fryday.controller.user.request.NotificationSettingsRequest;
 import basakan.fryday.service.auth.dto.SocialLoginDto;
 import basakan.fryday.service.user.UserAppService;
 import jakarta.validation.Valid;
@@ -95,5 +96,11 @@ public class UserController {
     public ResponseEntity<MessageResponse> logout(@Valid @RequestBody LogoutRequest request) {
         userAppService.logout(request.deviceId(), request.refreshToken());
         return ResponseEntity.ok(new MessageResponse("로그아웃이 완료되었습니다."));
+    }
+
+    @PatchMapping("/me/notification-settings")
+    public ResponseEntity<MessageResponse> updateNotificationSettings(@Valid @RequestBody NotificationSettingsRequest request) {
+        userAppService.updateNotificationSettings(request.pushNotificationEnabled());
+        return ResponseEntity.ok(new MessageResponse("알림 설정이 성공적으로 변경되었습니다."));
     }
 }

--- a/src/main/java/basakan/fryday/controller/user/request/NotificationSettingsRequest.java
+++ b/src/main/java/basakan/fryday/controller/user/request/NotificationSettingsRequest.java
@@ -1,0 +1,6 @@
+package basakan.fryday.controller.user.request;
+
+public record NotificationSettingsRequest(
+        boolean pushNotificationEnabled
+) {
+}

--- a/src/main/java/basakan/fryday/domain/todo/Todo.java
+++ b/src/main/java/basakan/fryday/domain/todo/Todo.java
@@ -43,6 +43,9 @@ public class Todo extends BaseEntity {
     @Column(nullable = false)
     private Boolean isBurnt = false;
 
+    @OneToOne(mappedBy = "todo", cascade = CascadeType.ALL, orphanRemoval = true)
+    private TodoAlarm todoAlarm;
+
     public enum Status {
         IN_PROGRESS, // 미완료 (체크 안 됨)
         COMPLETED    // 완료 (체크 됨)

--- a/src/main/java/basakan/fryday/domain/todo/TodoAlarm.java
+++ b/src/main/java/basakan/fryday/domain/todo/TodoAlarm.java
@@ -1,0 +1,63 @@
+package basakan.fryday.domain.todo;
+
+import basakan.fryday.domain.BaseEntity;
+import basakan.fryday.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "todo_alarms")
+public class TodoAlarm extends BaseEntity {
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "todo_id", nullable = false)
+    private Todo todo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private LocalDateTime notifyAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AlarmStatus status;
+
+    public enum AlarmStatus {
+        PENDING,  // 발송 대기
+        SENT      // 발송 완료
+    }
+
+    @Builder
+    private TodoAlarm(Todo todo, User user, LocalDateTime notifyAt) {
+        this.todo = todo;
+        this.user = user;
+        this.notifyAt = notifyAt;
+        this.status = AlarmStatus.PENDING;
+    }
+
+    public static TodoAlarm create(Todo todo, User user, LocalDateTime notifyAt) {
+        return TodoAlarm.builder()
+                .todo(todo)
+                .user(user)
+                .notifyAt(notifyAt)
+                .build();
+    }
+
+    public void changeTime(LocalDateTime notifyAt) {
+        this.notifyAt = notifyAt;
+        this.status = AlarmStatus.PENDING;
+    }
+
+    public void markAsSent() {
+        this.status = AlarmStatus.SENT;
+    }
+}

--- a/src/main/java/basakan/fryday/repository/auth/AgreementJpaRepository.java
+++ b/src/main/java/basakan/fryday/repository/auth/AgreementJpaRepository.java
@@ -3,10 +3,17 @@ package basakan.fryday.repository.auth;
 import basakan.fryday.domain.user.Agreement;
 import basakan.fryday.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface AgreementJpaRepository extends JpaRepository<Agreement, Long> {
 
     Optional<Agreement> findByUser(User user);
+
+    @Query("SELECT a.user FROM Agreement a " +
+            "WHERE a.pushNotificationAgreed = true " +
+            "AND a.user.accountStatus = 'ACTIVE'")
+    List<User> findAllUsersWithPushNotificationEnabled();
 }

--- a/src/main/java/basakan/fryday/repository/auth/UserDeviceRepository.java
+++ b/src/main/java/basakan/fryday/repository/auth/UserDeviceRepository.java
@@ -1,0 +1,13 @@
+package basakan.fryday.repository.auth;
+
+import basakan.fryday.domain.user.UserDevice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
+
+    List<UserDevice> findAllByUserIdAndIsActiveTrue(Long userId);
+
+    UserDevice findByUserIdAndDeviceId(Long userId, String deviceId);
+}

--- a/src/main/java/basakan/fryday/repository/todo/TodoAlarmRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/TodoAlarmRepository.java
@@ -1,0 +1,26 @@
+package basakan.fryday.repository.todo;
+
+import basakan.fryday.domain.todo.TodoAlarm;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface TodoAlarmRepository extends JpaRepository<TodoAlarm, Long> {
+
+    Optional<TodoAlarm> findByTodoId(Long todoId);
+
+    @Query("SELECT ta FROM TodoAlarm ta " +
+            "JOIN FETCH ta.user " +
+            "JOIN FETCH ta.todo " +
+            "WHERE ta.status = :status AND ta.notifyAt < :notifyAt")
+    List<TodoAlarm> findAllByStatusAndNotifyAtBefore(
+            @Param("status") TodoAlarm.AlarmStatus status,
+            @Param("notifyAt") LocalDateTime notifyAt
+    );
+
+    void deleteByTodoId(Long todoId);
+}

--- a/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
@@ -15,20 +15,29 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     @Query("SELECT MAX(t.displayOrder) FROM Todo t JOIN t.category c WHERE c.userId = :userId AND t.date = :date AND t.deletedAt IS NULL")
     Long findMaxDisplayOrder(@Param("userId") Long userId, @Param("date") LocalDate date);
 
-    // 전체 보기
     @Query("SELECT t FROM Todo t " +
             "WHERE t.category.userId = :userId AND t.date = :date AND t.deletedAt IS NULL " +
             "ORDER BY t.displayOrder ASC")
     List<Todo> findAllByUserIdAndDate(@Param("userId") Long userId, @Param("date") LocalDate date);
 
-    // 카테고리별 보기
     @Query("SELECT t FROM Todo t " +
             "WHERE t.category.id = :categoryId AND t.date = :date AND t.deletedAt IS NULL " +
             "ORDER BY t.displayOrder ASC")
     List<Todo> findAllByCategoryIdAndDate(@Param("categoryId") Long categoryId, @Param("date") LocalDate date);
 
-    // 특정 날짜의 미완료 투두를 탄 튀김 상태로 일괄 업데이트
     @Modifying
     @Query("UPDATE Todo t SET t.isBurnt = true WHERE t.date = :date AND t.status = :status AND t.deletedAt IS NULL")
     int updateBurntStatusByDate(@Param("date") LocalDate date, @Param("status") Todo.Status status);
+
+    @Query("SELECT COUNT(t) FROM Todo t JOIN t.category c " +
+            "WHERE c.userId = :userId AND t.date = :date AND t.status = :status AND t.deletedAt IS NULL")
+    long countByUserIdAndDateAndStatus(@Param("userId") Long userId, @Param("date") LocalDate date, @Param("status") Todo.Status status);
+
+    @Query("SELECT COUNT(t) FROM Todo t JOIN t.category c " +
+            "WHERE c.userId = :userId AND t.date = :date AND t.deletedAt IS NULL")
+    long countByUserIdAndDate(@Param("userId") Long userId, @Param("date") LocalDate date);
+
+    @Query("SELECT DISTINCT c.userId FROM Todo t JOIN t.category c " +
+            "WHERE t.date = :date AND t.isBurnt = true AND t.deletedAt IS NULL")
+    List<Long> findUserIdsWithBurntTodosByDate(@Param("date") LocalDate date);
 }

--- a/src/main/java/basakan/fryday/scheduler/BurntAlarmScheduler.java
+++ b/src/main/java/basakan/fryday/scheduler/BurntAlarmScheduler.java
@@ -1,0 +1,72 @@
+package basakan.fryday.scheduler;
+
+import basakan.fryday.common.service.push.PushService;
+import basakan.fryday.domain.user.User;
+import basakan.fryday.repository.auth.AgreementJpaRepository;
+import basakan.fryday.repository.todo.TodoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 실패 확정 알림 스케줄러 (Alarm-002)
+ * - 매일 새벽 00:05에 실행
+ * - 전날 미완료 투두가 있는 사용자에게 알림 발송
+ * - 메시지: "튀김이 타버렸어요. 새로운 계획을 세워요!"
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BurntAlarmScheduler {
+
+    private final AgreementJpaRepository agreementJpaRepository;
+    private final TodoRepository todoRepository;
+    private final PushService pushService;
+
+    @Scheduled(cron = "0 5 0 * * *", zone = "Asia/Seoul")
+    @Transactional(readOnly = true)
+    public void sendBurntAlarm() {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        log.info("Burnt Alarm start: {}", yesterday);
+
+        List<User> usersWithPushEnabled = agreementJpaRepository.findAllUsersWithPushNotificationEnabled();
+
+        if (usersWithPushEnabled.isEmpty()) {
+            log.info("No users with push notification enabled");
+            return;
+        }
+
+        List<Long> userIdsWithBurntTodos = todoRepository.findUserIdsWithBurntTodosByDate(yesterday);
+
+        if (userIdsWithBurntTodos.isEmpty()) {
+            log.info("No burnt todos found for {}", yesterday);
+            return;
+        }
+
+        Set<Long> burntUserIds = userIdsWithBurntTodos.stream().collect(Collectors.toSet());
+        List<User> targetUsers = usersWithPushEnabled.stream()
+                .filter(user -> burntUserIds.contains(user.getId()))
+                .toList();
+
+        int notificationCount = 0;
+
+        for (User user : targetUsers) {
+            try {
+                pushService.sendToUser(user, "FryDay", "튀김이 타버렸어요. 새로운 계획을 세워요!");
+                notificationCount++;
+                log.info("Burnt alarm sent: userId={}", user.getId());
+            } catch (Exception e) {
+                log.error("Burnt alarm failed for userId={}", user.getId(), e);
+            }
+        }
+
+        log.info("Burnt Alarm end: sent={}", notificationCount);
+    }
+}

--- a/src/main/java/basakan/fryday/scheduler/DeadlineAlarmScheduler.java
+++ b/src/main/java/basakan/fryday/scheduler/DeadlineAlarmScheduler.java
@@ -1,0 +1,65 @@
+package basakan.fryday.scheduler;
+
+import basakan.fryday.common.service.push.PushService;
+import basakan.fryday.domain.todo.Todo;
+import basakan.fryday.domain.user.User;
+import basakan.fryday.repository.auth.AgreementJpaRepository;
+import basakan.fryday.repository.todo.TodoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 마감 임박 알림 스케줄러 (Alarm-001)
+ * - 매일 오후 10시(22:00)에 실행
+ * - 당일 미완료 투두가 1개 이상 존재하는 사용자에게 알림 발송
+ * - 메시지: "튀김이 타기전에 완료하세요!"
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DeadlineAlarmScheduler {
+
+    private final AgreementJpaRepository agreementJpaRepository;
+    private final TodoRepository todoRepository;
+    private final PushService pushService;
+
+    @Scheduled(cron = "0 0 22 * * *", zone = "Asia/Seoul")
+    @Transactional(readOnly = true)
+    public void sendDeadlineAlarm() {
+        LocalDate today = LocalDate.now();
+        log.info("Deadline Alarm start: {}", today);
+
+        List<User> users = agreementJpaRepository.findAllUsersWithPushNotificationEnabled();
+
+        if (users.isEmpty()) {
+            log.info("No users with push notification enabled");
+            return;
+        }
+
+        int notificationCount = 0;
+
+        for (User user : users) {
+            try {
+                long incompleteCount = todoRepository.countByUserIdAndDateAndStatus(
+                        user.getId(), today, Todo.Status.IN_PROGRESS
+                );
+
+                if (incompleteCount > 0) {
+                    pushService.sendToUser(user, "FryDay", "튀김이 타기전에 완료하세요!");
+                    notificationCount++;
+                    log.info("Deadline alarm sent: userId={}, incompleteCount={}", user.getId(), incompleteCount);
+                }
+            } catch (Exception e) {
+                log.error("Deadline alarm failed for userId={}", user.getId(), e);
+            }
+        }
+
+        log.info("Deadline Alarm end: sent={}", notificationCount);
+    }
+}

--- a/src/main/java/basakan/fryday/scheduler/EncourageAlarmScheduler.java
+++ b/src/main/java/basakan/fryday/scheduler/EncourageAlarmScheduler.java
@@ -1,0 +1,62 @@
+package basakan.fryday.scheduler;
+
+import basakan.fryday.common.service.push.PushService;
+import basakan.fryday.domain.user.User;
+import basakan.fryday.repository.auth.AgreementJpaRepository;
+import basakan.fryday.repository.todo.TodoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 투두 추가 독려 알림 스케줄러 (Alarm-003)
+ * - 매일 오전 09:00에 실행
+ * - 당일 투두를 하나도 추가하지 않은 사용자에게 알림 발송
+ * - 메시지: "튀김기에 새로운 튀김을 넣어주세요!"
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EncourageAlarmScheduler {
+
+    private final AgreementJpaRepository agreementJpaRepository;
+    private final TodoRepository todoRepository;
+    private final PushService pushService;
+
+    @Scheduled(cron = "0 0 9 * * *", zone = "Asia/Seoul")
+    @Transactional(readOnly = true)
+    public void sendEncourageAlarm() {
+        LocalDate today = LocalDate.now();
+        log.info("Encourage Alarm start: {}", today);
+
+        List<User> users = agreementJpaRepository.findAllUsersWithPushNotificationEnabled();
+
+        if (users.isEmpty()) {
+            log.info("No users with push notification enabled");
+            return;
+        }
+
+        int notificationCount = 0;
+
+        for (User user : users) {
+            try {
+                long todoCount = todoRepository.countByUserIdAndDate(user.getId(), today);
+
+                if (todoCount == 0) {
+                    pushService.sendToUser(user, "FryDay", "튀김기에 새로운 튀김을 넣어주세요!");
+                    notificationCount++;
+                    log.info("Encourage alarm sent: userId={}", user.getId());
+                }
+            } catch (Exception e) {
+                log.error("Encourage alarm failed for userId={}", user.getId(), e);
+            }
+        }
+
+        log.info("Encourage Alarm end: sent={}", notificationCount);
+    }
+}

--- a/src/main/java/basakan/fryday/scheduler/NotificationScheduler.java
+++ b/src/main/java/basakan/fryday/scheduler/NotificationScheduler.java
@@ -1,0 +1,54 @@
+package basakan.fryday.scheduler;
+
+import basakan.fryday.common.service.push.PushService;
+import basakan.fryday.domain.todo.TodoAlarm;
+import basakan.fryday.repository.todo.TodoAlarmRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 개별 투두 알림 스케줄러 (Ad-005)
+ * - 매분 0초에 실행
+ * - 발송 시간이 되었고 아직 발송 전인 알림 발송
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationScheduler {
+
+    private final TodoAlarmRepository todoAlarmRepository;
+    private final PushService pushService;
+
+    @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void sendDueNotifications() {
+        LocalDateTime now = LocalDateTime.now();
+
+        List<TodoAlarm> dueAlarms = todoAlarmRepository.findAllByStatusAndNotifyAtBefore(
+                TodoAlarm.AlarmStatus.PENDING,
+                now
+        );
+
+        if (dueAlarms.isEmpty()) {
+            return;
+        }
+
+        log.info("Sending {} due notifications", dueAlarms.size());
+
+        for (TodoAlarm alarm : dueAlarms) {
+            try {
+                pushService.sendToUser(alarm.getUser(), "FryDay 알림", alarm.getTodo().getDescription());
+                alarm.markAsSent();
+                log.info("Notification sent: todoId={}, userId={}", alarm.getTodo().getId(), alarm.getUser().getId());
+            } catch (Exception e) {
+                log.error("Failed to send notification for alarmId: {}", alarm.getId(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/basakan/fryday/service/todo/TodoAlarmService.java
+++ b/src/main/java/basakan/fryday/service/todo/TodoAlarmService.java
@@ -1,0 +1,56 @@
+package basakan.fryday.service.todo;
+
+import basakan.fryday.common.ErrorCode;
+import basakan.fryday.common.exception.BusinessException;
+import basakan.fryday.domain.todo.Todo;
+import basakan.fryday.domain.todo.TodoAlarm;
+import basakan.fryday.domain.user.User;
+import basakan.fryday.repository.todo.TodoAlarmRepository;
+import basakan.fryday.repository.todo.TodoRepository;
+import basakan.fryday.service.user.UserReadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TodoAlarmService {
+
+    private final TodoAlarmRepository todoAlarmRepository;
+    private final TodoRepository todoRepository;
+    private final UserReadService userReadService;
+
+    public void setTodoAlarm(Long todoId, Long userId, LocalDateTime notifyAt) {
+        Todo todo = todoRepository.findById(todoId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        if (!todo.getCategory().getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
+
+        User user = userReadService.findById(userId);
+
+        todoAlarmRepository.findByTodoId(todoId)
+                .ifPresentOrElse(
+                        existingAlarm -> existingAlarm.changeTime(notifyAt),
+                        () -> {
+                            TodoAlarm newAlarm = TodoAlarm.create(todo, user, notifyAt);
+                            todoAlarmRepository.save(newAlarm);
+                        }
+                );
+    }
+
+    public void deleteTodoAlarm(Long todoId, Long userId) {
+        Todo todo = todoRepository.findById(todoId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        if (!todo.getCategory().getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
+
+        todoAlarmRepository.deleteByTodoId(todoId);
+    }
+}

--- a/src/main/java/basakan/fryday/service/todo/TodoService.java
+++ b/src/main/java/basakan/fryday/service/todo/TodoService.java
@@ -14,8 +14,12 @@ import basakan.fryday.domain.BaseEntity;
 import basakan.fryday.domain.category.Category;
 import basakan.fryday.domain.todo.CharacterStatus;
 import basakan.fryday.domain.todo.Todo;
+import basakan.fryday.domain.todo.TodoAlarm;
+import basakan.fryday.domain.user.User;
 import basakan.fryday.repository.CategoryRepository;
+import basakan.fryday.repository.todo.TodoAlarmRepository;
 import basakan.fryday.repository.todo.TodoRepository;
+import basakan.fryday.service.user.UserReadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +36,8 @@ public class TodoService {
 
     private final TodoRepository todoRepository;
     private final CategoryRepository categoryRepository;
+    private final TodoAlarmRepository todoAlarmRepository;
+    private final UserReadService userReadService;
 
     @Transactional
     public TodoResponse saveTodo(TodoSaveRequest request) {
@@ -45,9 +51,16 @@ public class TodoService {
 
         todo.updateDisplayOrder(nextOrder);
 
-        Todo saveTodo = todoRepository.save(todo);
+        Todo savedTodo = todoRepository.save(todo);
 
-        return TodoResponse.from(saveTodo);
+        // 알림 시간이 설정되어 있으면 TodoAlarm 생성
+        if (request.getNotifyAt() != null) {
+            User user = userReadService.findById(category.getUserId());
+            TodoAlarm todoAlarm = TodoAlarm.create(savedTodo, user, request.getNotifyAt());
+            todoAlarmRepository.save(todoAlarm);
+        }
+
+        return TodoResponse.from(savedTodo);
     }
 
     @Transactional

--- a/src/main/java/basakan/fryday/service/user/UserAppService.java
+++ b/src/main/java/basakan/fryday/service/user/UserAppService.java
@@ -74,6 +74,16 @@ public class UserAppService {
         userWriteService.updateNickname(user, nickname);
     }
 
+    public void updateNotificationSettings(boolean pushNotificationEnabled) {
+        Long userId = UserContext.getCurrentUserId();
+        User user = userReadService.findById(userId);
+
+        Agreement agreement = userReadService.findAgreementByUser(user)
+                .orElseGet(() -> Agreement.create(user, false, pushNotificationEnabled));
+
+        userWriteService.updateNotificationSettings(agreement, pushNotificationEnabled);
+    }
+
     public NicknameCheckResponse checkNicknameAvailability(String nickname) {
         if (nickname == null || nickname.length() < 2 || nickname.length() > 10) {
             throw new BusinessException(ErrorCode.INVALID_NICKNAME_LENGTH);

--- a/src/main/java/basakan/fryday/service/user/UserWriteService.java
+++ b/src/main/java/basakan/fryday/service/user/UserWriteService.java
@@ -60,6 +60,11 @@ public class UserWriteService {
         userJpaRepository.save(user);
     }
 
+    public void updateNotificationSettings(Agreement agreement, boolean pushNotificationEnabled) {
+        agreement.updatePushNotificationAgreement(pushNotificationEnabled);
+        agreementRepository.save(agreement);
+    }
+
     private void validateNicknameLength(String nickname) {
         if (nickname == null || nickname.length() < 2 || nickname.length() > 10) {
             throw new BusinessException(ErrorCode.INVALID_NICKNAME_LENGTH);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,12 @@ spring:
       username: ${REDIS_USERNAME}
       password: ${REDIS_PASSWORD}
 
+  task:
+    scheduling:
+      pool:
+        size: 5
+      thread-name-prefix: fryday-scheduler-
+
 jwt:
   secret-key: ${JWT_SECRET_KEY:your-default-jwt-secret-key}
   access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:3600000}
@@ -29,3 +35,8 @@ oauth:
   apple:
     client-id: ${APPLE_CLIENT_ID:com.example.app}
     jwks-url: https://appleid.apple.com/auth/keys
+
+fcm:
+  enabled: ${FCM_ENABLED:false}
+  credentials:
+    path: ${FCM_CREDENTIALS_PATH:firebase-adminsdk.json}

--- a/src/test/java/basakan/fryday/controller/todo/TodoAlarmControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/todo/TodoAlarmControllerTest.java
@@ -1,0 +1,112 @@
+package basakan.fryday.controller.todo;
+
+import basakan.fryday.RestDocsSupport;
+import basakan.fryday.common.config.SecurityConfig;
+import basakan.fryday.common.security.JwtAuthenticationFilter;
+import basakan.fryday.common.security.JwtTokenProvider;
+import basakan.fryday.controller.todo.request.TodoAlarmRequest;
+import basakan.fryday.service.todo.TodoAlarmService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = TodoAlarmController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+        }
+)
+class TodoAlarmControllerTest extends RestDocsSupport {
+
+    @MockitoBean
+    private TodoAlarmService todoAlarmService;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(1L, null, Collections.emptyList());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @Test
+    @DisplayName("개별 투두 알림 설정 API")
+    void setTodoAlarm() throws Exception {
+        // given
+        Long todoId = 1L;
+        TodoAlarmRequest request = new TodoAlarmRequest(LocalDateTime.of(2025, 12, 26, 14, 30, 0));
+
+        willDoNothing().given(todoAlarmService)
+                .setTodoAlarm(anyLong(), anyLong(), any(LocalDateTime.class));
+
+        // when & then
+        mockMvc.perform(post("/api/todos/{todoId}/alarm", todoId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("알림이 성공적으로 설정되었습니다."))
+                .andDo(document("todo-alarm-set",
+                        pathParameters(
+                                parameterWithName("todoId").description("투두 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("notifyAt").type(JsonFieldType.STRING).description("알림 시간 (ISO 8601 형식, 예: 2025-12-26T14:30:00)")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("개별 투두 알림 삭제 API")
+    void deleteTodoAlarm() throws Exception {
+        // given
+        Long todoId = 1L;
+
+        willDoNothing().given(todoAlarmService)
+                .deleteTodoAlarm(anyLong(), anyLong());
+
+        // when & then
+        mockMvc.perform(delete("/api/todos/{todoId}/alarm", todoId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("알림이 성공적으로 삭제되었습니다."))
+                .andDo(document("todo-alarm-delete",
+                        pathParameters(
+                                parameterWithName("todoId").description("투두 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")
+                        )
+                ));
+    }
+}

--- a/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
@@ -93,7 +93,8 @@ class TodoControllerTest extends RestDocsSupport {
                 .andDo(document("todo-create",
                         requestFields(
                                 fieldWithPath("description").type(JsonFieldType.STRING).description("할 일 내용"),
-                                fieldWithPath("categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID")
+                                fieldWithPath("categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
+                                fieldWithPath("notifyAt").type(JsonFieldType.STRING).description("알림 시간 (선택, ISO 8601 형식)").optional()
                         ),
                         responseFields(
                                 fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),

--- a/src/test/java/basakan/fryday/controller/user/UserControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/user/UserControllerTest.java
@@ -348,4 +348,30 @@ class UserControllerTest extends RestDocsSupport {
                         )
                 ));
     }
+
+    @Test
+    @DisplayName("알림 설정 변경 API")
+    @WithMockUser
+    void updateNotificationSettings() throws Exception {
+        // given
+        NotificationSettingsRequest request = new NotificationSettingsRequest(true);
+
+        doNothing().when(userAppService).updateNotificationSettings(anyBoolean());
+
+        // when & then
+        mockMvc.perform(patch("/api/users/me/notification-settings")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("알림 설정이 성공적으로 변경되었습니다."))
+                .andDo(document("user-notification-settings-update",
+                        requestFields(
+                                fieldWithPath("pushNotificationEnabled").type(JsonFieldType.BOOLEAN).description("푸시 알림 수신 여부 (true: 수신, false: 거부)")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")
+                        )
+                ));
+    }
 }


### PR DESCRIPTION
## 📌 Related Issue
- Closes: #26

## 🚀 Description

### 구현 기능
- **FCM 인프라**
  - Firebase Admin SDK 초기화 및 설정
  - 푸시 알림 발송 서비스 (재시도 로직: 최대 1회, 500ms 간격)

- **개별 투두 알림 API** (Ad-005)
  - `POST /api/todos/{todoId}/alarm` - 알림 설정
  - `DELETE /api/todos/{todoId}/alarm` - 알림 삭제
  - 투두 생성 시 알림 설정 지원 (`notifyAt` 필드)

- **시스템 알림 스케줄러**
  - **Alarm-001**: 마감 임박 알림 (매일 22:00)
  - **Alarm-002**: 실패 확정 알림 (매일 00:05)
  - **Alarm-003**: 투두 추가 독려 (매일 09:00)
  - **Ad-005**: 개별 투두 알림 발송 (매분 0초)

- **마이페이지 알림 설정**
  - `PATCH /api/users/me/notification-settings` - 푸시 알림 ON/OFF

- **보안 및 최적화**
  - 소유권 검증 (다른 사용자의 투두 알림 설정 방지)
  - N+1 쿼리 최적화 (JOIN FETCH)
  - 탈퇴/정지 회원 필터링
  - fcmToken 로그 노출 방지

## 📢 Notes

### 개별 투두 알림 설정

```mermaid
sequenceDiagram
    actor User
    participant Controller as TodoAlarmController
    participant Service as TodoAlarmService
    participant Repo as TodoAlarmRepository

    User->>Controller: POST /api/todos/{todoId}/alarm
    Controller->>Service: setTodoAlarm(todoId, userId, notifyAt)
    Service->>Service: 소유권 검증
    Service->>Repo: findByTodoId(todoId)
    alt 기존 알림 존재
        Repo-->>Service: TodoAlarm
        Service->>Service: changeTime(notifyAt)
    else 알림 없음
        Service->>Service: TodoAlarm.create()
        Service->>Repo: save(newAlarm)
    end
    Service-->>Controller: void
    Controller-->>User: 200 OK
```

### 알림 발송 흐름

```mermaid
sequenceDiagram
    participant Scheduler as NotificationScheduler
    participant Repo as TodoAlarmRepository
    participant FCM as FcmPushService
    participant Firebase

    Note over Scheduler: 매분 0초 실행
    Scheduler->>Repo: findAllByStatusAndNotifyAtBefore<br/>(PENDING, now)
    Note over Repo: JOIN FETCH user, todo
    Repo-->>Scheduler: List<TodoAlarm>

    loop 각 알림
        Scheduler->>FCM: sendToUser(user, title, body)
        FCM->>Firebase: send(message)
        alt 성공
            Firebase-->>FCM: response
            FCM-->>Scheduler: void
            Scheduler->>Scheduler: alarm.markAsSent()
        else 실패 (1회 재시도)
            Firebase-->>FCM: error
            FCM->>FCM: Thread.sleep(500ms)
            FCM->>Firebase: send(message) - 재시도
        end
    end
```

### 시스템 알림 스케줄러

```mermaid
sequenceDiagram
    participant Scheduler
    participant AgreementRepo
    participant TodoRepo
    participant FCM

    Note over Scheduler: DeadlineAlarmScheduler (22:00)
    Scheduler->>AgreementRepo: findAllUsersWithPushNotificationEnabled()
    AgreementRepo-->>Scheduler: List<User> (ACTIVE only)

    loop 각 사용자
        Scheduler->>TodoRepo: countByUserIdAndDateAndStatus<br/>(userId, today, IN_PROGRESS)
        TodoRepo-->>Scheduler: count
        alt count > 0
            Scheduler->>FCM: sendToUser(user, "FryDay", "튀김이 타기전에 완료하세요!")
        end
    end
```
