### PR TITLE
월간 리포트 평가 기준 변경 (달성률 -> 출석일)

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -205,6 +205,25 @@ include::{snippets}/user-withdraw/http-response.adoc[]
 ==== 응답 필드
 include::{snippets}/user-withdraw/response-fields.adoc[]
 
+== 월간 리포트(Monthly Report)
+
+=== 월간 리포트 조회
+`GET /api/reports/monthly`
+
+사용자의 특정 월간 리포트를 조회합니다.
+
+==== 요청 쿼리 파라미터
+include::{snippets}/monthly-report-get/query-parameters.adoc[]
+
+==== HTTP 요청 예시
+include::{snippets}/monthly-report-get/http-request.adoc[]
+
+==== HTTP 응답 예시
+include::{snippets}/monthly-report-get/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/monthly-report-get/response-fields.adoc[]
+
 == 투두(Todo)
 
 === 투두 생성

--- a/src/main/java/basakan/fryday/controller/report/MonthlyReportController.java
+++ b/src/main/java/basakan/fryday/controller/report/MonthlyReportController.java
@@ -1,7 +1,6 @@
 package basakan.fryday.controller.report;
 
 import basakan.fryday.controller.report.response.MonthlyReportResponse;
-import basakan.fryday.domain.report.MonthlyReport;
 import basakan.fryday.service.report.MonthlyReportReadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,8 +23,7 @@ public class MonthlyReportController {
             @RequestParam int month,
             @AuthenticationPrincipal Long userId) {
 
-        MonthlyReport report = monthlyReportReadService.getMonthlyReport(userId, year, month);
-        MonthlyReportResponse response = MonthlyReportResponse.from(report);
+        MonthlyReportResponse response = monthlyReportReadService.getMonthlyReportResponse(userId, year, month);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/basakan/fryday/controller/report/response/CategoryReportResponse.java
+++ b/src/main/java/basakan/fryday/controller/report/response/CategoryReportResponse.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class CategoryReportResponse {
+    private Long categoryId;
     private String categoryName;
     private CategoryColor categoryColor;
     private int totalTodos;
@@ -18,6 +19,7 @@ public class CategoryReportResponse {
 
     public static CategoryReportResponse from(MonthlyReportCategory category) {
         return CategoryReportResponse.builder()
+            .categoryId(category.getCategoryId())
             .categoryName(category.getCategoryName())
             .categoryColor(category.getCategoryColor())
             .totalTodos(category.getTotalTodos())

--- a/src/main/java/basakan/fryday/controller/report/response/MonthlyReportResponse.java
+++ b/src/main/java/basakan/fryday/controller/report/response/MonthlyReportResponse.java
@@ -15,24 +15,24 @@ public class MonthlyReportResponse {
     private int totalTodos;
     private int completedTodos;
     private int incompleteTodos;
+    private int attendanceDays;
     private double achievementRate;
     private AttendanceIcon attendanceIcon;
     private String attendanceMessage;
     private List<CategoryReportResponse> categories;
 
-    public static MonthlyReportResponse from(MonthlyReport report) {
+    public static MonthlyReportResponse from(MonthlyReport report, List<CategoryReportResponse> filteredCategories) {
         return MonthlyReportResponse.builder()
             .year(report.getYear())
             .month(report.getMonth())
             .totalTodos(report.getTotalTodos())
             .completedTodos(report.getCompletedTodos())
             .incompleteTodos(report.getIncompleteTodos())
+            .attendanceDays(report.getAttendanceDays())
             .achievementRate(report.getAchievementRate())
             .attendanceIcon(report.getAttendanceIcon())
             .attendanceMessage(report.getAttendanceMessage())
-            .categories(report.getCategories().stream()
-                .map(CategoryReportResponse::from)
-                .toList())
+            .categories(filteredCategories)
             .build();
     }
 }

--- a/src/main/java/basakan/fryday/domain/report/AttendanceIcon.java
+++ b/src/main/java/basakan/fryday/domain/report/AttendanceIcon.java
@@ -6,20 +6,16 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum AttendanceIcon {
-    EXCELLENT("완벽한 한 달이었어요!", 90.0),
-    GREAT("잘 하고 있어요!", 70.0),
-    GOOD("노력이 보여요!", 50.0),
-    NEEDS_IMPROVEMENT("조금만 더 힘내요!", 30.0),
-    POOR("다음 달엔 할 수 있어요!", 0.0);
+    EXCELLENT("튀김 장인입니다!", 21),
+    GOOD("튀김이 많아지고 있어요", 11),
+    POOR("튀김을 열심히 튀겨주세요", 0);
 
     private final String message;
-    private final double minRate;
+    private final int minDays;
 
-    public static AttendanceIcon fromAchievementRate(double achievementRate) {
-        if (achievementRate >= 90.0) return EXCELLENT;
-        if (achievementRate >= 70.0) return GREAT;
-        if (achievementRate >= 50.0) return GOOD;
-        if (achievementRate >= 30.0) return NEEDS_IMPROVEMENT;
+    public static AttendanceIcon fromAttendanceDays(int attendanceDays) {
+        if (attendanceDays >= 21) return EXCELLENT;
+        if (attendanceDays >= 11) return GOOD;
         return POOR;
     }
 }

--- a/src/main/java/basakan/fryday/domain/report/MonthlyReport.java
+++ b/src/main/java/basakan/fryday/domain/report/MonthlyReport.java
@@ -43,6 +43,9 @@ public class MonthlyReport extends BaseEntity {
     private int incompleteTodos;
 
     @Column(nullable = false)
+    private int attendanceDays;
+
+    @Column(nullable = false)
     private double achievementRate;
 
     @Enumerated(EnumType.STRING)
@@ -58,14 +61,15 @@ public class MonthlyReport extends BaseEntity {
     @Builder
     public MonthlyReport(Long userId, int year, int month,
                          int totalTodos, int completedTodos, int incompleteTodos,
-                         double achievementRate, AttendanceIcon attendanceIcon,
-                         String attendanceMessage) {
+                         int attendanceDays, double achievementRate,
+                         AttendanceIcon attendanceIcon, String attendanceMessage) {
         this.userId = userId;
         this.year = year;
         this.month = month;
         this.totalTodos = totalTodos;
         this.completedTodos = completedTodos;
         this.incompleteTodos = incompleteTodos;
+        this.attendanceDays = attendanceDays;
         this.achievementRate = achievementRate;
         this.attendanceIcon = attendanceIcon;
         this.attendanceMessage = attendanceMessage;

--- a/src/main/java/basakan/fryday/domain/report/MonthlyReportCategory.java
+++ b/src/main/java/basakan/fryday/domain/report/MonthlyReportCategory.java
@@ -18,6 +18,9 @@ public class MonthlyReportCategory extends BaseEntity {
     @JoinColumn(name = "monthly_report_id", nullable = false)
     private MonthlyReport monthlyReport;
 
+    @Column(nullable = false)
+    private Long categoryId;
+
     @Column(nullable = false, length = 50)
     private String categoryName;
 
@@ -41,9 +44,10 @@ public class MonthlyReportCategory extends BaseEntity {
     private double failureRate;
 
     @Builder
-    public MonthlyReportCategory(String categoryName, CategoryColor categoryColor,
+    public MonthlyReportCategory(Long categoryId, String categoryName, CategoryColor categoryColor,
                                  int totalTodos, int completedTodos, int incompleteTodos,
                                  double successRate, double failureRate) {
+        this.categoryId = categoryId;
         this.categoryName = categoryName;
         this.categoryColor = categoryColor;
         this.totalTodos = totalTodos;

--- a/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
@@ -46,6 +46,7 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     List<Todo> findAllByRecurrenceId(@Param("recurrenceId") Long recurrenceId);
 
     @Query("SELECT new basakan.fryday.service.report.dto.CategoryReportDto(" +
+           "c.id, " +
            "c.name, " +
            "c.color, " +
            "CAST(COUNT(t.id) AS int), " +
@@ -59,6 +60,19 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
            "  AND t.deletedAt IS NULL " +
            "GROUP BY c.id, c.name, c.color")
     List<CategoryReportDto> findMonthlyReportByCategory(
+        @Param("userId") Long userId,
+        @Param("year") int year,
+        @Param("month") int month
+    );
+
+    @Query("SELECT CAST(COUNT(DISTINCT DATE(t.date)) AS int) " +
+           "FROM Todo t " +
+           "JOIN t.category c " +
+           "WHERE c.userId = :userId " +
+           "  AND YEAR(t.date) = :year " +
+           "  AND MONTH(t.date) = :month " +
+           "  AND t.deletedAt IS NULL")
+    int countAttendanceDays(
         @Param("userId") Long userId,
         @Param("year") int year,
         @Param("month") int month

--- a/src/main/java/basakan/fryday/scheduler/MonthlyReportScheduler.java
+++ b/src/main/java/basakan/fryday/scheduler/MonthlyReportScheduler.java
@@ -18,7 +18,7 @@ public class MonthlyReportScheduler {
     private final MonthlyReportGenerateService reportGenerateService;
     private final UserJpaRepository userJpaRepository;
 
-    @Scheduled(cron = "0 10 0 1 * *")
+    @Scheduled(cron = "0 0 0 1 * *", zone = "Asia/Seoul")
     public void generateMonthlyReports() {
         log.info("[MonthlyReportScheduler] 월간 리포트 생성 시작");
 

--- a/src/main/java/basakan/fryday/service/report/MonthlyReportGenerateService.java
+++ b/src/main/java/basakan/fryday/service/report/MonthlyReportGenerateService.java
@@ -36,9 +36,10 @@ public class MonthlyReportGenerateService {
         int completedTodos = categoryStatistics.stream()
             .mapToInt(CategoryReportDto::getCompletedTodos).sum();
         int incompleteTodos = totalTodos - completedTodos;
+        int attendanceDays = todoRepository.countAttendanceDays(userId, year, month);
         double achievementRate = calculateRate(completedTodos, totalTodos);
 
-        AttendanceIcon icon = AttendanceIcon.fromAchievementRate(achievementRate);
+        AttendanceIcon icon = AttendanceIcon.fromAttendanceDays(attendanceDays);
 
         MonthlyReport report = MonthlyReport.builder()
             .userId(userId)
@@ -47,6 +48,7 @@ public class MonthlyReportGenerateService {
             .totalTodos(totalTodos)
             .completedTodos(completedTodos)
             .incompleteTodos(incompleteTodos)
+            .attendanceDays(attendanceDays)
             .achievementRate(achievementRate)
             .attendanceIcon(icon)
             .attendanceMessage(icon.getMessage())
@@ -57,6 +59,7 @@ public class MonthlyReportGenerateService {
             double failureRate = calculateRate(dto.getIncompleteTodos(), dto.getTotalTodos());
 
             MonthlyReportCategory categoryReport = MonthlyReportCategory.builder()
+                .categoryId(dto.getCategoryId())
                 .categoryName(dto.getCategoryName())
                 .categoryColor(dto.getCategoryColor())
                 .totalTodos(dto.getTotalTodos())

--- a/src/main/java/basakan/fryday/service/report/MonthlyReportReadService.java
+++ b/src/main/java/basakan/fryday/service/report/MonthlyReportReadService.java
@@ -2,13 +2,17 @@ package basakan.fryday.service.report;
 
 import basakan.fryday.common.ErrorCode;
 import basakan.fryday.common.exception.BusinessException;
+import basakan.fryday.controller.report.response.CategoryReportResponse;
+import basakan.fryday.controller.report.response.MonthlyReportResponse;
 import basakan.fryday.domain.report.MonthlyReport;
+import basakan.fryday.repository.CategoryRepository;
 import basakan.fryday.repository.report.MonthlyReportRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +20,7 @@ import java.time.LocalDate;
 public class MonthlyReportReadService {
 
     private final MonthlyReportRepository monthlyReportRepository;
+    private final CategoryRepository categoryRepository;
 
     public MonthlyReport getMonthlyReport(Long userId, int year, int month) {
         LocalDate now = LocalDate.now();
@@ -29,5 +34,18 @@ public class MonthlyReportReadService {
         return monthlyReportRepository
             .findByUserIdAndYearAndMonth(userId, year, month)
             .orElseThrow(() -> new BusinessException(ErrorCode.REPORT_NOT_FOUND));
+    }
+
+    public MonthlyReportResponse getMonthlyReportResponse(Long userId, int year, int month) {
+        MonthlyReport report = getMonthlyReport(userId, year, month);
+
+        List<CategoryReportResponse> filteredCategories = report.getCategories().stream()
+            .filter(category -> categoryRepository.findById(category.getCategoryId())
+                .map(c -> c.getDeletedAt() == null)
+                .orElse(false))
+            .map(CategoryReportResponse::from)
+            .toList();
+
+        return MonthlyReportResponse.from(report, filteredCategories);
     }
 }

--- a/src/main/java/basakan/fryday/service/report/dto/CategoryReportDto.java
+++ b/src/main/java/basakan/fryday/service/report/dto/CategoryReportDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class CategoryReportDto {
+    private Long categoryId;
     private String categoryName;
     private CategoryColor categoryColor;
     private int totalTodos;

--- a/src/test/java/basakan/fryday/controller/report/MonthlyReportControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/report/MonthlyReportControllerTest.java
@@ -6,10 +6,10 @@ import basakan.fryday.common.config.SecurityConfig;
 import basakan.fryday.common.exception.BusinessException;
 import basakan.fryday.common.security.JwtAuthenticationFilter;
 import basakan.fryday.common.security.JwtTokenProvider;
+import basakan.fryday.controller.report.response.CategoryReportResponse;
+import basakan.fryday.controller.report.response.MonthlyReportResponse;
 import basakan.fryday.domain.category.CategoryColor;
 import basakan.fryday.domain.report.AttendanceIcon;
-import basakan.fryday.domain.report.MonthlyReport;
-import basakan.fryday.domain.report.MonthlyReportCategory;
 import basakan.fryday.service.report.MonthlyReportReadService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +23,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.Collections;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -65,19 +66,8 @@ class MonthlyReportControllerTest extends RestDocsSupport {
     @DisplayName("월간 리포트 조회 API - 성공")
     void getMonthlyReport() throws Exception {
         // given
-        MonthlyReport report = MonthlyReport.builder()
-                .userId(1L)
-                .year(2025)
-                .month(4)
-                .totalTodos(45)
-                .completedTodos(30)
-                .incompleteTodos(15)
-                .achievementRate(66.67)
-                .attendanceIcon(AttendanceIcon.GOOD)
-                .attendanceMessage("노력이 보여요!")
-                .build();
-
-        MonthlyReportCategory category1 = MonthlyReportCategory.builder()
+        CategoryReportResponse category1 = CategoryReportResponse.builder()
+                .categoryId(1L)
                 .categoryName("운동")
                 .categoryColor(CategoryColor.BR)
                 .totalTodos(15)
@@ -87,7 +77,8 @@ class MonthlyReportControllerTest extends RestDocsSupport {
                 .failureRate(33.33)
                 .build();
 
-        MonthlyReportCategory category2 = MonthlyReportCategory.builder()
+        CategoryReportResponse category2 = CategoryReportResponse.builder()
+                .categoryId(2L)
                 .categoryName("공부")
                 .categoryColor(CategoryColor.CB)
                 .totalTodos(20)
@@ -97,11 +88,21 @@ class MonthlyReportControllerTest extends RestDocsSupport {
                 .failureRate(25.0)
                 .build();
 
-        report.addCategory(category1);
-        report.addCategory(category2);
+        MonthlyReportResponse response = MonthlyReportResponse.builder()
+                .year(2025)
+                .month(4)
+                .totalTodos(45)
+                .completedTodos(30)
+                .incompleteTodos(15)
+                .attendanceDays(18)
+                .achievementRate(66.67)
+                .attendanceIcon(AttendanceIcon.GOOD)
+                .attendanceMessage("튀김이 많아지고 있어요")
+                .categories(List.of(category1, category2))
+                .build();
 
-        given(monthlyReportReadService.getMonthlyReport(anyLong(), anyInt(), anyInt()))
-                .willReturn(report);
+        given(monthlyReportReadService.getMonthlyReportResponse(anyLong(), anyInt(), anyInt()))
+                .willReturn(response);
 
         // when & then
         mockMvc.perform(get("/api/reports/monthly")
@@ -114,10 +115,12 @@ class MonthlyReportControllerTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.totalTodos").value(45))
                 .andExpect(jsonPath("$.completedTodos").value(30))
                 .andExpect(jsonPath("$.incompleteTodos").value(15))
+                .andExpect(jsonPath("$.attendanceDays").value(18))
                 .andExpect(jsonPath("$.achievementRate").value(66.67))
                 .andExpect(jsonPath("$.attendanceIcon").value("GOOD"))
-                .andExpect(jsonPath("$.attendanceMessage").value("노력이 보여요!"))
+                .andExpect(jsonPath("$.attendanceMessage").value("튀김이 많아지고 있어요"))
                 .andExpect(jsonPath("$.categories").isArray())
+                .andExpect(jsonPath("$.categories[0].categoryId").value(1))
                 .andExpect(jsonPath("$.categories[0].categoryName").value("운동"))
                 .andDo(document("monthly-report-get",
                         queryParameters(
@@ -130,10 +133,12 @@ class MonthlyReportControllerTest extends RestDocsSupport {
                                 fieldWithPath("totalTodos").type(JsonFieldType.NUMBER).description("전체 투두 개수"),
                                 fieldWithPath("completedTodos").type(JsonFieldType.NUMBER).description("완료한 투두 개수"),
                                 fieldWithPath("incompleteTodos").type(JsonFieldType.NUMBER).description("미완료 투두 개수"),
+                                fieldWithPath("attendanceDays").type(JsonFieldType.NUMBER).description("출석 일수 (투두를 1개라도 추가한 날의 개수)"),
                                 fieldWithPath("achievementRate").type(JsonFieldType.NUMBER).description("달성률 (%)"),
-                                fieldWithPath("attendanceIcon").type(JsonFieldType.STRING).description("출석 아이콘 (EXCELLENT, GREAT, GOOD, NEEDS_IMPROVEMENT, POOR)"),
+                                fieldWithPath("attendanceIcon").type(JsonFieldType.STRING).description("출석 아이콘 (EXCELLENT: 21-31일, GOOD: 11-20일, POOR: 0-10일)"),
                                 fieldWithPath("attendanceMessage").type(JsonFieldType.STRING).description("출석 메시지"),
-                                fieldWithPath("categories").type(JsonFieldType.ARRAY).description("카테고리별 통계 목록"),
+                                fieldWithPath("categories").type(JsonFieldType.ARRAY).description("카테고리별 통계 목록 (삭제된 카테고리 제외)"),
+                                fieldWithPath("categories[].categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
                                 fieldWithPath("categories[].categoryName").type(JsonFieldType.STRING).description("카테고리 이름"),
                                 fieldWithPath("categories[].categoryColor").type(JsonFieldType.STRING).description("카테고리 색상 코드"),
                                 fieldWithPath("categories[].totalTodos").type(JsonFieldType.NUMBER).description("카테고리 전체 투두 개수"),
@@ -149,7 +154,7 @@ class MonthlyReportControllerTest extends RestDocsSupport {
     @DisplayName("월간 리포트 조회 API - 현재 월 조회 시 400 에러")
     void getMonthlyReportCurrentMonth() throws Exception {
         // given
-        given(monthlyReportReadService.getMonthlyReport(anyLong(), anyInt(), anyInt()))
+        given(monthlyReportReadService.getMonthlyReportResponse(anyLong(), anyInt(), anyInt()))
                 .willThrow(new BusinessException(ErrorCode.INVALID_REPORT_PERIOD));
 
         // when & then
@@ -166,7 +171,7 @@ class MonthlyReportControllerTest extends RestDocsSupport {
     @DisplayName("월간 리포트 조회 API - 리포트 없을 시 404 에러")
     void getMonthlyReportNotFound() throws Exception {
         // given
-        given(monthlyReportReadService.getMonthlyReport(anyLong(), anyInt(), anyInt()))
+        given(monthlyReportReadService.getMonthlyReportResponse(anyLong(), anyInt(), anyInt()))
                 .willThrow(new BusinessException(ErrorCode.REPORT_NOT_FOUND));
 
         // when & then


### PR DESCRIPTION
## 📌 Related Issue
- close: #

## 🚀 Description
월간 리포트 기능의 평가 기준을 기존 '목표 달성률'에서 **'월별 출석일'** 기준으로 변경하고, 이에 따른 API 명세와 관련 로직을 개편합니다.

### 주요 변경 사항
- **리포트 평가 기준 변경**
  - `MonthlyReport` 도메인에 `attendanceDays` 필드를 다시 추가합니다.
  - `TodoRepository`에 `countAttendanceDays` 쿼리를 추가하여, 한 달 동안 투두를 하나라도 생성한 날짜 수를 계산합니다.
  - `AttendanceIcon` enum의 평가 기준을 '달성률'(`minRate`)에서 '출석일'(`minDays`) 기준으로 변경합니다. (`EXCELLENT`: 21일 이상, `GOOD`: 11일 이상 등)

- **리포트 생성/조회 로직 수정**
  - `MonthlyReportGenerateService`에서 `attendanceDays`를 계산하여 리포트에 저장하도록 로직을 수정합니다.
  - `MonthlyReportReadService`에서 삭제된 카테고리를 필터링하는 로직을 다시 추가하여, 응답의 정확성을 높입니다.

- **API 응답 DTO 변경**
  - `MonthlyReportResponse`에 `attendanceDays` 필드를 다시 추가합니다.
  - `CategoryReportResponse`에 `categoryId`를 다시 추가합니다.

- **API 문서 및 테스트 코드**
  - `index.adoc`에 월간 리포트 API 명세를 다시 추가합니다.
  - 변경된 API 응답에 맞춰 테스트 코드를 수정합니다.