### PR TITLE
refactor: todo 날짜 변경 api 하나로 통합

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -398,23 +398,6 @@ include::{snippets}/todo-recurrence-update/http-request.adoc[]
 ==== HTTP 응답 예시
 include::{snippets}/todo-recurrence-update/http-response.adoc[]
 
-=== 반복 설정된 투두 회차 분리(날짜 변경)
-`POST /api/todos/recurrence/{recurrenceId}/detach`
-
-반복 투두로 생성된 특정 회차를 단건 투두로 분리하고, 날짜를 변경합니다.
-
-IMPORTANT: 반복 투두의 날짜를 변경하려면 이 API를 사용하세요. `newDate` 필드에 변경할 날짜를 지정하면 분리와 동시에 날짜가 변경됩니다.
-
-==== 경로 파라미터
-include::{snippets}/todo-recurrence-occurrence-detach/path-parameters.adoc[]
-==== 요청 필드
-include::{snippets}/todo-recurrence-occurrence-detach/request-fields.adoc[]
-==== HTTP 요청 예시
-include::{snippets}/todo-recurrence-occurrence-detach/http-request.adoc[]
-==== HTTP 응답 예시
-include::{snippets}/todo-recurrence-occurrence-detach/http-response.adoc[]
-==== 응답 필드
-include::{snippets}/todo-recurrence-occurrence-detach/response-fields.adoc[]
 
 
 === 반복 설정 투두 삭제(반복 해제)
@@ -463,20 +446,21 @@ include::{snippets}/todo-move-today/response-fields.adoc[]
 === 투두 날짜 변경
 `PATCH /api/todos/{todoId}/date`
 
-일반 투두(반복 설정이 없는 단건 투두)의 날짜를 변경합니다.
+투두의 날짜를 변경합니다. 반복 투두인 경우 자동으로 반복에서 분리되어 단건 투두로 변환됩니다.
 
-IMPORTANT: 반복 투두(`recurrenceId`가 있는 투두)의 날짜는 이 API로 변경할 수 없습니다. 
-반복 투두의 날짜를 변경하려면 `POST /api/todos/recurrence/{recurrenceId}/detach` API를 사용하세요.
+NOTE: 반복 투두의 날짜를 변경하면 해당 투두는 반복 규칙에서 분리되어 단건 투두로 변환됩니다.
+반복 규칙 자체는 유지되며, 이후 해당 날짜에는 새로운 투두가 생성되지 않습니다.
 
-==== 경로 파라미터
+
+===== 경로 파라미터
 include::{snippets}/todo-update-date/path-parameters.adoc[]
-==== 요청 필드
+===== 요청 필드
 include::{snippets}/todo-update-date/request-fields.adoc[]
-==== HTTP 요청 예시
+===== HTTP 요청 예시
 include::{snippets}/todo-update-date/http-request.adoc[]
-==== HTTP 응답 예시
+===== HTTP 응답 예시
 include::{snippets}/todo-update-date/http-response.adoc[]
-==== 응답 필드
+===== 응답 필드
 include::{snippets}/todo-update-date/response-fields.adoc[]
 
 === 투두 순서 변경

--- a/src/main/java/basakan/fryday/controller/todo/TodoController.java
+++ b/src/main/java/basakan/fryday/controller/todo/TodoController.java
@@ -166,17 +166,6 @@ public class TodoController {
 //        return ApiResponse.success(null, "반복 투두 회차가 제외되었습니다.");
 //    }
 
-    @PostMapping("/recurrence/{recurrenceId}/detach")
-    public ApiResponse<TodoResponse> detachRecurrenceOccurrence(
-            @PathVariable Long recurrenceId,
-            @Valid @RequestBody RecurrenceOccurrenceDetachRequest request,
-            @AuthenticationPrincipal Long userId
-    ) {
-        TodoResponse response = recurrenceService.detachRecurrenceOccurrence(
-                recurrenceId, request.getOccurrenceDate(), request.getNewDate(), userId);
-        return ApiResponse.success(response, "반복 투두가 단건 투두로 분리되었습니다.");
-    }
-
     @PatchMapping("/recurrence/{recurrenceId}")
     public ApiResponse<TodoDetailResponse.RecurrenceInfo> updateRecurrence(
             @PathVariable Long recurrenceId,

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
@@ -85,58 +85,6 @@ public class RecurrenceService {
         recurrenceRepository.delete(recurrence);
     }
 
-    // 반복 투두의 특정 회차를 분리
-    @Transactional
-    public TodoResponse detachRecurrenceOccurrence(Long recurrenceId, LocalDate occurrenceDate, LocalDate newDate, Long userId) {
-        Recurrence recurrence = recurrenceRepository.findById(recurrenceId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
-
-        if (recurrence.getUserId() != userId) {
-            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
-        }
-
-        // DETACHED 예외가 이미 존재하는지 확인
-        RecurrenceException existingException = recurrenceExceptionRepository
-                .findByRecurrenceIdAndOccurrenceDate(recurrenceId, occurrenceDate)
-                .orElse(null);
-
-        if (existingException != null && existingException.getType() == RecurrenceException.ExceptionType.DETACHED) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
-        }
-
-        // 기존 Todo 조회
-        List<Todo> existingTodos = todoRepository.findAllByUserIdAndDate(userId, occurrenceDate);
-        Todo existingTodo = existingTodos.stream()
-                .filter(todo -> todo.getRecurrenceId() != null
-                        && todo.getRecurrenceId().equals(recurrenceId)
-                        && todo.getDeletedAt() == null)
-                .findFirst()
-                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
-
-        // 날짜 변경
-        if (!occurrenceDate.equals(newDate)) {
-            existingTodo.updateDate(newDate);
-            // displayOrder 재계산 (새 날짜 기준)
-            Long maxOrder = todoRepository.findMaxDisplayOrder(userId, newDate);
-            long displayOrder = (maxOrder == null) ? 1 : maxOrder + 1;
-            existingTodo.updateDisplayOrder(displayOrder);
-        }
-
-        // recurrenceId를 null로 변경 (반복에서 분리)
-        existingTodo.setRecurrenceId(null);
-
-        // DETACHED 예외 생성
-        RecurrenceException exception = RecurrenceException.builder()
-                .recurrenceId(recurrenceId)
-                .occurrenceDate(occurrenceDate)
-                .type(RecurrenceException.ExceptionType.DETACHED)
-                .detachedTodoId(existingTodo.getId())
-                .build();
-
-        recurrenceExceptionRepository.save(exception);
-
-        return TodoResponse.from(existingTodo);
-    }
 
     /**
      * 반복 투두의 특정 회차를 제외(CANCELLED)합니다.

--- a/src/main/java/basakan/fryday/service/todo/TodoService.java
+++ b/src/main/java/basakan/fryday/service/todo/TodoService.java
@@ -153,15 +153,62 @@ public class TodoService {
         Todo todo = todoRepository.findById(todoId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
 
-        if (todo.getRecurrenceId() != null) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE,
-                    "반복 투두의 날짜는 이 API로 변경할 수 없습니다. detach API를 사용하세요.");
+        if (!todo.getCategory().getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
         }
 
         if (request.getDate().isBefore(LocalDate.now())) {
             throw new BusinessException(ErrorCode.PAST_DATE_NOT_ALLOWED);
         }
 
+        // 반복 투두인 경우 자동으로 detach 처리
+        if (todo.getRecurrenceId() != null) {
+            Long recurrenceId = todo.getRecurrenceId();
+            LocalDate occurrenceDate = todo.getDate();
+            LocalDate newDate = request.getDate();
+
+            // Recurrence 검증
+            Recurrence recurrence = recurrenceRepository.findById(recurrenceId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+            if (recurrence.getUserId() != userId) {
+                throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+            }
+
+            // DETACHED 예외가 이미 존재하는지 확인
+            RecurrenceException existingException = recurrenceExceptionRepository
+                    .findByRecurrenceIdAndOccurrenceDate(recurrenceId, occurrenceDate)
+                    .orElse(null);
+
+            if (existingException != null && existingException.getType() == RecurrenceException.ExceptionType.DETACHED) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+            }
+
+            // 날짜 변경
+            if (!occurrenceDate.equals(newDate)) {
+                todo.updateDate(newDate);
+                // displayOrder 재계산
+                Long maxOrder = todoRepository.findMaxDisplayOrder(userId, newDate);
+                long displayOrder = (maxOrder == null) ? 1 : maxOrder + 1;
+                todo.updateDisplayOrder(displayOrder);
+            }
+
+            todo.setRecurrenceId(null);
+
+            // DETACHED 예외 생성
+            RecurrenceException exception = RecurrenceException.builder()
+                    .recurrenceId(recurrenceId)
+                    .occurrenceDate(occurrenceDate)
+                    .type(RecurrenceException.ExceptionType.DETACHED)
+                    .detachedTodoId(todo.getId())
+                    .build();
+
+            recurrenceExceptionRepository.save(exception);
+
+            return TodoResponse.from(todo);
+        }
+
+        // 일반 투두인 경우 기존 로직
         todo.updateDate(request.getDate());
 
         return TodoResponse.from(todo);

--- a/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
@@ -467,7 +467,7 @@ class TodoControllerTest extends RestDocsSupport {
                 .andExpect(status().isOk())
                 .andDo(document("todo-update-date",
                         pathParameters(
-                                parameterWithName("todoId").description("수정할 투두 ID")
+                                parameterWithName("todoId").description("수정할 투두 ID (반복 투두인 경우 자동으로 분리됨)")
                         ),
                         requestFields(
                                 fieldWithPath("date").type(JsonFieldType.STRING).description("변경할 날짜 (YYYY-MM-DD, 오늘 이후만 가능)")
@@ -973,57 +973,6 @@ class TodoControllerTest extends RestDocsSupport {
                 ));
     }
 
-    @Test
-    @DisplayName("반복 투두 회차 분리")
-    void detachRecurrenceOccurrence() throws Exception {
-        // given
-        Long recurrenceId = 1L;
-        LocalDate occurrenceDate = LocalDate.of(2025, 12, 8);
-        LocalDate newDate = LocalDate.of(2025, 12, 10);
-        
-        RecurrenceOccurrenceDetachRequest request = new RecurrenceOccurrenceDetachRequest(occurrenceDate, newDate);
-
-        // Mocking: 분리된 단건 Todo 응답
-        Category mockCategory = Category.builder().name("운동").color(CategoryColor.BR).userId(1L).build();
-        ReflectionTestUtils.setField(mockCategory, "id", 1L);
-
-        Todo mockTodo = Todo.builder()
-                .description("매일 운동하기")
-                .category(mockCategory)
-                .date(newDate)
-                .build();
-        ReflectionTestUtils.setField(mockTodo, "id", 101L);
-
-        given(recurrenceService.detachRecurrenceOccurrence(anyLong(), any(LocalDate.class), any(LocalDate.class), anyLong()))
-                .willReturn(TodoResponse.from(mockTodo));
-
-        // when & then
-        mockMvc.perform(post("/api/todos/recurrence/{recurrenceId}/detach", recurrenceId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andDo(document("todo-recurrence-occurrence-detach",
-                        pathParameters(
-                                parameterWithName("recurrenceId").description("반복 투두 규칙 ID")
-                        ),
-                        requestFields(
-                                fieldWithPath("occurrenceDate").type(JsonFieldType.STRING).description("반복 투두의 발생일 (YYYY-MM-DD)"),
-                                fieldWithPath("newDate").type(JsonFieldType.STRING).description("단건 투두로 분리할 새로운 날짜 (YYYY-MM-DD)")
-                        ),
-                        responseFields(
-                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
-                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
-                                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("분리된 단건 투두 ID"),
-                                fieldWithPath("data.description").type(JsonFieldType.STRING).description("할 일 내용"),
-                                fieldWithPath("data.status").type(JsonFieldType.STRING).description("상태 (IN_PROGRESS, COMPLETED)"),
-                                fieldWithPath("data.categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
-                                fieldWithPath("data.memo").type(JsonFieldType.STRING).description("메모").optional(),
-                                fieldWithPath("data.date").type(JsonFieldType.STRING).description("새로운 투두 날짜"),
-                                fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
-                        )
-                ));
-    }
 
     @Test
     @DisplayName("반복 투두 규칙 수정")


### PR DESCRIPTION
## 📌 Related Issue
- close: #53 

## 🚀 Description
- 기존 분리되어 있던 날짜 변경 API(`PATCH /api/todos/{todoId}/date`)와 반복 설정으로 생긴 투두의 날짜 변경 API (`POST /api/todos/recurrence/{recurrenceId}/detach`)를 하나로 통합

## 📢 Notes
- 프론트에선 분기 처리를 안 해도 됨