### PR TITLE
#29, 30 반복 투두 전체 삭제 및 투두 카테고리 변경 기능 추가

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -416,6 +416,23 @@ include::{snippets}/todo-recurrence-create/http-request.adoc[]
 include::{snippets}/todo-recurrence-create/http-response.adoc[]
 
 
+=== 투두 카테고리 변경
+`PATCH /api/todos/{todoId}/category`
+
+투두의 카테고리를 변경합니다.
+
+==== 요청 필드
+include::{snippets}/todo-update-category/request-fields.adoc[]
+==== 경로 파라미터
+include::{snippets}/todo-update-category/path-parameters.adoc[]
+==== HTTP 요청 예시
+include::{snippets}/todo-update-category/http-request.adoc[]
+==== HTTP 응답 예시
+include::{snippets}/todo-update-category/http-response.adoc[]
+==== 응답 필드
+include::{snippets}/todo-update-category/response-fields.adoc[]
+
+
 == 카테고리(Category)
 
 === 카테고리 생성

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -306,6 +306,19 @@ include::{snippets}/todo-delete/http-response.adoc[]
 ==== 응답 필드
 include::{snippets}/todo-delete/response-fields.adoc[]
 
+=== 반복 설정 투두 삭제
+`DELETE /api/todos/{todoId}/recurrence`
+
+반복 설정이 된 투두를 전체 삭제합니다.
+
+==== 경로 파라미터
+include::{snippets}/todo-recurrence-delete/path-parameters.adoc[]
+==== HTTP 요청 예시
+include::{snippets}/todo-recurrence-delete/http-request.adoc[]
+==== HTTP 응답 예시
+include::{snippets}/todo-recurrence-delete/http-response.adoc[]
+==== 응답 필드
+include::{snippets}/todo-recurrence-delete/response-fields.adoc[]
 
 === 탄 투두 오늘로 가져오기
 `POST /api/todos/{todoId}/bring-to-today`

--- a/src/main/java/basakan/fryday/controller/todo/TodoController.java
+++ b/src/main/java/basakan/fryday/controller/todo/TodoController.java
@@ -135,4 +135,12 @@ public class TodoController {
         TodoResponse response = recurrenceService.createRecurrence(currentUserId, request);
         return ApiResponse.success(response, "반복 투두가 생성되었습니다.");
     }
+
+    @DeleteMapping("/{todoId}/recurrence")
+    public ApiResponse<Void> deleteRecurrence(@PathVariable Long todoId) {
+        Long currentUserId = 1L;
+
+        recurrenceService.deleteRecurrence(todoId, currentUserId);
+        return ApiResponse.success(null, "반복 투두가 모두 삭제되었습니다.");
+    }
 }

--- a/src/main/java/basakan/fryday/controller/todo/TodoController.java
+++ b/src/main/java/basakan/fryday/controller/todo/TodoController.java
@@ -4,6 +4,7 @@ import basakan.fryday.common.response.ApiResponse;
 import basakan.fryday.controller.todo.request.MemoRequest;
 import basakan.fryday.controller.dto.OrderUpdateRequest;
 import basakan.fryday.controller.todo.request.RecurrenceCreateRequest;
+import basakan.fryday.controller.todo.request.TodoCategoryUpdateRequest;
 import basakan.fryday.controller.todo.request.TodoDateUpdateRequest;
 import basakan.fryday.controller.todo.request.TodoSaveRequest;
 import basakan.fryday.controller.todo.response.CharacterStatusResponse;
@@ -105,6 +106,17 @@ public class TodoController {
 
         TodoResponse response = todoService.updateTodoDate(todoId, currentUserId, request);
         return ApiResponse.success(response, "날짜가 변경되었습니다.");
+    }
+
+    @PatchMapping("/{todoId}/category")
+    public ApiResponse<TodoResponse> updateCategory(
+            @PathVariable Long todoId,
+            @Valid @RequestBody TodoCategoryUpdateRequest request
+    ) {
+        Long currentUserId = 1L;
+
+        TodoResponse response = todoService.updateCategory(todoId, currentUserId, request);
+        return ApiResponse.success(response, "카테고리가 변경되었습니다.");
     }
 
     @PatchMapping("/reorder")

--- a/src/main/java/basakan/fryday/controller/todo/request/TodoCategoryUpdateRequest.java
+++ b/src/main/java/basakan/fryday/controller/todo/request/TodoCategoryUpdateRequest.java
@@ -1,0 +1,18 @@
+package basakan.fryday.controller.todo.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TodoCategoryUpdateRequest {
+
+    @NotNull(message = "변경할 카테고리 ID는 필수입니다.")
+    private Long categoryId;
+
+    public TodoCategoryUpdateRequest(Long categoryId) {
+        this.categoryId = categoryId;
+    }
+}
+

--- a/src/main/java/basakan/fryday/domain/todo/Todo.java
+++ b/src/main/java/basakan/fryday/domain/todo/Todo.java
@@ -99,4 +99,8 @@ public class Todo extends BaseEntity {
         this.recurrenceId = recurrenceId;
     }
 
+    public void updateCategory(Category category) {
+        this.category = category;
+    }
+
 }

--- a/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
@@ -40,4 +40,7 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     @Query("SELECT DISTINCT c.userId FROM Todo t JOIN t.category c " +
             "WHERE t.date = :date AND t.isBurnt = true AND t.deletedAt IS NULL")
     List<Long> findUserIdsWithBurntTodosByDate(@Param("date") LocalDate date);
+
+    @Query("SELECT t FROM Todo t WHERE t.recurrenceId = :recurrenceId AND t.deletedAt IS NULL")
+    List<Todo> findAllByRecurrenceId(@Param("recurrenceId") Long recurrenceId);
 }

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
@@ -113,4 +113,28 @@ public class RecurrenceService {
                 return false;
         }
     }
+
+    @Transactional
+    public void deleteRecurrence(Long todoId, Long userId) {
+        Todo todo = todoRepository.findById(todoId)
+                .filter(t -> !t.isDeleted())
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        if (!todo.getCategory().getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
+
+        Long recurrenceId = todo.getRecurrenceId();
+        if (recurrenceId == null) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
+
+        List<Todo> allRecurringTodos = todoRepository.findAllByRecurrenceId(recurrenceId);
+
+        todoRepository.deleteAll(allRecurringTodos);
+
+        Recurrence recurrence = recurrenceRepository.findById(recurrenceId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+        recurrenceRepository.delete(recurrence);
+    }
 }

--- a/src/main/java/basakan/fryday/service/todo/TodoService.java
+++ b/src/main/java/basakan/fryday/service/todo/TodoService.java
@@ -4,6 +4,7 @@ import basakan.fryday.common.ErrorCode;
 import basakan.fryday.common.exception.BusinessException;
 import basakan.fryday.controller.todo.request.MemoRequest;
 import basakan.fryday.controller.dto.OrderUpdateRequest;
+import basakan.fryday.controller.todo.request.TodoCategoryUpdateRequest;
 import basakan.fryday.controller.todo.request.TodoDateUpdateRequest;
 import basakan.fryday.controller.todo.request.TodoSaveRequest;
 import basakan.fryday.controller.todo.response.CharacterStatusResponse;
@@ -141,6 +142,28 @@ public class TodoService {
         }
 
         todo.updateDate(request.getDate());
+
+        return TodoResponse.from(todo);
+    }
+
+    @Transactional
+    public TodoResponse updateCategory(Long todoId, Long userId, TodoCategoryUpdateRequest request) {
+        Todo todo = todoRepository.findById(todoId)
+                .filter(t -> !t.isDeleted())
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        if (!todo.getCategory().getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
+
+        Category newCategory = categoryRepository.findById(request.getCategoryId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+
+        if (!newCategory.getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.CATEGORY_NOT_FOUND);
+        }
+
+        todo.updateCategory(newCategory);
 
         return TodoResponse.from(todo);
     }

--- a/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
@@ -218,6 +218,29 @@ class TodoControllerTest extends RestDocsSupport {
     }
 
     @Test
+    @DisplayName("반복 투두 전체 삭제 API")
+    void deleteRecurrence() throws Exception {
+        // given
+        Long todoId = 1L;
+
+        // when & then
+        mockMvc.perform(delete("/api/todos/{todoId}/recurrence", todoId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("todo-recurrence-delete",
+                        pathParameters(
+                                parameterWithName("todoId").description("반복 투두를 삭제할 투두 ID (원본 투두 포함 모든 반복 투두가 삭제됩니다)")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
+                        )
+                ));
+    }
+
+    @Test
     @DisplayName("지난 투두 오늘로 가져오기 API")
     void bringTodoToToday() throws Exception {
         // given

--- a/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
@@ -8,6 +8,7 @@ import basakan.fryday.common.security.JwtTokenProvider;
 import basakan.fryday.controller.todo.request.MemoRequest;
 import basakan.fryday.controller.dto.OrderUpdateRequest;
 import basakan.fryday.controller.todo.request.RecurrenceCreateRequest;
+import basakan.fryday.controller.todo.request.TodoCategoryUpdateRequest;
 import basakan.fryday.controller.todo.request.TodoDateUpdateRequest;
 import basakan.fryday.controller.todo.request.TodoSaveRequest;
 import basakan.fryday.controller.todo.response.CharacterStatusResponse;
@@ -441,6 +442,58 @@ class TodoControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
                                 fieldWithPath("data.memo").type(JsonFieldType.STRING).description("메모").optional(),
                                 fieldWithPath("data.date").type(JsonFieldType.STRING).description("변경된 날짜"),
+                                fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("투두 카테고리 변경")
+    void updateCategory() throws Exception {
+        // given
+        Long todoId = 1L;
+        Long newCategoryId = 2L;
+        TodoCategoryUpdateRequest request = new TodoCategoryUpdateRequest(newCategoryId);
+
+        // Mocking
+        Category oldCategory = Category.builder().name("요리").color(CategoryColor.BR).userId(1L).build();
+        ReflectionTestUtils.setField(oldCategory, "id", 1L);
+
+        Category newCategory = Category.builder().name("운동").color(CategoryColor.CB).userId(1L).build();
+        ReflectionTestUtils.setField(newCategory, "id", newCategoryId);
+
+        Todo mockTodo = Todo.builder()
+                .description("장보기")
+                .category(newCategory) // 변경된 카테고리
+                .date(LocalDate.now())
+                .build();
+        ReflectionTestUtils.setField(mockTodo, "id", todoId);
+
+        given(todoService.updateCategory(anyLong(), anyLong(), any(TodoCategoryUpdateRequest.class)))
+                .willReturn(TodoResponse.from(mockTodo));
+
+        // when & then
+        mockMvc.perform(patch("/api/todos/{todoId}/category", todoId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("todo-update-category",
+                        pathParameters(
+                                parameterWithName("todoId").description("카테고리를 변경할 투두 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("categoryId").type(JsonFieldType.NUMBER).description("변경할 카테고리 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("투두 ID"),
+                                fieldWithPath("data.description").type(JsonFieldType.STRING).description("할 일 내용"),
+                                fieldWithPath("data.status").type(JsonFieldType.STRING).description("상태"),
+                                fieldWithPath("data.categoryId").type(JsonFieldType.NUMBER).description("변경된 카테고리 ID"),
+                                fieldWithPath("data.memo").type(JsonFieldType.STRING).description("메모").optional(),
+                                fieldWithPath("data.date").type(JsonFieldType.STRING).description("투두 날짜"),
                                 fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
                         )
                 ));


### PR DESCRIPTION
## 📌 Related Issue
- close: #29
- close: #30 

## 🚀 Description

### 1. 반복 투두 전체 삭제 기능(`DELETE /api/todos/{todoId}/recurrence`)
- 반복 설정된 투두의 원본 투두를 포함하여 모든 반복 투두를 한 번에 삭제할 수 있는 기능을 추가
- `Recurrence` 엔티티도 함께 삭제됨.

### 2. 투두 카테고리 변경 기능(`PATCH /api/todos/{todoId}/category`)
- 기존에 존재하는 카테고리 중 다른 카테고리로 투두의 카테고리를 변경할 수 있는 기능을 추가

## 📢 Notes
- 반복 투두 삭제 시 원본 투두를 포함한 모든 반복 투두가 삭제됨
