### PR TITLE
탈퇴 후 7일 재가입 제한 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,12 @@ tasks/**
 ### REST Docs ###
 src/main/resources/static/docs/
 
+### Firebase / Secrets ###
+src/main/resources/firebase-adminsdk.json
+src/main/resources/firebase-adminsdk*.json
+src/main/resources/*-adminsdk.json
+src/main/resources/google-services.json
+src/main/r
 
 ### for local test ###
 application-dev.yml

--- a/src/main/java/basakan/fryday/common/ErrorCode.java
+++ b/src/main/java/basakan/fryday/common/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
     UNSUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 Provider입니다."),
     USER_BLOCKED(HttpStatus.FORBIDDEN, "차단된 사용자입니다."),
     USER_WITHDRAWN(HttpStatus.FORBIDDEN, "탈퇴한 사용자입니다."),
+    USER_REREGISTER_NOT_ALLOWED(HttpStatus.FORBIDDEN, "탈퇴 후 7일 이내에는 재가입할 수 없습니다."),
     INTERNAL_AUTH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "인증 처리 중 오류가 발생했습니다."),
     REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "Refresh Token이 유효하지 않거나 만료되었습니다."),
 

--- a/src/main/java/basakan/fryday/common/config/FcmConfig.java
+++ b/src/main/java/basakan/fryday/common/config/FcmConfig.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -22,11 +23,13 @@ import java.io.InputStream;
 @Configuration
 public class FcmConfig {
 
+    private static final String DEFAULT_CREDENTIALS_PATH = "firebase-adminsdk.json";
+
     @Value("${fcm.enabled:false}")
     private boolean fcmEnabled;
 
-    @Value("${fcm.credentials.path:firebase-adminsdk.json}")
-    private String credentialsPath;
+    @Value("${fcm.credentials.json:#{null}}")
+    private String credentialsJson;
 
     @PostConstruct
     public void initialize() {
@@ -36,15 +39,26 @@ public class FcmConfig {
         }
 
         try {
-            ClassPathResource resource = new ClassPathResource(credentialsPath);
+            InputStream serviceAccount;
 
-            if (!resource.exists()) {
-                log.error("FCM credentials file not found: {}", credentialsPath);
-                log.error("Push notifications will not work. Please add {} to src/main/resources/", credentialsPath);
-                return;
+            // 1. 환경변수로 JSON 내용이 제공된 경우 우선 사용 (운영 환경)
+            if (credentialsJson != null && !credentialsJson.isEmpty()) {
+                log.info("Loading FCM credentials from environment variable");
+                serviceAccount = new ByteArrayInputStream(credentialsJson.getBytes());
             }
+            // 2. 파일 경로로 로드 (로컬 환경)
+            else {
+                log.info("Loading FCM credentials from file: {}", DEFAULT_CREDENTIALS_PATH);
+                ClassPathResource resource = new ClassPathResource(DEFAULT_CREDENTIALS_PATH);
 
-            InputStream serviceAccount = resource.getInputStream();
+                if (!resource.exists()) {
+                    log.error("FCM credentials file not found: {}", DEFAULT_CREDENTIALS_PATH);
+                    log.error("Push notifications will not work. Please add {} to src/main/resources/", DEFAULT_CREDENTIALS_PATH);
+                    return;
+                }
+
+                serviceAccount = resource.getInputStream();
+            }
 
             FirebaseOptions options = FirebaseOptions.builder()
                     .setCredentials(GoogleCredentials.fromStream(serviceAccount))

--- a/src/main/java/basakan/fryday/common/exception/auth/UserReregisterNotAllowedException.java
+++ b/src/main/java/basakan/fryday/common/exception/auth/UserReregisterNotAllowedException.java
@@ -1,0 +1,11 @@
+package basakan.fryday.common.exception.auth;
+
+import basakan.fryday.common.ErrorCode;
+import basakan.fryday.common.exception.BusinessException;
+
+public class UserReregisterNotAllowedException extends BusinessException {
+
+    public UserReregisterNotAllowedException() {
+        super(ErrorCode.USER_REREGISTER_NOT_ALLOWED);
+    }
+}

--- a/src/main/java/basakan/fryday/domain/user/User.java
+++ b/src/main/java/basakan/fryday/domain/user/User.java
@@ -7,12 +7,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "users", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"provider", "providerUserId"})
-})
+@Table(name = "users")
 public class User extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
@@ -35,6 +35,8 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role = Role.USER;
+
+    private LocalDateTime withdrawnAt;
 
     @Builder
     private User(AuthProvider provider, String providerUserId, String nickname,
@@ -77,6 +79,14 @@ public class User extends BaseEntity {
 
     public void withdraw() {
         this.accountStatus = AccountStatus.WITHDRAWN;
+        this.withdrawnAt = java.time.LocalDateTime.now();
+    }
+
+    public boolean canReregister() {
+        if (this.withdrawnAt == null) {
+            return true;
+        }
+        return java.time.LocalDateTime.now().isAfter(this.withdrawnAt.plusDays(7));
     }
 
     public void block() {

--- a/src/main/java/basakan/fryday/repository/auth/UserJpaRepository.java
+++ b/src/main/java/basakan/fryday/repository/auth/UserJpaRepository.java
@@ -14,6 +14,8 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByProviderAndProviderUserId(AuthProvider provider, String providerUserId);
 
+    Optional<User> findByProviderAndProviderUserIdAndAccountStatus(AuthProvider provider, String providerUserId, User.AccountStatus accountStatus);
+
     @Query("SELECT u.id FROM User u WHERE u.accountStatus = 'ACTIVE'")
     List<Long> findAllActiveUserIds();
 }

--- a/src/main/java/basakan/fryday/service/user/UserAppService.java
+++ b/src/main/java/basakan/fryday/service/user/UserAppService.java
@@ -26,6 +26,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
+import java.util.Optional;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -113,12 +115,24 @@ public class UserAppService {
             throw new BusinessException(ErrorCode.INTERNAL_AUTH_ERROR);
         }
 
-        User user = userReadService.findByProviderAndProviderUserId(
-                        socialUserInfo.provider(),
-                        socialUserInfo.providerUserId()
-                ).orElseGet(() -> userWriteService.createUser(socialUserInfo));
+        User user;
 
-        validateUserStatus(user);
+        // 1. 탈퇴한 사용자가 있는지 확인 (재가입 처리)
+        Optional<User> withdrawnUser = userReadService.findWithdrawnUserByProviderAndProviderUserId(
+                socialUserInfo.provider(), socialUserInfo.providerUserId());
+
+        if (withdrawnUser.isPresent()) {
+            // 탈퇴한 사용자 재가입 처리 (7일 체크 후 기존 계정 삭제 + 신규 생성)
+            user = userWriteService.handleWithdrawnUserReregister(withdrawnUser.get(), socialUserInfo);
+        } else {
+            // 2. ACTIVE 상태인 사용자 확인 (기존 로그인) 또는 신규 생성
+            user = userReadService.findActiveUserByProviderAndProviderUserId(
+                            socialUserInfo.provider(),
+                            socialUserInfo.providerUserId()
+                    ).orElseGet(() -> userWriteService.createUser(socialUserInfo));
+
+            validateUserStatus(user);
+        }
 
         userDeviceReadService.findByUserIdAndDeviceId(user.getId(), serviceDto.deviceId())
                 .ifPresentOrElse(

--- a/src/main/java/basakan/fryday/service/user/UserReadService.java
+++ b/src/main/java/basakan/fryday/service/user/UserReadService.java
@@ -34,6 +34,16 @@ public class UserReadService {
         return userJpaRepository.findByProviderAndProviderUserId(provider, providerUserId);
     }
 
+    public Optional<User> findActiveUserByProviderAndProviderUserId(AuthProvider provider, String providerUserId) {
+        return userJpaRepository.findByProviderAndProviderUserIdAndAccountStatus(
+                provider, providerUserId, User.AccountStatus.ACTIVE);
+    }
+
+    public Optional<User> findWithdrawnUserByProviderAndProviderUserId(AuthProvider provider, String providerUserId) {
+        return userJpaRepository.findByProviderAndProviderUserIdAndAccountStatus(
+                provider, providerUserId, User.AccountStatus.WITHDRAWN);
+    }
+
     public Optional<Agreement> findAgreementByUser(User user) {
         return agreementRepository.findByUser(user);
     }

--- a/src/main/java/basakan/fryday/service/user/UserWriteService.java
+++ b/src/main/java/basakan/fryday/service/user/UserWriteService.java
@@ -2,6 +2,7 @@ package basakan.fryday.service.user;
 
 import basakan.fryday.common.ErrorCode;
 import basakan.fryday.common.exception.BusinessException;
+import basakan.fryday.common.exception.auth.UserReregisterNotAllowedException;
 import basakan.fryday.domain.user.Agreement;
 import basakan.fryday.domain.user.User;
 import basakan.fryday.repository.auth.AgreementJpaRepository;
@@ -83,5 +84,18 @@ public class UserWriteService {
                 socialUserInfo.providerUserId()
         );
         return userJpaRepository.save(newUser);
+    }
+
+    public User handleWithdrawnUserReregister(User withdrawnUser, SocialUserInfo socialUserInfo) {
+        // 재가입 가능 여부 확인 (7일 경과 여부)
+        if (!withdrawnUser.canReregister()) {
+            throw new UserReregisterNotAllowedException();
+        }
+
+        // 7일이 지났으므로 기존 계정 삭제 후 신규 생성
+        userJpaRepository.delete(withdrawnUser);
+        userJpaRepository.flush(); // 즉시 삭제 반영
+
+        return createUser(socialUserInfo);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,4 +39,4 @@ oauth:
 fcm:
   enabled: ${FCM_ENABLED:false}
   credentials:
-    path: ${FCM_CREDENTIALS_PATH:firebase-adminsdk.json}
+    json: ${FCM_CREDENTIALS_JSON:#{null}}


### PR DESCRIPTION
## 📌 Related Issue
- close: #

## 🚀 Description

  ### 1. 탈퇴 회원 재가입 기능 구현
  - 탈퇴 후 7일 이내 재가입 제한 기능 추가
  - 7일 경과 시 동일 소셜 계정으로 재가입 가능 (신규 회원으로 등록)

  ### 2. User 엔티티 개선
  - `withdrawnAt` 필드 추가하여 탈퇴 시점 기록
  - `canReregister()` 메서드로 재가입 가능 여부 판단
  - `provider + providerUserId` UniqueConstraint 제거하여 재가입 허용

  ### 3. 재가입 로직
  - 탈퇴 회원 로그인 시도 시:
    - **7일 이내**: `USER_REREGISTER_NOT_ALLOWED` 에러 반환 (403)
    - **7일 이후**: 기존 WITHDRAWN 계정 삭제 후 신규 ACTIVE 계정 생성
  - Repository, Service 계층에 상태별 조회 메서드 추가
    - `findActiveUserByProviderAndProviderUserId()`
    - `findWithdrawnUserByProviderAndProviderUserId()`

  ### 4. FCM 설정 개선
  - 환경변수(`FCM_CREDENTIALS_JSON`)로 인증 정보 전달 지원
  - 운영 환경에서 Secret Manager 연동 용이
  - 로컬 환경은 기본 파일 경로(`firebase-adminsdk.json`) 사용

  ### 5. 보안 강화
  - Firebase 인증 파일들을 `.gitignore`에 추가하여 민감 정보 보호

  ## 📝 주요 변경 사항

  ### 도메인
  - `User.java`
    - `withdrawnAt` 필드 추가
    - `withdraw()` 메서드 수정: 탈퇴 시 `withdrawnAt` 자동 설정
    - `canReregister()` 메서드 추가: 7일 경과 여부 확인
    - UniqueConstraint 제거

  ### 에러 처리
  - `ErrorCode.java`: `USER_REREGISTER_NOT_ALLOWED` 추가
  - `UserReregisterNotAllowedException.java`: 새로운 예외 클래스

  ### 서비스 로직
  - `UserJpaRepository.java`
    - `findByProviderAndProviderUserIdAndAccountStatus()` 추가

  - `UserReadService.java`
    - `findActiveUserByProviderAndProviderUserId()` 추가
    - `findWithdrawnUserByProviderAndProviderUserId()` 추가

  - `UserWriteService.java`
    - `handleWithdrawnUserReregister()` 추가: 재가입 처리 로직

  - `UserAppService.java`
    - 소셜 로그인 로직 개선: WITHDRAWN 사용자 우선 확인 후 재가입 처리

  ### 설정
  - `FcmConfig.java`
    - `FCM_CREDENTIALS_JSON` 환경변수 지원 추가
    - 기본 파일 경로를 상수로 관리

  - `application.yml`
    - `fcm.credentials.json` 설정 추가

  - `.gitignore`
    - Firebase 관련 인증 파일 추가

  ## 📢 Notes

 ##  환경변수 설정 (운영 환경)

  ### FCM 활성화
  export FCM_ENABLED=true

  ### Firebase 인증 정보 (JSON 전체 내용)
  export FCM_CREDENTIALS_JSON='{"type":"service_account","project_id":"...",...}'



