### PR TITLE
#58 투두 연동 과정 버그 픽스

### DIFF
--- a/src/main/java/basakan/fryday/common/ErrorCode.java
+++ b/src/main/java/basakan/fryday/common/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     CANNOT_DELETE_FAILED_TODO(HttpStatus.BAD_REQUEST, "타버린(미완료) 투두는 삭제할 수 없습니다."),
     TODO_NOT_TODAY(HttpStatus.BAD_REQUEST, "오늘 날짜의 투두만 내일로 미룰 수 있습니다."),
     PAST_DATE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "과거 날짜로 변경할 수 없습니다."),
+    DUPLICATE_TODO_DATE(HttpStatus.BAD_REQUEST, "해당 날짜에 이미 같은 반복 투두가 존재합니다."),
 
     // Auth
     PROVIDER_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "소셜 토큰이 유효하지 않거나 만료되었습니다."),

--- a/src/main/java/basakan/fryday/controller/todo/response/TodoDetailResponse.java
+++ b/src/main/java/basakan/fryday/controller/todo/response/TodoDetailResponse.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Getter
 @Builder
@@ -50,7 +51,7 @@ public class TodoDetailResponse {
         private final String frequencyValues;
         private final LocalDate startDate;
         private final LocalDate endDate;
-        private final LocalDateTime notificationTime;
+        private final LocalTime notificationTime;
 
         public static RecurrenceInfo from(Recurrence recurrence) {
             if (recurrence == null) {
@@ -62,7 +63,7 @@ public class TodoDetailResponse {
                     .frequencyValues(recurrence.getFrequencyValues())
                     .startDate(recurrence.getStartDate())
                     .endDate(recurrence.getEndDate())
-                    .notificationTime(null) // notificationTime은 LocalTime이므로 필요시 변환
+                    .notificationTime(recurrence.getNotificationTime())
                     .build();
         }
     }

--- a/src/main/java/basakan/fryday/domain/todo/RecurrenceException.java
+++ b/src/main/java/basakan/fryday/domain/todo/RecurrenceException.java
@@ -32,6 +32,7 @@ public class RecurrenceException extends BaseEntity {
 
     public enum ExceptionType {
         DELETED,    // 삭제 (반복 투두를 삭제하여 재생성 방지)
+        MOVED,      // 이동 (반복 투두를 이동하여 재생성 방지)
         DETACHED    // 분리(반복에서 제외하고 단건 todo로 변환)
     }
 

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceOccurrenceCalculator.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceOccurrenceCalculator.java
@@ -25,7 +25,7 @@ public class RecurrenceOccurrenceCalculator {
      * @param recurrence 반복 규칙
      * @param fromDate 시작 날짜 (포함)
      * @param toDate 종료 날짜 (포함)
-     * @param cancelledDates 제외된 날짜 목록 (DELETED 예외)
+     * @param cancelledDates 제외된 날짜 목록 (DELETED, MOVED 예외)
      * @return 발생일 목록 (정렬됨)
      */
     public List<LocalDate> calculateOccurrences(Recurrence recurrence, LocalDate fromDate, LocalDate toDate, Set<LocalDate> cancelledDates) {

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceOccurrenceMaterializeService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceOccurrenceMaterializeService.java
@@ -67,7 +67,7 @@ public class RecurrenceOccurrenceMaterializeService {
             return existingTodo;
         }
 
-        // 예외 확인 (DELETED와 DETACHED 제외)
+        // 예외 확인 (DELETED, MOVED, DETACHED 제외)
         List<RecurrenceException> exceptions = recurrenceExceptionRepository.findByRecurrenceId(recurrenceId);
         boolean isException = exceptions.stream()
                 .anyMatch(e -> e.getOccurrenceDate().equals(occurrenceDate));
@@ -147,7 +147,7 @@ public class RecurrenceOccurrenceMaterializeService {
 
         for (Recurrence recurrence : recurrences) {
             try {
-                // 2. 예외 조회 (DELETED와 DETACHED 모두 제외)
+                // 2. 예외 조회 (DELETED, MOVED, DETACHED 모두 제외)
                 List<RecurrenceException> exceptions = recurrenceExceptionRepository
                         .findByRecurrenceId(recurrence.getId());
 

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
@@ -55,6 +55,14 @@ public class RecurrenceService {
         // 원본 투두에 recurrenceId 연결
         originalTodo.setRecurrenceId(savedRecurrence.getId());
 
+        // Todo 의미 확인 필요
+        RecurrenceException exception = RecurrenceException.builder()
+                .recurrenceId(savedRecurrence.getId())
+                .occurrenceDate(originalTodo.getDate())
+                .type(RecurrenceException.ExceptionType.DELETED)
+                .build();
+        recurrenceExceptionRepository.save(exception);
+
         // 반복 규칙만 저장하고, 투두는 대량 생성하지 않음
         // 가상 회차는 조회 시 동적으로 생성됨
 

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
@@ -17,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -142,6 +144,23 @@ public class RecurrenceService {
             throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
         }
 
+        List<RecurrenceException> detachedExceptions = recurrenceExceptionRepository.findByRecurrenceId(recurrenceId)
+                .stream()
+                .filter(e -> e.getType() == RecurrenceException.ExceptionType.DETACHED && e.getDetachedTodoId() != null)
+                .toList();
+        
+        Set<Long> detachedTodoIds = detachedExceptions.stream()
+                .map(RecurrenceException::getDetachedTodoId)
+                .collect(Collectors.toSet());
+
+        // 기존 반복 투두들 삭제 (분리된 투두 제외)
+        List<Todo> todos = todoRepository.findAllByRecurrenceId(recurrenceId);
+        for (Todo todo : todos) {
+            if (!detachedTodoIds.contains(todo.getId())) {
+                todo.delete();
+            }
+        }
+
         String frequencyValuesStr = (request.getFrequencyValues() != null && !request.getFrequencyValues().isEmpty())
                 ? String.join(",", request.getFrequencyValues())
                 : null;
@@ -153,6 +172,9 @@ public class RecurrenceService {
                 request.getEndDate(),
                 request.getNotificationTime()
         );
+
+        // lastGeneratedDate를 새로운 startDate로 업데이트
+        recurrence.updateLastGeneratedDate(request.getStartDate());
 
         return recurrence;
     }

--- a/src/main/java/basakan/fryday/service/todo/TodoService.java
+++ b/src/main/java/basakan/fryday/service/todo/TodoService.java
@@ -43,6 +43,7 @@ public class TodoService {
     private final RecurrenceRepository recurrenceRepository;
     private final RecurrenceExceptionRepository recurrenceExceptionRepository;
     private final RecurrenceOccurrenceMaterializeService materializeService;
+    private final RecurrenceOccurrenceCalculator occurrenceCalculator;
 
     @Transactional
     public TodoResponse saveTodo(TodoSaveRequest request, Long userId) {
@@ -129,11 +130,24 @@ public class TodoService {
         Todo todo = todoRepository.findById(todoId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
 
+        if (!todo.getCategory().getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
+
         if (!todo.getDate().equals(LocalDate.now())) {
             throw new BusinessException(ErrorCode.TODO_NOT_TODAY);
         }
 
-        todo.updateDate(LocalDate.now().plusDays(1));
+        LocalDate tomorrow = LocalDate.now().plusDays(1);
+        LocalDate originalDate = todo.getDate();
+
+        // 반복 투두인 경우, 원래 날짜와 이동할 날짜에 예외 생성
+        if (todo.getRecurrenceId() != null) {
+            preventRecurrenceOccurrenceRecreation(todo.getRecurrenceId(), originalDate, userId);
+            preventDuplicateRecurrenceOccurrence(todo.getRecurrenceId(), tomorrow, userId);
+        }
+
+        todo.updateDate(tomorrow);
 
         return TodoResponse.from(todo);
     }
@@ -143,7 +157,20 @@ public class TodoService {
         Todo todo = todoRepository.findById(todoId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
 
-        todo.updateDate(LocalDate.now());
+        if (!todo.getCategory().getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
+
+        LocalDate today = LocalDate.now();
+        LocalDate originalDate = todo.getDate();
+
+        // 반복 투두인 경우, 원래 날짜와 이동할 날짜에 예외 생성
+        if (todo.getRecurrenceId() != null) {
+            preventRecurrenceOccurrenceRecreation(todo.getRecurrenceId(), originalDate, userId);
+            preventDuplicateRecurrenceOccurrence(todo.getRecurrenceId(), today, userId);
+        }
+
+        todo.updateDate(today);
 
         return TodoResponse.from(todo);
     }
@@ -175,17 +202,26 @@ public class TodoService {
                 throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
             }
 
-            // DETACHED 예외가 이미 존재하는지 확인
+            // 이미 예외가 존재하는지 확인
             RecurrenceException existingException = recurrenceExceptionRepository
                     .findByRecurrenceIdAndOccurrenceDate(recurrenceId, occurrenceDate)
                     .orElse(null);
 
+            // DETACHED 예외가 이미 존재하면 이미 분리된 투두
             if (existingException != null && existingException.getType() == RecurrenceException.ExceptionType.DETACHED) {
                 throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
             }
 
-            // 날짜 변경
+            // DELETED나 MOVED 예외가 이미 존재하면 중복 키 오류를 방지하기 위해 예외 발생
+            // (같은 날짜에 이미 예외가 존재하는데 DETACHED 예외를 생성하려고 하면 unique constraint 위반)
+            if (existingException != null) {
+                throw new BusinessException(ErrorCode.DUPLICATE_TODO_DATE);
+            }
+
+            // 날짜 변경 시 중복 체크
             if (!occurrenceDate.equals(newDate)) {
+                preventDuplicateRecurrenceOccurrence(recurrenceId, newDate, userId);
+                
                 todo.updateDate(newDate);
                 // displayOrder 재계산
                 Long maxOrder = todoRepository.findMaxDisplayOrder(userId, newDate);
@@ -378,6 +414,87 @@ public class TodoService {
         }
 
         return TodoDetailResponse.from(todo, todoAlarm, recurrence);
+    }
+
+    /**
+     * 반복 투두를 이동한 원래 날짜에 MOVED 예외를 생성하여 재생성을 방지합니다.
+     */
+    private void preventRecurrenceOccurrenceRecreation(Long recurrenceId, LocalDate originalDate, Long userId) {
+        Recurrence recurrence = recurrenceRepository.findById(recurrenceId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        if (recurrence.getUserId() != userId) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
+
+        RecurrenceException existingException = recurrenceExceptionRepository
+                .findByRecurrenceIdAndOccurrenceDate(recurrenceId, originalDate)
+                .orElse(null);
+
+        if (existingException != null) {
+            return;
+        }
+
+        // 원래 날짜에 MOVED 예외 생성하여 재생성 방지
+        RecurrenceException exception = RecurrenceException.builder()
+                .recurrenceId(recurrenceId)
+                .occurrenceDate(originalDate)
+                .type(RecurrenceException.ExceptionType.MOVED)
+                .build();
+        recurrenceExceptionRepository.save(exception);
+    }
+
+    /**
+     * 반복 투두를 특정 날짜로 이동할 때, 해당 날짜에 이미 같은 반복 투두가 존재하거나
+     * 반복 주기와 겹치면 예외를 발생시키거나 MOVED 예외를 생성하여 중복 생성을 방지합니다.
+     */
+    private void preventDuplicateRecurrenceOccurrence(Long recurrenceId, LocalDate targetDate, Long userId) {
+        Recurrence recurrence = recurrenceRepository.findById(recurrenceId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        if (recurrence.getUserId() != userId) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
+
+        // 해당 날짜에 이미 같은 recurrenceId를 가진 투두가 존재하는지 확인
+        List<Todo> existingTodos = todoRepository.findAllByUserIdAndDate(userId, targetDate);
+        boolean hasExistingRecurrenceTodo = existingTodos.stream()
+                .anyMatch(todo -> todo.getRecurrenceId() != null
+                        && todo.getRecurrenceId().equals(recurrenceId)
+                        && todo.getDeletedAt() == null);
+
+        if (hasExistingRecurrenceTodo) {
+            throw new BusinessException(ErrorCode.DUPLICATE_TODO_DATE);
+        }
+
+        // 이미 예외가 존재하는지 확인
+        RecurrenceException existingException = recurrenceExceptionRepository
+                .findByRecurrenceIdAndOccurrenceDate(recurrenceId, targetDate)
+                .orElse(null);
+
+        if (existingException != null) {
+            return;
+        }
+
+        // 해당 날짜에 반복으로 생성될 예정인지 확인
+        List<RecurrenceException> exceptions = recurrenceExceptionRepository.findByRecurrenceId(recurrenceId);
+        Set<LocalDate> cancelledDates = exceptions.stream()
+                .map(RecurrenceException::getOccurrenceDate)
+                .collect(Collectors.toSet());
+
+        List<LocalDate> occurrenceDates = occurrenceCalculator.calculateOccurrences(
+                recurrence, targetDate, targetDate, cancelledDates
+        );
+
+        // 해당 날짜에 반복으로 생성될 예정이면 MOVED 예외 생성
+        if (!occurrenceDates.isEmpty() && occurrenceDates.contains(targetDate)) {
+            RecurrenceException exception = RecurrenceException.builder()
+                    .recurrenceId(recurrenceId)
+                    .occurrenceDate(targetDate)
+                    .type(RecurrenceException.ExceptionType.MOVED)
+                    .build();
+            recurrenceExceptionRepository.save(exception);
+        }
     }
 
     private String resolveImageCode(CharacterStatus status) {

--- a/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
@@ -914,7 +914,7 @@ class TodoControllerTest extends RestDocsSupport {
                 .frequencyValues("MONDAY,WEDNESDAY,FRIDAY")
                 .startDate(LocalDate.of(2026, 1, 1))
                 .endDate(LocalDate.of(2026, 12, 31))
-                .notificationTime(null) // DTO 로직상 null
+                .notificationTime(null) // 테스트 데이터 (null 가능)
                 .build();
 
         TodoDetailResponse response = TodoDetailResponse.builder()


### PR DESCRIPTION
## 📌 Related Issue
- close: #58 

## 🚀 Description
### 1. 날짜 변경 시 투두 중복 생성 방지(추가 논의 필요한 부분임)

#### 문제점
- 반복 설정으로 생성된 투두를 날짜 변경 API(`/{todoId}/tomorrow`, `/{todoId}/today`, `/{todoId}/date`)로 변경할 때, 이동할 날짜에 이미 같은 반복 투두가 존재하거나 반복 주기와 겹치는 경우 중복으로 생성되는 문제가 발생
- 예시: 1월 18일 원본 투두(반복 설정)가 있고, 1월 19일 반복 투두를 "오늘 하기" API로 1월 18일로 이동하면 같은 날짜에 중복 투두가 생성되는 문제

#### 해결 방법
- `RecurrenceException.ExceptionType`에 `MOVED` 타입 추가: 반복 투두를 이동한 경우를 구분하기 위한 예외 타입
- `DUPLICATE_TODO_DATE` 에러 코드 추가: 중복 투두 생성 시도 시 명확한 에러 메시지 제공
- `preventDuplicateRecurrenceOccurrence()` 메서드 추가:
  - 이동할 날짜에 이미 같은 `recurrenceId`를 가진 투두가 존재하는지 확인
  - 존재하면 `DUPLICATE_TODO_DATE` 예외 발생
  - 반복 주기와 겹치면 `MOVED` 예외 생성하여 중복 생성을 방지
- `preventRecurrenceOccurrenceRecreation()` 메서드 추가: 원래 날짜에 `MOVED` 예외를 생성하여 재생성 방지
- 날짜 변경 API(`postponeToTomorrow`, `moveToToday`, `updateTodoDate`)에 중복 체크 로직 적용

---

### 2. 반복 규칙 수정 시 기존 반복 투두 삭제

#### 문제점
- 반복 규칙 수정 API(`PATCH /api/todos/recurrence/{recurrenceId}`)로 규칙을 수정하면 규칙은 변경되지만, 기존에 반복 설정으로 생성된 투두들이 삭제되지 않고 계속 존재하는 문제가 존재
- 새로운 규칙에 맞춰서만 투두가 생성되어 기존 투두와 새 투두가 혼재하는 상황

#### 해결 방법
- `updateRecurrence()` 메서드에 기존 반복 투두 삭제 로직 추가:
  - `DETACHED` 예외가 있는 투두(분리된 투두)는 제외하고 삭제
  - 사용자가 분리한 투두는 유지하여 사용자 의도 보존
  - 나머지 반복 투두들은 soft delete 처리
- `lastGeneratedDate`를 새로운 `startDate`로 업데이트하여 새로운 규칙에 맞게 재생성되도록 개선

---

### 3. notificationTime 필드 응답 수정

#### 문제점
- 투두 단건 조회 API와 반복 규칙 수정 API 응답에서 `notificationTime` 필드가 항상 `null`로 반환되는 문제가 존재
- `Recurrence` 엔티티의 `notificationTime`은 `LocalTime` 타입인데, 응답 DTO에서는 `LocalDateTime` 타입으로 정의되어 있었고, 매핑 시 하드코딩된 `null` 값을 사용하고 있었음.

#### 해결 방법
- `TodoDetailResponse.RecurrenceInfo`의 `notificationTime` 필드 타입을 `LocalDateTime`에서 `LocalTime`으로 변경하여 엔티티와 일치시킴
- `RecurrenceInfo.from()` 메서드에서 `recurrence.getNotificationTime()`을 실제로 매핑하도록 수정


## 📢 Notes

