### PR TITLE
#64 투두 관련 기획 변경에 따른 기능 변경

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -432,10 +432,10 @@ include::{snippets}/todo-recurrence-update/http-response.adoc[]
 
 
 
-=== 반복 설정 투두 삭제(반복 해제)
-`DELETE /api/todos/recurrence/{recurrenceId}`
+=== 반복 해제
+`DELETE /api/todos/{todoId}/recurrence`
 
-반복 설정이 된 투두를 전체 삭제합니다.
+해당 투두를 제외하고, 원본 투두를 포함한 나머지 반복 투두를 삭제합니다. 해당 투두는 반복에서 해제되어 단건 투두로 유지됩니다.
 
 ==== 경로 파라미터
 include::{snippets}/todo-recurrence-delete/path-parameters.adoc[]

--- a/src/main/java/basakan/fryday/common/ErrorCode.java
+++ b/src/main/java/basakan/fryday/common/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     TODO_NOT_TODAY(HttpStatus.BAD_REQUEST, "오늘 날짜의 투두만 내일로 미룰 수 있습니다."),
     PAST_DATE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "과거 날짜로 변경할 수 없습니다."),
     DUPLICATE_TODO_DATE(HttpStatus.BAD_REQUEST, "해당 날짜에 이미 같은 반복 투두가 존재합니다."),
+    NOT_RECURRING_TODO(HttpStatus.BAD_REQUEST, "반복 설정된 투두가 아닙니다."),
 
     // Auth
     PROVIDER_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "소셜 토큰이 유효하지 않거나 만료되었습니다."),

--- a/src/main/java/basakan/fryday/controller/todo/TodoController.java
+++ b/src/main/java/basakan/fryday/controller/todo/TodoController.java
@@ -148,11 +148,11 @@ public class TodoController {
         return ApiResponse.success(response, "반복 투두가 생성되었습니다.");
     }
 
-    @DeleteMapping("/recurrence/{recurrenceId}")
-    public ApiResponse<Void> deleteRecurrence(@PathVariable Long recurrenceId,
+    @DeleteMapping("/{todoId}/recurrence")
+    public ApiResponse<Void> deleteRecurrence(@PathVariable Long todoId,
                                               @AuthenticationPrincipal Long userId) {
-        recurrenceService.deleteRecurrence(recurrenceId, userId);
-        return ApiResponse.success(null, "반복 투두가 모두 해제(삭제)되었습니다.");
+        recurrenceService.deleteRecurrence(todoId, userId);
+        return ApiResponse.success(null, "반복 해제되었습니다. 해당 투두만 남고 나머지 반복 투두가 삭제됩니다.");
     }
 
     // 현재 기획상은 미존재, 나중에 들어올 것 같음

--- a/src/main/java/basakan/fryday/controller/todo/request/RecurrenceCreateRequest.java
+++ b/src/main/java/basakan/fryday/controller/todo/request/RecurrenceCreateRequest.java
@@ -24,7 +24,6 @@ public class RecurrenceCreateRequest {
     private List<String> frequencyValues;
 
     @NotNull(message = "시작일은 필수입니다.")
-    @FutureOrPresent(message = "과거 날짜로는 반복 설정을 할 수 없습니다.")
     private LocalDate startDate;
 
     private LocalDate endDate;

--- a/src/main/java/basakan/fryday/controller/todo/request/RecurrenceUpdateRequest.java
+++ b/src/main/java/basakan/fryday/controller/todo/request/RecurrenceUpdateRequest.java
@@ -20,7 +20,6 @@ public class RecurrenceUpdateRequest {
     private List<String> frequencyValues;
 
     @NotNull(message = "시작일은 필수입니다.")
-    @FutureOrPresent(message = "과거 날짜로는 반복 설정을 수정할 수 없습니다.")
     private LocalDate startDate;
 
     private LocalDate endDate;

--- a/src/main/java/basakan/fryday/controller/todo/request/TodoSaveRequest.java
+++ b/src/main/java/basakan/fryday/controller/todo/request/TodoSaveRequest.java
@@ -22,7 +22,6 @@ public class TodoSaveRequest {
     @NotNull
     private Long categoryId;
 
-    @FutureOrPresent(message = "과거 날짜로는 투두를 생성할 수 없습니다.")
     private LocalDate date;
 
     public TodoSaveRequest(String description, Long categoryId, LocalDate date) {

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
@@ -71,9 +71,24 @@ public class RecurrenceService {
         return TodoResponse.from(originalTodo);
     }
 
-    // 반복 해제
+    /**
+     * 반복 해제: 해당 투두만 남기고, 원본 투두를 포함한 나머지 반복 투두를 삭제
+     */
     @Transactional
-    public void deleteRecurrence(Long recurrenceId, Long userId) {
+    public void deleteRecurrence(Long todoId, Long userId) {
+        Todo keepTodo = todoRepository.findById(todoId)
+                .filter(t -> !t.isDeleted())
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        if (!keepTodo.getCategory().getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
+
+        Long recurrenceId = keepTodo.getRecurrenceId();
+        if (recurrenceId == null) {
+            throw new BusinessException(ErrorCode.NOT_RECURRING_TODO);
+        }
+
         Recurrence recurrence = recurrenceRepository.findById(recurrenceId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
 
@@ -81,17 +96,18 @@ public class RecurrenceService {
             throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
         }
 
-        // 반복으로 생성된 모든 Todo 삭제 (soft delete)
         List<Todo> todos = todoRepository.findAllByRecurrenceId(recurrenceId);
         for (Todo todo : todos) {
-            todo.delete();
+            if (todo.getId().equals(todoId)) {
+                todo.setRecurrenceId(null);
+            } else {
+                todo.delete();
+            }
         }
 
-        // 관련 예외 삭제
         List<RecurrenceException> exceptions = recurrenceExceptionRepository.findByRecurrenceId(recurrenceId);
         recurrenceExceptionRepository.deleteAll(exceptions);
 
-        // 반복 규칙 삭제
         recurrenceRepository.delete(recurrence);
     }
 

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
@@ -30,10 +30,6 @@ public class RecurrenceService {
 
     @Transactional
     public TodoResponse createRecurrence(Long userId, RecurrenceCreateRequest request) {
-        if (request.getStartDate().isBefore(LocalDate.now())) {
-            throw new BusinessException(ErrorCode.PAST_DATE_NOT_ALLOWED);
-        }
-
         Todo originalTodo = todoRepository.findById(request.getTodoId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
 
@@ -148,11 +144,6 @@ public class RecurrenceService {
     // 반복 규칙 수정
     @Transactional
     public Recurrence updateRecurrence(Long recurrenceId, RecurrenceUpdateRequest request, Long userId) {
-        // 과거 날짜 검증
-        if (request.getStartDate().isBefore(LocalDate.now())) {
-            throw new BusinessException(ErrorCode.PAST_DATE_NOT_ALLOWED);
-        }
-
         Recurrence recurrence = recurrenceRepository.findById(recurrenceId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
 

--- a/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
@@ -302,22 +302,21 @@ class TodoControllerTest extends RestDocsSupport {
     }
 
     @Test
-    @DisplayName("반복 투두 전체 삭제 API")
+    @DisplayName("반복 해제 API")
     void deleteRecurrence() throws Exception {
         // given
-        Long recurrenceId = 1L;
+        Long todoId = 1L;
 
-        // Mocking: void 메서드이므로 willDoNothing 사용
         willDoNothing().given(recurrenceService).deleteRecurrence(anyLong(), anyLong());
 
         // when & then
-        mockMvc.perform(delete("/api/todos/recurrence/{recurrenceId}", recurrenceId)
+        mockMvc.perform(delete("/api/todos/{todoId}/recurrence", todoId)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("todo-recurrence-delete",
                         pathParameters(
-                                parameterWithName("recurrenceId").description("삭제할 반복 투두 규칙 ID (반복 규칙과 반복으로 생성된 모든 투두가 삭제됩니다)")
+                                parameterWithName("todoId").description("반복 해제를 실행하는 투두 ID. 이 투두만 남고, 원본 포함 나머지 반복 투두는 삭제됩니다.")
                         ),
                         responseFields(
                                 fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),

--- a/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
@@ -118,7 +118,7 @@ class TodoControllerTest extends RestDocsSupport {
                         requestFields(
                                 fieldWithPath("description").type(JsonFieldType.STRING).description("할 일 내용"),
                                 fieldWithPath("categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
-                                fieldWithPath("date").type(JsonFieldType.STRING).description("투두 날짜 (YYYY-MM-DD, optional, 미래 날짜 가능, null이면 오늘 날짜)").optional()
+                                fieldWithPath("date").type(JsonFieldType.STRING).description("투두 날짜 (YYYY-MM-DD, optional, 과거, 미래 날짜 모두 가능, null이면 오늘 날짜)").optional()
                         ),
                         responseFields(
                                 fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),


### PR DESCRIPTION
## 📌 Related Issue
- close: #64 

## 🚀 Description

### 1. 투두 생성 – 과거 날짜 허용
- `TodoSaveRequest.date`에서 `@FutureOrPresent` 제거

### 2. 반복 해제 – 해당 투두만 남기고 나머지 삭제
- **API:** `DELETE /api/todos/recurrence/{recurrenceId}` → `DELETE /api/todos/{todoId}/recurrence`
- **동작:** `todoId` 투두만 남기고, 원본 포함 나머지 반복 투두 삭제. 해당 투두는 `recurrenceId` 제거 후 단건으로 유지
- `NOT_RECURRING_TODO` 에러 코드 추가 (반복 미설정 투두에 대한 반복 해제 시)

### 3. 반복 설정·규칙 수정 – 시작일 과거 허용
- `RecurrenceCreateRequest.startDate`, `RecurrenceUpdateRequest.startDate`에서 `@FutureOrPresent` 제거
- 반복 생성·수정 시 시작일을 과거로 설정 가능


## 📢 Notes

