### PR TITLE
#58 반복 투두 관련 버그 수정

### DIFF
--- a/src/main/java/basakan/fryday/domain/todo/Recurrence.java
+++ b/src/main/java/basakan/fryday/domain/todo/Recurrence.java
@@ -34,6 +34,7 @@ public class Recurrence extends BaseEntity {
     @Column(nullable = false)
     private RecurrenceType type;
 
+    @Column(columnDefinition = "TEXT")
     private String frequencyValues;
 
     @Column(nullable = false)

--- a/src/main/java/basakan/fryday/domain/todo/RecurrenceException.java
+++ b/src/main/java/basakan/fryday/domain/todo/RecurrenceException.java
@@ -32,7 +32,8 @@ public class RecurrenceException extends BaseEntity {
 
     public enum ExceptionType {
         DELETED,    // 삭제 (반복 투두를 삭제하여 재생성 방지)
-        DETACHED    // 분리(반복에서 제외하고 단건 todo로 변환)
+        DETACHED,   // 분리(반복에서 제외하고 단건 todo로 변환)
+        MOVED       // 이동 (반복 투두를 다른 날짜로 이동하여 해당 날짜에 자동 생성 방지)
     }
 
     @Builder

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceOccurrenceMaterializeService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceOccurrenceMaterializeService.java
@@ -67,7 +67,7 @@ public class RecurrenceOccurrenceMaterializeService {
             return existingTodo;
         }
 
-        // 예외 확인 (DELETED와 DETACHED 제외)
+        // 예외 확인 (DELETED, DETACHED, MOVED 제외)
         List<RecurrenceException> exceptions = recurrenceExceptionRepository.findByRecurrenceId(recurrenceId);
         boolean isException = exceptions.stream()
                 .anyMatch(e -> e.getOccurrenceDate().equals(occurrenceDate));
@@ -147,7 +147,7 @@ public class RecurrenceOccurrenceMaterializeService {
 
         for (Recurrence recurrence : recurrences) {
             try {
-                // 2. 예외 조회 (DELETED와 DETACHED 모두 제외)
+                // 2. 예외 조회 (DELETED, DETACHED, MOVED 모두 제외)
                 List<RecurrenceException> exceptions = recurrenceExceptionRepository
                         .findByRecurrenceId(recurrence.getId());
 

--- a/src/main/java/basakan/fryday/service/todo/TodoService.java
+++ b/src/main/java/basakan/fryday/service/todo/TodoService.java
@@ -43,6 +43,7 @@ public class TodoService {
     private final RecurrenceRepository recurrenceRepository;
     private final RecurrenceExceptionRepository recurrenceExceptionRepository;
     private final RecurrenceOccurrenceMaterializeService materializeService;
+    private final RecurrenceOccurrenceCalculator occurrenceCalculator;
 
     @Transactional
     public TodoResponse saveTodo(TodoSaveRequest request, Long userId) {
@@ -129,11 +130,24 @@ public class TodoService {
         Todo todo = todoRepository.findById(todoId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
 
+        if (!todo.getCategory().getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
+
         if (!todo.getDate().equals(LocalDate.now())) {
             throw new BusinessException(ErrorCode.TODO_NOT_TODAY);
         }
 
-        todo.updateDate(LocalDate.now().plusDays(1));
+        LocalDate tomorrow = LocalDate.now().plusDays(1);
+        LocalDate originalDate = todo.getDate();
+
+        // 반복 투두인 경우, 원래 날짜와 이동할 날짜에 예외 생성
+        if (todo.getRecurrenceId() != null) {
+            preventRecurrenceOccurrenceRecreation(todo.getRecurrenceId(), originalDate, userId);
+            preventDuplicateRecurrenceOccurrence(todo.getRecurrenceId(), tomorrow, userId);
+        }
+
+        todo.updateDate(tomorrow);
 
         return TodoResponse.from(todo);
     }
@@ -143,7 +157,20 @@ public class TodoService {
         Todo todo = todoRepository.findById(todoId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
 
-        todo.updateDate(LocalDate.now());
+        if (!todo.getCategory().getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
+
+        LocalDate today = LocalDate.now();
+        LocalDate originalDate = todo.getDate();
+
+        // 반복 투두인 경우, 원래 날짜와 이동할 날짜에 예외 생성
+        if (todo.getRecurrenceId() != null) {
+            preventRecurrenceOccurrenceRecreation(todo.getRecurrenceId(), originalDate, userId);
+            preventDuplicateRecurrenceOccurrence(todo.getRecurrenceId(), today, userId);
+        }
+
+        todo.updateDate(today);
 
         return TodoResponse.from(todo);
     }
@@ -378,6 +405,75 @@ public class TodoService {
         }
 
         return TodoDetailResponse.from(todo, todoAlarm, recurrence);
+    }
+
+    /**
+     * 반복 투두를 이동한 원래 날짜에 MOVED 예외를 생성하여 재생성을 방지합니다.
+     */
+    private void preventRecurrenceOccurrenceRecreation(Long recurrenceId, LocalDate originalDate, Long userId) {
+        Recurrence recurrence = recurrenceRepository.findById(recurrenceId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        if (recurrence.getUserId() != userId) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
+
+        RecurrenceException existingException = recurrenceExceptionRepository
+                .findByRecurrenceIdAndOccurrenceDate(recurrenceId, originalDate)
+                .orElse(null);
+
+        if (existingException != null) {
+            return;
+        }
+
+        // 원래 날짜에 MOVED 예외 생성하여 재생성 방지
+        RecurrenceException exception = RecurrenceException.builder()
+                .recurrenceId(recurrenceId)
+                .occurrenceDate(originalDate)
+                .type(RecurrenceException.ExceptionType.MOVED)
+                .build();
+        recurrenceExceptionRepository.save(exception);
+    }
+
+    /**
+     * 반복 투두를 특정 날짜로 이동할 때, 해당 날짜에 반복으로 생성될 예정인 경우
+     * MOVED 예외를 생성하여 중복 생성을 방지합니다.
+     */
+    private void preventDuplicateRecurrenceOccurrence(Long recurrenceId, LocalDate targetDate, Long userId) {
+        Recurrence recurrence = recurrenceRepository.findById(recurrenceId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        if (recurrence.getUserId() != userId) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
+
+        RecurrenceException existingException = recurrenceExceptionRepository
+                .findByRecurrenceIdAndOccurrenceDate(recurrenceId, targetDate)
+                .orElse(null);
+
+        if (existingException != null) {
+            return;
+        }
+
+        // 해당 날짜에 반복으로 생성될 예정인지 확인
+        List<RecurrenceException> exceptions = recurrenceExceptionRepository.findByRecurrenceId(recurrenceId);
+        Set<LocalDate> cancelledDates = exceptions.stream()
+                .map(RecurrenceException::getOccurrenceDate)
+                .collect(Collectors.toSet());
+
+        List<LocalDate> occurrenceDates = occurrenceCalculator.calculateOccurrences(
+                recurrence, targetDate, targetDate, cancelledDates
+        );
+
+        // 해당 날짜에 반복으로 생성될 예정이면 MOVED 예외 생성
+        if (!occurrenceDates.isEmpty() && occurrenceDates.contains(targetDate)) {
+            RecurrenceException exception = RecurrenceException.builder()
+                    .recurrenceId(recurrenceId)
+                    .occurrenceDate(targetDate)
+                    .type(RecurrenceException.ExceptionType.MOVED)
+                    .build();
+            recurrenceExceptionRepository.save(exception);
+        }
     }
 
     private String resolveImageCode(CharacterStatus status) {


### PR DESCRIPTION
## 📌 Related Issue
- close: #58

## 🚀 Description
### 문제 상황

1. **YEARLY 반복 설정 시 500 에러**: 1년에 존재하는 모든 홀수월+홀수일 조합 시 `frequencyValues`가 575자 이상 생성되어 VARCHAR(255) 제한 초과
2. **반복 투두 날짜 이동 시 중복 생성**: `today`/`tomorrow` API로 이동 시 원래 날짜에 재생성되거나 이동할 날짜에 중복 생성

## 해결 방법

1. **frequencyValues 컬럼 타입 변경**: `@Column(columnDefinition = "TEXT")` 추가하여 무제한 저장 가능
2. **MOVED 예외 타입 추가**: 반복 투두 이동 시 원래 날짜와 이동할 날짜 모두에 `MOVED` 예외 생성하여 재생성/중복 방지

## 📢 Notes

