### PR TITLE
투두 제목 수정 API 추가

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -238,6 +238,24 @@ include::{snippets}/todo-list/http-response.adoc[]
 ==== 응답 필드
 include::{snippets}/todo-list/response-fields.adoc[]
 
+=== 투두 내용(제목) 수정
+`PATCH /api/todos/{todoId}/description`
+
+투두의 내용(제목)을 수정합니다.
+
+==== 요청 필드
+include::{snippets}/todo-update-description/request-fields.adoc[]
+==== 경로 파라미터
+include::{snippets}/todo-update-description/path-parameters.adoc[]
+==== HTTP 요청 예시
+include::{snippets}/todo-update-description/http-request.adoc[]
+==== HTTP 응답 예시
+include::{snippets}/todo-update-description/http-response.adoc[]
+==== 응답 필드
+include::{snippets}/todo-update-description/response-fields.adoc[]
+
+
+
 === 투두 캐릭터 상태 조회
 `GET /api/todos/character-status`
 

--- a/src/main/java/basakan/fryday/controller/todo/TodoController.java
+++ b/src/main/java/basakan/fryday/controller/todo/TodoController.java
@@ -1,12 +1,8 @@
 package basakan.fryday.controller.todo;
 
 import basakan.fryday.common.response.ApiResponse;
-import basakan.fryday.controller.todo.request.MemoRequest;
+import basakan.fryday.controller.todo.request.*;
 import basakan.fryday.controller.dto.OrderUpdateRequest;
-import basakan.fryday.controller.todo.request.RecurrenceCreateRequest;
-import basakan.fryday.controller.todo.request.TodoCategoryUpdateRequest;
-import basakan.fryday.controller.todo.request.TodoDateUpdateRequest;
-import basakan.fryday.controller.todo.request.TodoSaveRequest;
 import basakan.fryday.controller.todo.response.CharacterStatusResponse;
 import basakan.fryday.controller.todo.response.MemoResponse;
 import basakan.fryday.controller.todo.response.TodoListResponse;
@@ -45,6 +41,16 @@ public class TodoController {
                                                 @AuthenticationPrincipal Long userId) {
         TodoResponse response = todoService.saveTodo(request, userId);
         return ApiResponse.success(response);
+    }
+
+    @PatchMapping("/{todoId}/description")
+    public ApiResponse<TodoResponse> updateDescription(
+            @PathVariable Long todoId,
+            @Valid @RequestBody TodoDescriptionUpdateRequest request,
+            @AuthenticationPrincipal Long userId
+    ) {
+        TodoResponse response = todoService.updateDescription(todoId, userId, request);
+        return ApiResponse.success(response, "내용이 수정되었습니다.");
     }
 
     @PostMapping("/{todoId}/completion")

--- a/src/main/java/basakan/fryday/controller/todo/request/TodoDescriptionUpdateRequest.java
+++ b/src/main/java/basakan/fryday/controller/todo/request/TodoDescriptionUpdateRequest.java
@@ -1,0 +1,17 @@
+package basakan.fryday.controller.todo.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TodoDescriptionUpdateRequest {
+
+    @NotBlank(message = "할 일 내용은 필수입니다.")
+    private String description;
+
+    public TodoDescriptionUpdateRequest(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/basakan/fryday/domain/todo/Todo.java
+++ b/src/main/java/basakan/fryday/domain/todo/Todo.java
@@ -103,4 +103,8 @@ public class Todo extends BaseEntity {
         this.category = category;
     }
 
+    public void updateDescription(String description) {
+        this.description = description;
+    }
+
 }

--- a/src/main/java/basakan/fryday/service/todo/TodoService.java
+++ b/src/main/java/basakan/fryday/service/todo/TodoService.java
@@ -2,11 +2,8 @@ package basakan.fryday.service.todo;
 
 import basakan.fryday.common.ErrorCode;
 import basakan.fryday.common.exception.BusinessException;
-import basakan.fryday.controller.todo.request.MemoRequest;
+import basakan.fryday.controller.todo.request.*;
 import basakan.fryday.controller.dto.OrderUpdateRequest;
-import basakan.fryday.controller.todo.request.TodoCategoryUpdateRequest;
-import basakan.fryday.controller.todo.request.TodoDateUpdateRequest;
-import basakan.fryday.controller.todo.request.TodoSaveRequest;
 import basakan.fryday.controller.todo.response.CharacterStatusResponse;
 import basakan.fryday.controller.todo.response.MemoResponse;
 import basakan.fryday.controller.todo.response.TodoListResponse;
@@ -216,6 +213,21 @@ public class TodoService {
                 .description(status.getDescription())
                 .build();
 
+    }
+
+    @Transactional
+    public TodoResponse updateDescription(Long todoId, Long userId, TodoDescriptionUpdateRequest request) {
+        Todo todo = todoRepository.findById(todoId)
+                .filter(t -> !t.isDeleted())
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        if (!todo.getCategory().getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
+
+        todo.updateDescription(request.getDescription());
+
+        return TodoResponse.from(todo);
     }
 
     private String resolveImageCode(CharacterStatus status) {

--- a/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
@@ -6,12 +6,8 @@ import basakan.fryday.common.config.SecurityConfig;
 import basakan.fryday.common.exception.BusinessException;
 import basakan.fryday.common.security.JwtAuthenticationFilter;
 import basakan.fryday.common.security.JwtTokenProvider;
-import basakan.fryday.controller.todo.request.MemoRequest;
+import basakan.fryday.controller.todo.request.*;
 import basakan.fryday.controller.dto.OrderUpdateRequest;
-import basakan.fryday.controller.todo.request.RecurrenceCreateRequest;
-import basakan.fryday.controller.todo.request.TodoCategoryUpdateRequest;
-import basakan.fryday.controller.todo.request.TodoDateUpdateRequest;
-import basakan.fryday.controller.todo.request.TodoSaveRequest;
 import basakan.fryday.controller.todo.response.CharacterStatusResponse;
 import basakan.fryday.controller.todo.response.MemoResponse;
 import basakan.fryday.controller.todo.response.TodoListResponse;
@@ -129,6 +125,66 @@ class TodoControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("생성된 투두 ID"),
                                 fieldWithPath("data.description").type(JsonFieldType.STRING).description("할 일 내용"),
                                 fieldWithPath("data.status").type(JsonFieldType.STRING).description("상태 (IN_PROGRESS, COMPLETED, FAILED)"),
+                                fieldWithPath("data.categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
+                                fieldWithPath("data.memo").type(JsonFieldType.STRING).description("메모").optional(),
+                                fieldWithPath("data.date").type(JsonFieldType.STRING).description("투두 날짜"),
+
+                                fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("투두 내용(제목) 수정 API")
+    void updateDescription() throws Exception {
+        // given
+        Long todoId = 1L;
+        String newDescription = "양파 다지기"; // 변경할 내용
+        TodoDescriptionUpdateRequest request = new TodoDescriptionUpdateRequest(newDescription);
+
+        Category mockCategory = Category.builder()
+                .name("요리")
+                .color(CategoryColor.BR)
+                .userId(1L)
+                .build();
+        ReflectionTestUtils.setField(mockCategory, "id", 1L);
+
+        Todo mockTodo = Todo.builder()
+                .description(newDescription) // 변경된 내용 적용
+                .category(mockCategory)
+                .build();
+
+        ReflectionTestUtils.setField(mockTodo, "id", todoId);
+//        ReflectionTestUtils.setField(mockTodo, "status", Todo.Status.IN_PROGRESS);
+//        ReflectionTestUtils.setField(mockTodo, "date", LocalDate.now());
+//        ReflectionTestUtils.setField(mockTodo, "isBurnt", false);
+//        ReflectionTestUtils.setField(mockTodo, "displayOrder", 1L);
+//        ReflectionTestUtils.setField(mockTodo, "memo", "메모 있음");
+
+        // Service Mocking
+        given(todoService.updateDescription(anyLong(), anyLong(), any(TodoDescriptionUpdateRequest.class)))
+                .willReturn(TodoResponse.from(mockTodo));
+
+        // when & then
+        mockMvc.perform(patch("/api/todos/{todoId}/description", todoId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("todo-update-description",
+                        pathParameters(
+                                parameterWithName("todoId").description("수정할 투두 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("description").type(JsonFieldType.STRING).description("변경할 할 일 내용")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("투두 ID"),
+                                fieldWithPath("data.description").type(JsonFieldType.STRING).description("변경된 내용"),
+                                fieldWithPath("data.status").type(JsonFieldType.STRING).description("상태"),
                                 fieldWithPath("data.categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
                                 fieldWithPath("data.memo").type(JsonFieldType.STRING).description("메모").optional(),
                                 fieldWithPath("data.date").type(JsonFieldType.STRING).description("투두 날짜"),


### PR DESCRIPTION
## 📌 Related Issue
- close: #35 

## 🚀 Description
- 투두 제목(내용)을 수정하는 API(`/api/todos/{todoId}/description`)

