### PR TITLE
월간 리포트 기능 구현

### DIFF
--- a/src/main/java/basakan/fryday/common/ErrorCode.java
+++ b/src/main/java/basakan/fryday/common/ErrorCode.java
@@ -40,7 +40,11 @@ public enum ErrorCode {
 
     // Device
     DEVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "디바이스를 찾을 수 없습니다."),
-    DEVICE_EXPIRED(HttpStatus.UNAUTHORIZED, "디바이스 세션이 만료되었습니다.");
+    DEVICE_EXPIRED(HttpStatus.UNAUTHORIZED, "디바이스 세션이 만료되었습니다."),
+
+    // Report
+    REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 월의 리포트가 존재하지 않습니다."),
+    INVALID_REPORT_PERIOD(HttpStatus.BAD_REQUEST, "현재 월의 리포트는 조회할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/basakan/fryday/controller/report/MonthlyReportController.java
+++ b/src/main/java/basakan/fryday/controller/report/MonthlyReportController.java
@@ -1,0 +1,32 @@
+package basakan.fryday.controller.report;
+
+import basakan.fryday.controller.report.response.MonthlyReportResponse;
+import basakan.fryday.domain.report.MonthlyReport;
+import basakan.fryday.service.report.MonthlyReportReadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/reports")
+@RequiredArgsConstructor
+public class MonthlyReportController {
+
+    private final MonthlyReportReadService monthlyReportReadService;
+
+    @GetMapping("/monthly")
+    public ResponseEntity<MonthlyReportResponse> getMonthlyReport(
+            @RequestParam int year,
+            @RequestParam int month,
+            @AuthenticationPrincipal Long userId) {
+
+        MonthlyReport report = monthlyReportReadService.getMonthlyReport(userId, year, month);
+        MonthlyReportResponse response = MonthlyReportResponse.from(report);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/basakan/fryday/controller/report/response/CategoryReportResponse.java
+++ b/src/main/java/basakan/fryday/controller/report/response/CategoryReportResponse.java
@@ -1,0 +1,30 @@
+package basakan.fryday.controller.report.response;
+
+import basakan.fryday.domain.category.CategoryColor;
+import basakan.fryday.domain.report.MonthlyReportCategory;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CategoryReportResponse {
+    private String categoryName;
+    private CategoryColor categoryColor;
+    private int totalTodos;
+    private int completedTodos;
+    private int incompleteTodos;
+    private double successRate;
+    private double failureRate;
+
+    public static CategoryReportResponse from(MonthlyReportCategory category) {
+        return CategoryReportResponse.builder()
+            .categoryName(category.getCategoryName())
+            .categoryColor(category.getCategoryColor())
+            .totalTodos(category.getTotalTodos())
+            .completedTodos(category.getCompletedTodos())
+            .incompleteTodos(category.getIncompleteTodos())
+            .successRate(category.getSuccessRate())
+            .failureRate(category.getFailureRate())
+            .build();
+    }
+}

--- a/src/main/java/basakan/fryday/controller/report/response/MonthlyReportResponse.java
+++ b/src/main/java/basakan/fryday/controller/report/response/MonthlyReportResponse.java
@@ -1,0 +1,38 @@
+package basakan.fryday.controller.report.response;
+
+import basakan.fryday.domain.report.AttendanceIcon;
+import basakan.fryday.domain.report.MonthlyReport;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MonthlyReportResponse {
+    private int year;
+    private int month;
+    private int totalTodos;
+    private int completedTodos;
+    private int incompleteTodos;
+    private double achievementRate;
+    private AttendanceIcon attendanceIcon;
+    private String attendanceMessage;
+    private List<CategoryReportResponse> categories;
+
+    public static MonthlyReportResponse from(MonthlyReport report) {
+        return MonthlyReportResponse.builder()
+            .year(report.getYear())
+            .month(report.getMonth())
+            .totalTodos(report.getTotalTodos())
+            .completedTodos(report.getCompletedTodos())
+            .incompleteTodos(report.getIncompleteTodos())
+            .achievementRate(report.getAchievementRate())
+            .attendanceIcon(report.getAttendanceIcon())
+            .attendanceMessage(report.getAttendanceMessage())
+            .categories(report.getCategories().stream()
+                .map(CategoryReportResponse::from)
+                .toList())
+            .build();
+    }
+}

--- a/src/main/java/basakan/fryday/domain/report/AttendanceIcon.java
+++ b/src/main/java/basakan/fryday/domain/report/AttendanceIcon.java
@@ -1,0 +1,25 @@
+package basakan.fryday.domain.report;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AttendanceIcon {
+    EXCELLENT("완벽한 한 달이었어요!", 90.0),
+    GREAT("잘 하고 있어요!", 70.0),
+    GOOD("노력이 보여요!", 50.0),
+    NEEDS_IMPROVEMENT("조금만 더 힘내요!", 30.0),
+    POOR("다음 달엔 할 수 있어요!", 0.0);
+
+    private final String message;
+    private final double minRate;
+
+    public static AttendanceIcon fromAchievementRate(double achievementRate) {
+        if (achievementRate >= 90.0) return EXCELLENT;
+        if (achievementRate >= 70.0) return GREAT;
+        if (achievementRate >= 50.0) return GOOD;
+        if (achievementRate >= 30.0) return NEEDS_IMPROVEMENT;
+        return POOR;
+    }
+}

--- a/src/main/java/basakan/fryday/domain/report/MonthlyReport.java
+++ b/src/main/java/basakan/fryday/domain/report/MonthlyReport.java
@@ -1,0 +1,78 @@
+package basakan.fryday.domain.report;
+
+import basakan.fryday.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(
+    name = "monthly_reports",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_monthly_report_user_year_month",
+            columnNames = {"user_id", "year", "month"}
+        )
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MonthlyReport extends BaseEntity {
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private int year;
+
+    @Column(nullable = false)
+    private int month;
+
+    @Column(nullable = false)
+    private int totalTodos;
+
+    @Column(nullable = false)
+    private int completedTodos;
+
+    @Column(nullable = false)
+    private int incompleteTodos;
+
+    @Column(nullable = false)
+    private double achievementRate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AttendanceIcon attendanceIcon;
+
+    @Column(nullable = false, length = 100)
+    private String attendanceMessage;
+
+    @OneToMany(mappedBy = "monthlyReport", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MonthlyReportCategory> categories = new ArrayList<>();
+
+    @Builder
+    public MonthlyReport(Long userId, int year, int month,
+                         int totalTodos, int completedTodos, int incompleteTodos,
+                         double achievementRate, AttendanceIcon attendanceIcon,
+                         String attendanceMessage) {
+        this.userId = userId;
+        this.year = year;
+        this.month = month;
+        this.totalTodos = totalTodos;
+        this.completedTodos = completedTodos;
+        this.incompleteTodos = incompleteTodos;
+        this.achievementRate = achievementRate;
+        this.attendanceIcon = attendanceIcon;
+        this.attendanceMessage = attendanceMessage;
+    }
+
+    public void addCategory(MonthlyReportCategory category) {
+        this.categories.add(category);
+        category.assignReport(this);
+    }
+}

--- a/src/main/java/basakan/fryday/domain/report/MonthlyReportCategory.java
+++ b/src/main/java/basakan/fryday/domain/report/MonthlyReportCategory.java
@@ -1,0 +1,59 @@
+package basakan.fryday.domain.report;
+
+import basakan.fryday.domain.BaseEntity;
+import basakan.fryday.domain.category.CategoryColor;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "monthly_report_categories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MonthlyReportCategory extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "monthly_report_id", nullable = false)
+    private MonthlyReport monthlyReport;
+
+    @Column(nullable = false, length = 50)
+    private String categoryName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private CategoryColor categoryColor;
+
+    @Column(nullable = false)
+    private int totalTodos;
+
+    @Column(nullable = false)
+    private int completedTodos;
+
+    @Column(nullable = false)
+    private int incompleteTodos;
+
+    @Column(nullable = false)
+    private double successRate;
+
+    @Column(nullable = false)
+    private double failureRate;
+
+    @Builder
+    public MonthlyReportCategory(String categoryName, CategoryColor categoryColor,
+                                 int totalTodos, int completedTodos, int incompleteTodos,
+                                 double successRate, double failureRate) {
+        this.categoryName = categoryName;
+        this.categoryColor = categoryColor;
+        this.totalTodos = totalTodos;
+        this.completedTodos = completedTodos;
+        this.incompleteTodos = incompleteTodos;
+        this.successRate = successRate;
+        this.failureRate = failureRate;
+    }
+
+    void assignReport(MonthlyReport monthlyReport) {
+        this.monthlyReport = monthlyReport;
+    }
+}

--- a/src/main/java/basakan/fryday/repository/auth/UserJpaRepository.java
+++ b/src/main/java/basakan/fryday/repository/auth/UserJpaRepository.java
@@ -3,7 +3,9 @@ package basakan.fryday.repository.auth;
 import basakan.fryday.domain.user.AuthProvider;
 import basakan.fryday.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserJpaRepository extends JpaRepository<User, Long> {
@@ -11,4 +13,7 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
 
     Optional<User> findByProviderAndProviderUserId(AuthProvider provider, String providerUserId);
+
+    @Query("SELECT u.id FROM User u WHERE u.accountStatus = 'ACTIVE'")
+    List<Long> findAllActiveUserIds();
 }

--- a/src/main/java/basakan/fryday/repository/report/MonthlyReportRepository.java
+++ b/src/main/java/basakan/fryday/repository/report/MonthlyReportRepository.java
@@ -1,0 +1,22 @@
+package basakan.fryday.repository.report;
+
+import basakan.fryday.domain.report.MonthlyReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface MonthlyReportRepository extends JpaRepository<MonthlyReport, Long> {
+
+    @Query("SELECT mr FROM MonthlyReport mr " +
+           "LEFT JOIN FETCH mr.categories " +
+           "WHERE mr.userId = :userId AND mr.year = :year AND mr.month = :month")
+    Optional<MonthlyReport> findByUserIdAndYearAndMonth(
+        @Param("userId") Long userId,
+        @Param("year") int year,
+        @Param("month") int month
+    );
+
+    boolean existsByUserIdAndYearAndMonth(Long userId, int year, int month);
+}

--- a/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
@@ -1,6 +1,7 @@
 package basakan.fryday.repository.todo;
 
 import basakan.fryday.domain.todo.Todo;
+import basakan.fryday.service.report.dto.CategoryReportDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -43,4 +44,23 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
 
     @Query("SELECT t FROM Todo t WHERE t.recurrenceId = :recurrenceId AND t.deletedAt IS NULL")
     List<Todo> findAllByRecurrenceId(@Param("recurrenceId") Long recurrenceId);
+
+    @Query("SELECT new basakan.fryday.service.report.dto.CategoryReportDto(" +
+           "c.name, " +
+           "c.color, " +
+           "CAST(COUNT(t.id) AS int), " +
+           "CAST(SUM(CASE WHEN t.status = 'COMPLETED' THEN 1 ELSE 0 END) AS int), " +
+           "CAST(SUM(CASE WHEN t.status = 'IN_PROGRESS' OR t.isBurnt = true THEN 1 ELSE 0 END) AS int)) " +
+           "FROM Todo t " +
+           "JOIN t.category c " +
+           "WHERE c.userId = :userId " +
+           "  AND YEAR(t.date) = :year " +
+           "  AND MONTH(t.date) = :month " +
+           "  AND t.deletedAt IS NULL " +
+           "GROUP BY c.id, c.name, c.color")
+    List<CategoryReportDto> findMonthlyReportByCategory(
+        @Param("userId") Long userId,
+        @Param("year") int year,
+        @Param("month") int month
+    );
 }

--- a/src/main/java/basakan/fryday/scheduler/MonthlyReportScheduler.java
+++ b/src/main/java/basakan/fryday/scheduler/MonthlyReportScheduler.java
@@ -1,0 +1,48 @@
+package basakan.fryday.scheduler;
+
+import basakan.fryday.repository.auth.UserJpaRepository;
+import basakan.fryday.service.report.MonthlyReportGenerateService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MonthlyReportScheduler {
+
+    private final MonthlyReportGenerateService reportGenerateService;
+    private final UserJpaRepository userJpaRepository;
+
+    @Scheduled(cron = "0 10 0 1 * *")
+    public void generateMonthlyReports() {
+        log.info("[MonthlyReportScheduler] 월간 리포트 생성 시작");
+
+        LocalDate previousMonth = LocalDate.now().minusMonths(1);
+        int year = previousMonth.getYear();
+        int month = previousMonth.getMonthValue();
+
+        List<Long> activeUserIds = userJpaRepository.findAllActiveUserIds();
+
+        int successCount = 0;
+        int failCount = 0;
+
+        for (Long userId : activeUserIds) {
+            try {
+                reportGenerateService.generateMonthlyReport(userId, year, month);
+                successCount++;
+            } catch (Exception e) {
+                log.error("[MonthlyReportScheduler] 리포트 생성 실패 - userId: {}, year: {}, month: {}",
+                          userId, year, month, e);
+                failCount++;
+            }
+        }
+
+        log.info("[MonthlyReportScheduler] 월간 리포트 생성 완료 - 성공: {}, 실패: {}",
+                 successCount, failCount);
+    }
+}

--- a/src/main/java/basakan/fryday/service/report/MonthlyReportGenerateService.java
+++ b/src/main/java/basakan/fryday/service/report/MonthlyReportGenerateService.java
@@ -1,0 +1,81 @@
+package basakan.fryday.service.report;
+
+import basakan.fryday.domain.report.AttendanceIcon;
+import basakan.fryday.domain.report.MonthlyReport;
+import basakan.fryday.domain.report.MonthlyReportCategory;
+import basakan.fryday.repository.report.MonthlyReportRepository;
+import basakan.fryday.repository.todo.TodoRepository;
+import basakan.fryday.service.report.dto.CategoryReportDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MonthlyReportGenerateService {
+
+    private static final double PERCENTAGE_SCALE = 100.0;
+    private static final double ROUNDING_SCALE = 10000.0;
+
+    private final MonthlyReportRepository monthlyReportRepository;
+    private final TodoRepository todoRepository;
+
+    public void generateMonthlyReport(Long userId, int year, int month) {
+        if (monthlyReportRepository.existsByUserIdAndYearAndMonth(userId, year, month)) {
+            return;
+        }
+
+        List<CategoryReportDto> categoryStatistics =
+            todoRepository.findMonthlyReportByCategory(userId, year, month);
+
+        int totalTodos = categoryStatistics.stream()
+            .mapToInt(CategoryReportDto::getTotalTodos).sum();
+        int completedTodos = categoryStatistics.stream()
+            .mapToInt(CategoryReportDto::getCompletedTodos).sum();
+        int incompleteTodos = totalTodos - completedTodos;
+        double achievementRate = calculateRate(completedTodos, totalTodos);
+
+        AttendanceIcon icon = AttendanceIcon.fromAchievementRate(achievementRate);
+
+        MonthlyReport report = MonthlyReport.builder()
+            .userId(userId)
+            .year(year)
+            .month(month)
+            .totalTodos(totalTodos)
+            .completedTodos(completedTodos)
+            .incompleteTodos(incompleteTodos)
+            .achievementRate(achievementRate)
+            .attendanceIcon(icon)
+            .attendanceMessage(icon.getMessage())
+            .build();
+
+        for (CategoryReportDto dto : categoryStatistics) {
+            double successRate = calculateRate(dto.getCompletedTodos(), dto.getTotalTodos());
+            double failureRate = calculateRate(dto.getIncompleteTodos(), dto.getTotalTodos());
+
+            MonthlyReportCategory categoryReport = MonthlyReportCategory.builder()
+                .categoryName(dto.getCategoryName())
+                .categoryColor(dto.getCategoryColor())
+                .totalTodos(dto.getTotalTodos())
+                .completedTodos(dto.getCompletedTodos())
+                .incompleteTodos(dto.getIncompleteTodos())
+                .successRate(successRate)
+                .failureRate(failureRate)
+                .build();
+
+            report.addCategory(categoryReport);
+        }
+
+        monthlyReportRepository.save(report);
+    }
+
+    private double calculateRate(int numerator, int denominator) {
+        if (denominator == 0) {
+            return 0.0;
+        }
+        return Math.round(numerator * ROUNDING_SCALE / denominator) / PERCENTAGE_SCALE;
+    }
+}

--- a/src/main/java/basakan/fryday/service/report/MonthlyReportReadService.java
+++ b/src/main/java/basakan/fryday/service/report/MonthlyReportReadService.java
@@ -1,0 +1,33 @@
+package basakan.fryday.service.report;
+
+import basakan.fryday.common.ErrorCode;
+import basakan.fryday.common.exception.BusinessException;
+import basakan.fryday.domain.report.MonthlyReport;
+import basakan.fryday.repository.report.MonthlyReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MonthlyReportReadService {
+
+    private final MonthlyReportRepository monthlyReportRepository;
+
+    public MonthlyReport getMonthlyReport(Long userId, int year, int month) {
+        LocalDate now = LocalDate.now();
+        LocalDate requestedYearMonth = LocalDate.of(year, month, 1);
+        LocalDate currentYearMonth = now.withDayOfMonth(1);
+
+        if (!requestedYearMonth.isBefore(currentYearMonth)) {
+            throw new BusinessException(ErrorCode.INVALID_REPORT_PERIOD);
+        }
+
+        return monthlyReportRepository
+            .findByUserIdAndYearAndMonth(userId, year, month)
+            .orElseThrow(() -> new BusinessException(ErrorCode.REPORT_NOT_FOUND));
+    }
+}

--- a/src/main/java/basakan/fryday/service/report/dto/CategoryReportDto.java
+++ b/src/main/java/basakan/fryday/service/report/dto/CategoryReportDto.java
@@ -1,0 +1,15 @@
+package basakan.fryday.service.report.dto;
+
+import basakan.fryday.domain.category.CategoryColor;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CategoryReportDto {
+    private String categoryName;
+    private CategoryColor categoryColor;
+    private int totalTodos;
+    private int completedTodos;
+    private int incompleteTodos;
+}

--- a/src/test/java/basakan/fryday/controller/report/MonthlyReportControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/report/MonthlyReportControllerTest.java
@@ -1,0 +1,181 @@
+package basakan.fryday.controller.report;
+
+import basakan.fryday.RestDocsSupport;
+import basakan.fryday.common.ErrorCode;
+import basakan.fryday.common.config.SecurityConfig;
+import basakan.fryday.common.exception.BusinessException;
+import basakan.fryday.common.security.JwtAuthenticationFilter;
+import basakan.fryday.common.security.JwtTokenProvider;
+import basakan.fryday.domain.category.CategoryColor;
+import basakan.fryday.domain.report.AttendanceIcon;
+import basakan.fryday.domain.report.MonthlyReport;
+import basakan.fryday.domain.report.MonthlyReportCategory;
+import basakan.fryday.service.report.MonthlyReportReadService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = MonthlyReportController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+        }
+)
+class MonthlyReportControllerTest extends RestDocsSupport {
+
+    @MockitoBean
+    private MonthlyReportReadService monthlyReportReadService;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(1L, null, Collections.emptyList());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @Test
+    @DisplayName("월간 리포트 조회 API - 성공")
+    void getMonthlyReport() throws Exception {
+        // given
+        MonthlyReport report = MonthlyReport.builder()
+                .userId(1L)
+                .year(2025)
+                .month(4)
+                .totalTodos(45)
+                .completedTodos(30)
+                .incompleteTodos(15)
+                .achievementRate(66.67)
+                .attendanceIcon(AttendanceIcon.GOOD)
+                .attendanceMessage("노력이 보여요!")
+                .build();
+
+        MonthlyReportCategory category1 = MonthlyReportCategory.builder()
+                .categoryName("운동")
+                .categoryColor(CategoryColor.BR)
+                .totalTodos(15)
+                .completedTodos(10)
+                .incompleteTodos(5)
+                .successRate(66.67)
+                .failureRate(33.33)
+                .build();
+
+        MonthlyReportCategory category2 = MonthlyReportCategory.builder()
+                .categoryName("공부")
+                .categoryColor(CategoryColor.CB)
+                .totalTodos(20)
+                .completedTodos(15)
+                .incompleteTodos(5)
+                .successRate(75.0)
+                .failureRate(25.0)
+                .build();
+
+        report.addCategory(category1);
+        report.addCategory(category2);
+
+        given(monthlyReportReadService.getMonthlyReport(anyLong(), anyInt(), anyInt()))
+                .willReturn(report);
+
+        // when & then
+        mockMvc.perform(get("/api/reports/monthly")
+                        .param("year", "2025")
+                        .param("month", "4"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.year").value(2025))
+                .andExpect(jsonPath("$.month").value(4))
+                .andExpect(jsonPath("$.totalTodos").value(45))
+                .andExpect(jsonPath("$.completedTodos").value(30))
+                .andExpect(jsonPath("$.incompleteTodos").value(15))
+                .andExpect(jsonPath("$.achievementRate").value(66.67))
+                .andExpect(jsonPath("$.attendanceIcon").value("GOOD"))
+                .andExpect(jsonPath("$.attendanceMessage").value("노력이 보여요!"))
+                .andExpect(jsonPath("$.categories").isArray())
+                .andExpect(jsonPath("$.categories[0].categoryName").value("운동"))
+                .andDo(document("monthly-report-get",
+                        queryParameters(
+                                parameterWithName("year").description("조회할 연도 (예: 2025)"),
+                                parameterWithName("month").description("조회할 월 (1~12)")
+                        ),
+                        responseFields(
+                                fieldWithPath("year").type(JsonFieldType.NUMBER).description("연도"),
+                                fieldWithPath("month").type(JsonFieldType.NUMBER).description("월"),
+                                fieldWithPath("totalTodos").type(JsonFieldType.NUMBER).description("전체 투두 개수"),
+                                fieldWithPath("completedTodos").type(JsonFieldType.NUMBER).description("완료한 투두 개수"),
+                                fieldWithPath("incompleteTodos").type(JsonFieldType.NUMBER).description("미완료 투두 개수"),
+                                fieldWithPath("achievementRate").type(JsonFieldType.NUMBER).description("달성률 (%)"),
+                                fieldWithPath("attendanceIcon").type(JsonFieldType.STRING).description("출석 아이콘 (EXCELLENT, GREAT, GOOD, NEEDS_IMPROVEMENT, POOR)"),
+                                fieldWithPath("attendanceMessage").type(JsonFieldType.STRING).description("출석 메시지"),
+                                fieldWithPath("categories").type(JsonFieldType.ARRAY).description("카테고리별 통계 목록"),
+                                fieldWithPath("categories[].categoryName").type(JsonFieldType.STRING).description("카테고리 이름"),
+                                fieldWithPath("categories[].categoryColor").type(JsonFieldType.STRING).description("카테고리 색상 코드"),
+                                fieldWithPath("categories[].totalTodos").type(JsonFieldType.NUMBER).description("카테고리 전체 투두 개수"),
+                                fieldWithPath("categories[].completedTodos").type(JsonFieldType.NUMBER).description("카테고리 완료 투두 개수"),
+                                fieldWithPath("categories[].incompleteTodos").type(JsonFieldType.NUMBER).description("카테고리 미완료 투두 개수"),
+                                fieldWithPath("categories[].successRate").type(JsonFieldType.NUMBER).description("카테고리 성공률 (%)"),
+                                fieldWithPath("categories[].failureRate").type(JsonFieldType.NUMBER).description("카테고리 실패율 (%)")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("월간 리포트 조회 API - 현재 월 조회 시 400 에러")
+    void getMonthlyReportCurrentMonth() throws Exception {
+        // given
+        given(monthlyReportReadService.getMonthlyReport(anyLong(), anyInt(), anyInt()))
+                .willThrow(new BusinessException(ErrorCode.INVALID_REPORT_PERIOD));
+
+        // when & then
+        mockMvc.perform(get("/api/reports/monthly")
+                        .param("year", "2025")
+                        .param("month", "12"))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("현재 월의 리포트는 조회할 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("월간 리포트 조회 API - 리포트 없을 시 404 에러")
+    void getMonthlyReportNotFound() throws Exception {
+        // given
+        given(monthlyReportReadService.getMonthlyReport(anyLong(), anyInt(), anyInt()))
+                .willThrow(new BusinessException(ErrorCode.REPORT_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/api/reports/monthly")
+                        .param("year", "2025")
+                        .param("month", "3"))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("해당 월의 리포트가 존재하지 않습니다."));
+    }
+}


### PR DESCRIPTION
## 📌 Related Issue
N/A

## 🚀 Description

### 구현 내용
- 월간 리포트 조회 API 구현 (`GET /api/reports/{year}/{month}`)
- 월간 리포트 자동 생성 스케줄러 (매월 1일 00:10 실행)
- 카테고리별 투두 통계 집계 및 달성률 계산
- 출석 아이콘 자동 결정 로직

### 시퀀스 다이어그램

#### 1. 월간 리포트 조회 흐름
```mermaid
sequenceDiagram
    actor User
    participant Controller as MonthlyReportController
    participant ReadService as MonthlyReportReadService
    participant Repository as MonthlyReportRepository
    participant DB

    User->>Controller: GET /api/reports/{year}/{month}
    Controller->>ReadService: getMonthlyReport(userId, year, month)
    ReadService->>ReadService: 현재 월 조회 검증
    ReadService->>Repository: findByUserIdAndYearAndMonth()
    Repository->>DB: SELECT (JOIN FETCH categories)
    DB-->>Repository: MonthlyReport + Categories
    Repository-->>ReadService: MonthlyReport
    ReadService-->>Controller: MonthlyReport
    Controller-->>User: MonthlyReportResponse
```

#### 2. 월간 리포트 자동 생성 흐름
```mermaid
sequenceDiagram
    participant Scheduler as MonthlyReportScheduler
    participant GenerateService as MonthlyReportGenerateService
    participant UserRepo as UserJpaRepository
    participant TodoRepo as TodoRepository
    participant ReportRepo as MonthlyReportRepository
    participant DB

    Note over Scheduler: 매월 1일 00:10 실행
    Scheduler->>UserRepo: findAllActiveUserIds()
    UserRepo-->>Scheduler: List<userId>
    
    loop 각 활성 사용자
        Scheduler->>GenerateService: generateMonthlyReport(userId, year, month)
        GenerateService->>ReportRepo: existsByUserIdAndYearAndMonth()
        ReportRepo-->>GenerateService: false
        GenerateService->>TodoRepo: findMonthlyReportByCategory()
        TodoRepo-->>GenerateService: List<CategoryReportDto>
        GenerateService->>GenerateService: 달성률 계산 및 아이콘 결정
        GenerateService->>ReportRepo: save(MonthlyReport)
        ReportRepo->>DB: INSERT
    end
```

## 📢 Notes

### 필요 조건
- ✅ JWT 인증 필터 설정 완료
- ✅ User 엔티티의 ACTIVE 상태 관리
- ✅ Todo 엔티티의 status 및 isBurnt 필드
- ✅ Category 엔티티 및 관계 설정

### 주요 특징
- **중복 생성 방지**: 동일 userId + year + month 조합에 대해 UNIQUE 제약
- **N+1 방지**: JOIN FETCH를 통한 카테고리 데이터 한번에 조회
- **스냅샷 패턴**: MonthlyReportCategory는 Category FK 없이 값만 저장
- **현재 월 조회 차단**: 현재 월은 아직 완료되지 않았으므로 조회 불가 처리