### PR TITLE
#46 반복 설정 관련 리팩토링 및 버그 수정

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -233,6 +233,9 @@ include::{snippets}/monthly-report-get/response-fields.adoc[]
 
 ==== 요청 필드
 include::{snippets}/todo-create/request-fields.adoc[]
+
+NOTE: `date` 필드는 선택사항입니다. 제공하지 않으면 오늘 날짜로 생성됩니다. 과거 날짜는 허용되지 않습니다.
+
 ==== HTTP 요청 예시
 include::{snippets}/todo-create/http-request.adoc[]
 ==== HTTP 응답 예시

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -377,10 +377,20 @@ include::{snippets}/todo-recurrence-update/http-response.adoc[]
 === 반복 설정된 투두 회차 분리
 `POST /api/todos/recurrence/{recurrenceId}/detach`
 
-반복 설정이 된 투두의 특정 회차를 분리하여 개별 투두로 만듭니다.
+반복 투두로 생성된 특정 회차를 단건 투두로 분리하고, 날짜를 변경합니다.
+
+IMPORTANT: 반복 투두의 날짜를 변경하려면 이 API를 사용하세요. `newDate` 필드에 변경할 날짜를 지정하면 분리와 동시에 날짜가 변경됩니다.
+
+==== 동작 방식
+1. 지정된 날짜(`occurrenceDate`)의 반복 투두를 찾습니다.
+2. `newDate`가 제공된 경우, 투두의 날짜를 `newDate`로 변경합니다.
+3. 해당 투두의 `recurrenceId`를 `null`로 변경하여 단건 투두로 만듭니다.
+4. DETACHED 예외를 생성하여 해당 날짜(`occurrenceDate`)에 다시 반복 투두가 생성되지 않도록 합니다.
 
 ==== 경로 파라미터
 include::{snippets}/todo-recurrence-occurrence-detach/path-parameters.adoc[]
+==== 요청 필드
+include::{snippets}/todo-recurrence-occurrence-detach/request-fields.adoc[]
 ==== HTTP 요청 예시
 include::{snippets}/todo-recurrence-occurrence-detach/http-request.adoc[]
 ==== HTTP 응답 예시
@@ -435,7 +445,10 @@ include::{snippets}/todo-move-today/response-fields.adoc[]
 === 투두 날짜 변경
 `PATCH /api/todos/{todoId}/date`
 
-투두의 날짜를 변경합니다.
+일반 투두(반복 설정이 없는 단건 투두)의 날짜를 변경합니다.
+
+IMPORTANT: 반복 투두(`recurrenceId`가 있는 투두)의 날짜는 이 API로 변경할 수 없습니다. 
+반복 투두의 날짜를 변경하려면 `POST /api/todos/recurrence/{recurrenceId}/detach` API를 사용하세요.
 
 ==== 경로 파라미터
 include::{snippets}/todo-update-date/path-parameters.adoc[]

--- a/src/main/java/basakan/fryday/controller/todo/TodoController.java
+++ b/src/main/java/basakan/fryday/controller/todo/TodoController.java
@@ -8,6 +8,7 @@ import basakan.fryday.controller.todo.response.MemoResponse;
 import basakan.fryday.controller.todo.response.TodoListResponse;
 import basakan.fryday.controller.todo.response.TodoResponse;
 import basakan.fryday.controller.todo.response.TodoDetailResponse;
+import basakan.fryday.domain.todo.Recurrence;
 import basakan.fryday.service.todo.RecurrenceService;
 import basakan.fryday.service.todo.TodoService;
 import jakarta.validation.Valid;
@@ -177,12 +178,12 @@ public class TodoController {
     }
 
     @PatchMapping("/recurrence/{recurrenceId}")
-    public ApiResponse<Void> updateRecurrence(
+    public ApiResponse<TodoDetailResponse.RecurrenceInfo> updateRecurrence(
             @PathVariable Long recurrenceId,
             @Valid @RequestBody RecurrenceUpdateRequest request,
             @AuthenticationPrincipal Long userId
     ) {
-        recurrenceService.updateRecurrence(recurrenceId, request, userId);
-        return ApiResponse.success(null, "반복 투두 규칙이 수정되었습니다.");
+        Recurrence recurrence = recurrenceService.updateRecurrence(recurrenceId, request, userId);
+        return ApiResponse.success(TodoDetailResponse.RecurrenceInfo.from(recurrence), "반복 투두 규칙이 수정되었습니다.");
     }
 }

--- a/src/main/java/basakan/fryday/controller/todo/request/TodoSaveRequest.java
+++ b/src/main/java/basakan/fryday/controller/todo/request/TodoSaveRequest.java
@@ -7,8 +7,6 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Getter
 @NoArgsConstructor
 public class TodoSaveRequest {
@@ -28,6 +26,7 @@ public class TodoSaveRequest {
         return Todo.builder()
                 .description(this.description)
                 .category(category)
+                .recurrenceId(null)
                 .build();
     }
 }

--- a/src/main/java/basakan/fryday/controller/todo/request/TodoSaveRequest.java
+++ b/src/main/java/basakan/fryday/controller/todo/request/TodoSaveRequest.java
@@ -2,10 +2,13 @@ package basakan.fryday.controller.todo.request;
 
 import basakan.fryday.domain.category.Category;
 import basakan.fryday.domain.todo.Todo;
+import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor
@@ -17,15 +20,20 @@ public class TodoSaveRequest {
     @NotNull
     private Long categoryId;
 
-    public TodoSaveRequest(String description, Long categoryId) {
+    @FutureOrPresent(message = "과거 날짜로는 투두를 생성할 수 없습니다.")
+    private LocalDate date;
+
+    public TodoSaveRequest(String description, Long categoryId, LocalDate date) {
         this.categoryId = categoryId;
         this.description = description;
+        this.date = date;
     }
 
     public Todo toEntity(Category category) {
         return Todo.builder()
                 .description(this.description)
                 .category(category)
+                .date(this.date)  // date가 null이면 Todo.builder에서 오늘 날짜로 설정됨
                 .recurrenceId(null)
                 .build();
     }

--- a/src/main/java/basakan/fryday/controller/todo/response/TodoListResponse.java
+++ b/src/main/java/basakan/fryday/controller/todo/response/TodoListResponse.java
@@ -25,7 +25,8 @@ public class TodoListResponse {
         this.displayOrder = todo.getDisplayOrder();
         this.date = todo.getDate();
         this.recurrenceId = todo.getRecurrenceId();
-        this.occurrenceDate = null;
+        // 반복 투두의 경우 date가 occurrenceDate와 같음 (생성 시 occurrenceDate로 설정됨)
+        this.occurrenceDate = todo.getRecurrenceId() != null ? todo.getDate() : null;
     }
 
     // 가상 회차(반복 투두)용 생성자

--- a/src/main/java/basakan/fryday/domain/todo/Recurrence.java
+++ b/src/main/java/basakan/fryday/domain/todo/Recurrence.java
@@ -27,6 +27,9 @@ public class Recurrence extends BaseEntity {
     @Column(nullable = false)
     private String description;
 
+    @Column(length = 300)
+    private String memo;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private RecurrenceType type;
@@ -44,12 +47,13 @@ public class Recurrence extends BaseEntity {
     private LocalDate lastGeneratedDate;
 
     @Builder
-    public Recurrence(long userId, long categoryId, String description, RecurrenceType type,
+    public Recurrence(long userId, long categoryId, String description, String memo, RecurrenceType type,
                       String frequencyValues, LocalDate startDate, LocalDate endDate,
                       LocalTime notificationTime, LocalDate lastGeneratedDate) {
         this.userId = userId;
         this.categoryId = categoryId;
         this.description = description;
+        this.memo = memo;
         this.type = type;
         this.frequencyValues = frequencyValues;
         this.startDate = startDate;

--- a/src/main/java/basakan/fryday/domain/todo/Todo.java
+++ b/src/main/java/basakan/fryday/domain/todo/Todo.java
@@ -52,13 +52,14 @@ public class Todo extends BaseEntity {
     }
 
     @Builder
-    public Todo(String description, Category category, LocalDate date, Long displayOrder, long recurrenceId) {
+    public Todo(String description, Category category, LocalDate date, Long displayOrder, Long recurrenceId) {
         this.description = description;
         this.status = Status.IN_PROGRESS;
         this.category = category;
         this.date = (date != null) ? date : LocalDate.now();
         this.displayOrder = displayOrder != null ? displayOrder : 0L;
-        this.recurrenceId = recurrenceId;
+        // recurrenceId가 0이면 null로 변환 (반복 없는 투두는 null)
+        this.recurrenceId = (recurrenceId != null && recurrenceId == 0) ? null : recurrenceId;
         this.isBurnt = false;
     }
 

--- a/src/main/java/basakan/fryday/domain/todo/Todo.java
+++ b/src/main/java/basakan/fryday/domain/todo/Todo.java
@@ -52,7 +52,7 @@ public class Todo extends BaseEntity {
     }
 
     @Builder
-    public Todo(String description, Category category, LocalDate date, Long displayOrder, Long recurrenceId) {
+    public Todo(String description, Category category, LocalDate date, Long displayOrder, Long recurrenceId, String memo) {
         this.description = description;
         this.status = Status.IN_PROGRESS;
         this.category = category;
@@ -60,6 +60,7 @@ public class Todo extends BaseEntity {
         this.displayOrder = displayOrder != null ? displayOrder : 0L;
         // recurrenceId가 0이면 null로 변환 (반복 없는 투두는 null)
         this.recurrenceId = (recurrenceId != null && recurrenceId == 0) ? null : recurrenceId;
+        this.memo = memo;
         this.isBurnt = false;
     }
 

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceOccurrenceMaterializeService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceOccurrenceMaterializeService.java
@@ -102,6 +102,7 @@ public class RecurrenceOccurrenceMaterializeService {
                 .date(occurrenceDate)
                 .displayOrder(displayOrder)
                 .recurrenceId(recurrence.getId())
+                .memo(recurrence.getMemo())
                 .build();
 
         Todo savedTodo = todoRepository.save(todo);

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceOccurrenceMaterializeService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceOccurrenceMaterializeService.java
@@ -17,6 +17,7 @@ import basakan.fryday.service.user.UserReadService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -44,7 +45,7 @@ public class RecurrenceOccurrenceMaterializeService {
     /**
      * 특정 반복 투두의 가상 회차를 실제 Todo로 생성 (이미 존재하면 생성하지 않음)
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Todo materializeOccurrenceIfNotExists(Long userId, Long recurrenceId, LocalDate occurrenceDate) {
         Recurrence recurrence = recurrenceRepository.findById(recurrenceId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
@@ -37,6 +37,7 @@ public class RecurrenceService {
                 .userId(userId)
                 .categoryId(originalTodo.getCategory().getId())
                 .description(originalTodo.getDescription())
+                .memo(originalTodo.getMemo())
                 .type(request.getType())
                 .frequencyValues(request.getFrequencyValues() != null 
                         ? String.join(",", request.getFrequencyValues()) 

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
@@ -5,11 +5,9 @@ import basakan.fryday.common.exception.BusinessException;
 import basakan.fryday.controller.todo.request.RecurrenceCreateRequest;
 import basakan.fryday.controller.todo.request.RecurrenceUpdateRequest;
 import basakan.fryday.controller.todo.response.TodoResponse;
-import basakan.fryday.domain.category.Category;
 import basakan.fryday.domain.todo.Recurrence;
 import basakan.fryday.domain.todo.RecurrenceException;
 import basakan.fryday.domain.todo.Todo;
-import basakan.fryday.repository.CategoryRepository;
 import basakan.fryday.repository.todo.RecurrenceExceptionRepository;
 import basakan.fryday.repository.todo.RecurrenceRepository;
 import basakan.fryday.repository.todo.TodoRepository;
@@ -27,7 +25,6 @@ public class RecurrenceService {
     private final RecurrenceRepository recurrenceRepository;
     private final TodoRepository todoRepository;
     private final RecurrenceExceptionRepository recurrenceExceptionRepository;
-    private final CategoryRepository categoryRepository;
 
     @Transactional
     public TodoResponse createRecurrence(Long userId, RecurrenceCreateRequest request) {
@@ -173,7 +170,7 @@ public class RecurrenceService {
 
     // 반복 규칙 수정
     @Transactional
-    public void updateRecurrence(Long recurrenceId, RecurrenceUpdateRequest request, Long userId) {
+    public Recurrence updateRecurrence(Long recurrenceId, RecurrenceUpdateRequest request, Long userId) {
         Recurrence recurrence = recurrenceRepository.findById(recurrenceId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
 
@@ -192,5 +189,7 @@ public class RecurrenceService {
                 request.getEndDate(),
                 request.getNotificationTime()
         );
+
+        return recurrence;
     }
 }

--- a/src/main/java/basakan/fryday/service/todo/TodoService.java
+++ b/src/main/java/basakan/fryday/service/todo/TodoService.java
@@ -19,9 +19,10 @@ import basakan.fryday.repository.CategoryRepository;
 import basakan.fryday.repository.todo.TodoAlarmRepository;
 import basakan.fryday.repository.todo.TodoRepository;
 import basakan.fryday.repository.todo.RecurrenceRepository;
-import basakan.fryday.service.todo.RecurrenceOccurrenceMaterializeService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -29,6 +30,7 @@ import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TodoService {
@@ -166,8 +168,11 @@ public class TodoService {
         }
     }
 
-    @Transactional
-    public List<TodoListResponse> getTodoList(Long userId, LocalDate date, Long categoryId) {
+    /**
+     * 반복 투두 materialization을 별도 트랜잭션에서 수행
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void materializeRecurrenceOccurrences(Long userId, LocalDate date, Long categoryId) {
         List<Recurrence> recurrences = recurrenceRepository.findByUserIdAndDateRange(userId, date);
 
         if (categoryId != null) {
@@ -184,9 +189,21 @@ public class TodoService {
                     continue;
                 }
                 throw e;
+            } catch (Exception e) {
+                // REQUIRES_NEW로 분리된 트랜잭션에서 발생한 예외는 외부 트랜잭션에 영향을 주지 않음
+                log.error("반복 투두 materialize 중 예상치 못한 예외 발생 - recurrenceId: {}, date: {}. 스킵하고 계속 진행", 
+                        recurrence.getId(), date, e);
+                continue;
             }
         }
+    }
 
+    /**
+     * 투두 목록 조회를 별도 트랜잭션에서 수행
+     * materialization이 완료된 후 조회하므로 새로 생성된 Todo를 포함하여 반환
+     */
+    @Transactional(readOnly = true)
+    public List<TodoListResponse> getTodoListInternal(Long userId, LocalDate date, Long categoryId) {
         List<Todo> todos;
         if (categoryId == null) {
             todos = todoRepository.findAllByUserIdAndDate(userId, date);
@@ -201,6 +218,17 @@ public class TodoService {
         allResponses.sort(Comparator.comparing(TodoListResponse::getDisplayOrder));
 
         return allResponses;
+    }
+
+    /**
+     * 투두 목록 조회
+     * 1. 먼저 반복 투두를 materialize (별도 트랜잭션)
+     * 2. 그 다음 투두 목록을 조회 (별도 읽기 전용 트랜잭션)
+     * 이렇게 분리하여 materialization이 커밋된 후 조회하므로 새로 생성된 Todo를 포함하여 반환
+     */
+    public List<TodoListResponse> getTodoList(Long userId, LocalDate date, Long categoryId) {
+        materializeRecurrenceOccurrences(userId, date, categoryId);
+        return getTodoListInternal(userId, date, categoryId);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
@@ -830,7 +830,7 @@ class TodoControllerTest extends RestDocsSupport {
                                 parameterWithName("recurrenceId").description("반복 투두 규칙 ID")
                         ),
                         requestFields(
-                                fieldWithPath("occurrenceDate").type(JsonFieldType.STRING).description("원본 가상 회차의 발생일 (YYYY-MM-DD)"),
+                                fieldWithPath("occurrenceDate").type(JsonFieldType.STRING).description("반복 투두의 발생일 (YYYY-MM-DD)"),
                                 fieldWithPath("newDate").type(JsonFieldType.STRING).description("단건 투두로 분리할 새로운 날짜 (YYYY-MM-DD)")
                         ),
                         responseFields(

--- a/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
@@ -12,6 +12,7 @@ import basakan.fryday.controller.todo.response.*;
 import basakan.fryday.domain.category.Category;
 import basakan.fryday.domain.category.CategoryColor;
 import basakan.fryday.domain.todo.CharacterStatus;
+import basakan.fryday.domain.todo.Recurrence;
 import basakan.fryday.domain.todo.RecurrenceType;
 import basakan.fryday.domain.todo.Todo;
 import basakan.fryday.service.todo.RecurrenceService;
@@ -79,7 +80,8 @@ class TodoControllerTest extends RestDocsSupport {
     void createTodo() throws Exception {
         // given
         Long categoryId = 1L;
-        TodoSaveRequest request = new TodoSaveRequest("양파 썰기", categoryId);
+        LocalDate todoDate = LocalDate.now();
+        TodoSaveRequest request = new TodoSaveRequest("양파 썰기", categoryId, todoDate);
 
         // Mocking을 위한 가짜 데이터 생성
         Category mockCategory = Category.builder()
@@ -92,6 +94,7 @@ class TodoControllerTest extends RestDocsSupport {
         Todo mockTodo = Todo.builder()
                 .description("양파 썰기")
                 .category(mockCategory)
+                .date(todoDate)
                 .build();
 
         ReflectionTestUtils.setField(mockTodo, "id", 1L);
@@ -114,7 +117,8 @@ class TodoControllerTest extends RestDocsSupport {
                 .andDo(document("todo-create",
                         requestFields(
                                 fieldWithPath("description").type(JsonFieldType.STRING).description("할 일 내용"),
-                                fieldWithPath("categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID")
+                                fieldWithPath("categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
+                                fieldWithPath("date").type(JsonFieldType.STRING).description("투두 날짜 (YYYY-MM-DD, optional, 미래 날짜 가능, null이면 오늘 날짜)").optional()
                         ),
                         responseFields(
                                 fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
@@ -861,8 +865,22 @@ class TodoControllerTest extends RestDocsSupport {
         ReflectionTestUtils.setField(request, "endDate", LocalDate.of(2026, 1, 31));
         ReflectionTestUtils.setField(request, "notificationTime", LocalTime.of(10, 0));
 
-        // Mocking: void 메서드이므로 willDoNothing 사용
-        willDoNothing().given(recurrenceService).updateRecurrence(anyLong(), any(RecurrenceUpdateRequest.class), anyLong());
+        // Mocking: 수정된 Recurrence 엔티티 생성
+        Recurrence mockRecurrence = Recurrence.builder()
+                .userId(1L)
+                .categoryId(1L)
+                .description("매주 운동하기")
+                .type(RecurrenceType.WEEKLY)
+                .frequencyValues("TUESDAY,THURSDAY")
+                .startDate(startDate)
+                .endDate(LocalDate.of(2026, 1, 31))
+                .notificationTime(LocalTime.of(10, 0))
+                .lastGeneratedDate(startDate)
+                .build();
+        ReflectionTestUtils.setField(mockRecurrence, "id", recurrenceId);
+
+        given(recurrenceService.updateRecurrence(anyLong(), any(RecurrenceUpdateRequest.class), anyLong()))
+                .willReturn(mockRecurrence);
 
         // when & then
         mockMvc.perform(patch("/api/todos/recurrence/{recurrenceId}", recurrenceId)
@@ -884,6 +902,12 @@ class TodoControllerTest extends RestDocsSupport {
                         responseFields(
                                 fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
                                 fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("data.recurrenceId").type(JsonFieldType.NUMBER).description("반복 규칙 ID"),
+                                fieldWithPath("data.type").type(JsonFieldType.STRING).description("반복 주기"),
+                                fieldWithPath("data.frequencyValues").type(JsonFieldType.STRING).description("반복 상세 값").optional(),
+                                fieldWithPath("data.startDate").type(JsonFieldType.STRING).description("반복 시작일"),
+                                fieldWithPath("data.endDate").type(JsonFieldType.STRING).description("반복 종료일").optional(),
+                                fieldWithPath("data.notificationTime").type(JsonFieldType.STRING).description("반복 알림 시간").optional(),
                                 fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
                         )
                 ));


### PR DESCRIPTION
## 📌 Related Issue
- close: #46 

## 🚀 Description

### 1. 반복 투두 실제 생성과 투두 목록 조회 트랜잭션 분리

**문제점:**
- `GET /api/todos` 호출 시 첫 번째 호출에서 빈 배열이 반환되고, 두 번째 호출에서야 데이터가 채워지는 문제 발생
- 원인: 한 번의 API 요청 안에서 반복 회차를 실제 Todo로 생성, 그다음 같은 트랜잭션에서 `findAllByUserIdAndDate`로 목록 조회
“생성”과 “조회”가 같은 트랜잭션에 묶여 있어서, materialize에서 insert한 행이 아직 커밋되지 않았거나, 같은 트랜잭션 내에서의 flush/가시성 이슈로 조회 시점에 방금 넣은 행이 보이지 않는 상황이 발생한 것으로 보입니다.

**해결 방법:**
- 생성과 조회를 별도 트랜잭션으로 분리
  - `materializeRecurrenceOccurrences()`: `REQUIRES_NEW`로 반복 투두 materialization 수행
  - `getTodoListInternal()`: 읽기 전용 트랜잭션으로 투두 목록 조회
  - `getTodoList()`: 위 두 메서드를 순차적으로 호출

**효과:**
- Materialization이 완전히 커밋된 후 조회하므로 첫 호출부터 정상적으로 데이터 반환
- 트랜잭션 롤백 문제 해결

### 2. 반복 투두 실제 생성 시 occurrenceDate 채워지도록 수정

**문제점:**
- 반복 투두가 materialize되어 실제 Todo로 저장되었을 때, `TodoListResponse`의 `occurrenceDate`가 항상 `null`로 반환됨

**해결 방법:**
- `TodoListResponse` 생성자에서 `recurrenceId`가 있으면 `todo.getDate()`를 `occurrenceDate`로 설정
- 반복 투두의 경우 materialize 시 `date(occurrenceDate)`로 설정되므로 동일한 값 사용

### 3. Todo 생성 API 미래 날짜 지원

**변경 내용:**
- `POST /api/todos`에서 선택적 `date` 파라미터 추가
- 미래 날짜로 투두 생성 가능하도록 수정
- 과거 날짜는 여전히 허용하지 않음 (`@FutureOrPresent` 검증)

### 4. 반복 투두 생성 시 메모 복사 문제 해결

**문제점:**
- 반복 투두를 생성할 때 원본 투두의 `memo`가 `Recurrence` 엔티티로 복사되지 않음
- Materialize 시 `memo`가 비어있던 문제

**해결 방법:**
- `Recurrence` 엔티티에 `memo` 필드 추가
- `RecurrenceService.createRecurrence()`에서 원본 투두의 `memo` 복사
- `RecurrenceOccurrenceMaterializeService`에서 materialize 시 `memo` 복사


## 📢 Notes
- 트랜잭션 공부 필요.........
