### PR TITLE
fix: 반복 설정으로 생긴 투두 삭제 시 재생성 안 되게 수정

### DIFF
--- a/src/main/java/basakan/fryday/domain/todo/RecurrenceException.java
+++ b/src/main/java/basakan/fryday/domain/todo/RecurrenceException.java
@@ -31,7 +31,7 @@ public class RecurrenceException extends BaseEntity {
     private Long detachedTodoId;
 
     public enum ExceptionType {
-        CANCELLED,  // 제외(삭제)
+        DELETED,    // 삭제 (반복 투두를 삭제하여 재생성 방지)
         DETACHED    // 분리(반복에서 제외하고 단건 todo로 변환)
     }
 

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceOccurrenceCalculator.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceOccurrenceCalculator.java
@@ -25,7 +25,7 @@ public class RecurrenceOccurrenceCalculator {
      * @param recurrence 반복 규칙
      * @param fromDate 시작 날짜 (포함)
      * @param toDate 종료 날짜 (포함)
-     * @param cancelledDates 제외된 날짜 목록 (CANCELLED 예외)
+     * @param cancelledDates 제외된 날짜 목록 (DELETED 예외)
      * @return 발생일 목록 (정렬됨)
      */
     public List<LocalDate> calculateOccurrences(Recurrence recurrence, LocalDate fromDate, LocalDate toDate, Set<LocalDate> cancelledDates) {

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceOccurrenceMaterializeService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceOccurrenceMaterializeService.java
@@ -67,7 +67,7 @@ public class RecurrenceOccurrenceMaterializeService {
             return existingTodo;
         }
 
-        // 예외 확인 (CANCELLED와 DETACHED 제외)
+        // 예외 확인 (DELETED와 DETACHED 제외)
         List<RecurrenceException> exceptions = recurrenceExceptionRepository.findByRecurrenceId(recurrenceId);
         boolean isException = exceptions.stream()
                 .anyMatch(e -> e.getOccurrenceDate().equals(occurrenceDate));
@@ -147,7 +147,7 @@ public class RecurrenceOccurrenceMaterializeService {
 
         for (Recurrence recurrence : recurrences) {
             try {
-                // 2. 예외 조회 (CANCELLED와 DETACHED 모두 제외)
+                // 2. 예외 조회 (DELETED와 DETACHED 모두 제외)
                 List<RecurrenceException> exceptions = recurrenceExceptionRepository
                         .findByRecurrenceId(recurrence.getId());
 

--- a/src/main/java/basakan/fryday/service/todo/TodoService.java
+++ b/src/main/java/basakan/fryday/service/todo/TodoService.java
@@ -19,6 +19,8 @@ import basakan.fryday.repository.CategoryRepository;
 import basakan.fryday.repository.todo.TodoAlarmRepository;
 import basakan.fryday.repository.todo.TodoRepository;
 import basakan.fryday.repository.todo.RecurrenceRepository;
+import basakan.fryday.repository.todo.RecurrenceExceptionRepository;
+import basakan.fryday.domain.todo.RecurrenceException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -39,6 +41,7 @@ public class TodoService {
     private final CategoryRepository categoryRepository;
     private final TodoAlarmRepository todoAlarmRepository;
     private final RecurrenceRepository recurrenceRepository;
+    private final RecurrenceExceptionRepository recurrenceExceptionRepository;
     private final RecurrenceOccurrenceMaterializeService materializeService;
 
     @Transactional
@@ -88,7 +91,37 @@ public class TodoService {
                 .filter(t -> !t.isDeleted())
                 .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
 
-        todoRepository.delete(todo);
+        if (!todo.getCategory().getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
+
+        // 반복 투두인 경우 DELETED 예외 생성하여 재생성 방지
+        if (todo.getRecurrenceId() != null) {
+            Long recurrenceId = todo.getRecurrenceId();
+            LocalDate occurrenceDate = todo.getDate();
+
+            // 이미 예외가 존재하는지 확인
+            RecurrenceException existingException = recurrenceExceptionRepository
+                    .findByRecurrenceIdAndOccurrenceDate(recurrenceId, occurrenceDate)
+                    .orElse(null);
+
+            // DETACHED 예외가 있으면 이미 분리된 투두이므로 예외 생성 불필요
+            // DELETED 예외가 없으면 생성
+            if (existingException == null) {
+                RecurrenceException exception = RecurrenceException.builder()
+                        .recurrenceId(recurrenceId)
+                        .occurrenceDate(occurrenceDate)
+                        .type(RecurrenceException.ExceptionType.DELETED)
+                        .build();
+                recurrenceExceptionRepository.save(exception);
+            } else if (existingException.getType() == RecurrenceException.ExceptionType.DETACHED) {
+                // 이미 분리된 투두는 예외 생성 불필요
+            }
+            // 이미 DELETED 예외가 있으면 추가 생성 불필요
+        }
+
+        // Todo 삭제 (soft delete)
+        todo.delete();
     }
 
     @Transactional


### PR DESCRIPTION
## 📌 Related Issue
- close: #48 

## 🚀 Description

### 문제 상황
반복 설정으로 생성된 투두를 `DELETE /api/todos/{todoId}`로 삭제한 후, 해당 날짜를 조회하거나 스케줄러가 실행되면 투두가 다시 생성되는 문제가 발생

### 원인
`materializeOccurrenceIfNotExists()`에서 삭제된 투두(`deletedAt != null`)를 확인하지 못해, 예외가 없으면 재생성하는 로직 때문이었음

### 해결 방법
- 반복 투두 삭제 시 `RecurrenceException`을 `DELETED` 타입으로 생성하여 해당 날짜에 재생성되지 않도록 수정
- `CANCELED` 타입을 의미 명확하게 하기 위해 `DELETED`로 수정

## 📢 Notes

