### PR TITLE
#65 반복 투두 날짜 이동 기획 변경 반영

### DIFF
--- a/src/main/java/basakan/fryday/service/todo/TodoService.java
+++ b/src/main/java/basakan/fryday/service/todo/TodoService.java
@@ -222,16 +222,10 @@ public class TodoService {
                 throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
             }
 
-            // DELETED나 MOVED 예외가 이미 존재하면 중복 키 오류를 방지하기 위해 예외 발생
-            // (같은 날짜에 이미 예외가 존재하는데 DETACHED 예외를 생성하려고 하면 unique constraint 위반)
-            if (existingException != null) {
-                throw new BusinessException(ErrorCode.DUPLICATE_TODO_DATE);
-            }
+            boolean shouldCreateDetached = (existingException == null);
 
-            // 날짜 변경 시 중복 체크
+            // 날짜 변경: 대상 날짜에 이미 반복 투두가 있어도 이동 허용.
             if (!occurrenceDate.equals(newDate)) {
-                preventDuplicateRecurrenceOccurrence(recurrenceId, newDate, userId);
-                
                 todo.updateDate(newDate);
                 // displayOrder 재계산
                 Long maxOrder = todoRepository.findMaxDisplayOrder(userId, newDate);
@@ -241,15 +235,15 @@ public class TodoService {
 
             todo.setRecurrenceId(null);
 
-            // DETACHED 예외 생성
-            RecurrenceException exception = RecurrenceException.builder()
-                    .recurrenceId(recurrenceId)
-                    .occurrenceDate(occurrenceDate)
-                    .type(RecurrenceException.ExceptionType.DETACHED)
-                    .detachedTodoId(todo.getId())
-                    .build();
-
-            recurrenceExceptionRepository.save(exception);
+            if (shouldCreateDetached) {
+                RecurrenceException exception = RecurrenceException.builder()
+                        .recurrenceId(recurrenceId)
+                        .occurrenceDate(occurrenceDate)
+                        .type(RecurrenceException.ExceptionType.DETACHED)
+                        .detachedTodoId(todo.getId())
+                        .build();
+                recurrenceExceptionRepository.save(exception);
+            }
 
             return TodoResponse.from(todo);
         }
@@ -443,32 +437,6 @@ public class TodoService {
                 .type(RecurrenceException.ExceptionType.MOVED)
                 .build();
         recurrenceExceptionRepository.save(exception);
-    }
-
-    /**
-     * 반복 투두를 특정 날짜로 이동할 때, 해당 날짜에 이미 같은 반복 투두가 존재하거나
-     * 반복 주기와 겹치면 예외를 발생시키거나 MOVED 예외를 생성하여 중복 생성을 방지합니다.
-     */
-    private void preventDuplicateRecurrenceOccurrence(Long recurrenceId, LocalDate targetDate, Long userId) {
-        Recurrence recurrence = recurrenceRepository.findById(recurrenceId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
-
-        if (recurrence.getUserId() != userId) {
-            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
-        }
-
-        // 해당 날짜에 이미 같은 recurrenceId를 가진 투두가 존재하는지 확인
-        List<Todo> existingTodos = todoRepository.findAllByUserIdAndDate(userId, targetDate);
-        boolean hasExistingRecurrenceTodo = existingTodos.stream()
-                .anyMatch(todo -> todo.getRecurrenceId() != null
-                        && todo.getRecurrenceId().equals(recurrenceId)
-                        && todo.getDeletedAt() == null);
-
-        if (hasExistingRecurrenceTodo) {
-            throw new BusinessException(ErrorCode.DUPLICATE_TODO_DATE);
-        }
-
-        ensureMovedExceptionIfInSchedule(recurrenceId, targetDate, recurrence);
     }
 
     private void ensureMovedExceptionIfInSchedule(Long recurrenceId, LocalDate targetDate, Recurrence recurrence) {

--- a/src/main/java/basakan/fryday/service/todo/TodoService.java
+++ b/src/main/java/basakan/fryday/service/todo/TodoService.java
@@ -141,10 +141,15 @@ public class TodoService {
         LocalDate tomorrow = LocalDate.now().plusDays(1);
         LocalDate originalDate = todo.getDate();
 
-        // 반복 투두인 경우, 원래 날짜와 이동할 날짜에 예외 생성
+        // 반복 투두인 경우: 원래 날짜에 재생성 방지, 기존 투두 삭제 없이 옮기기만
         if (todo.getRecurrenceId() != null) {
             preventRecurrenceOccurrenceRecreation(todo.getRecurrenceId(), originalDate, userId);
-            preventDuplicateRecurrenceOccurrence(todo.getRecurrenceId(), tomorrow, userId);
+            Recurrence recurrence = recurrenceRepository.findById(todo.getRecurrenceId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+            if (recurrence.getUserId() != userId) {
+                throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+            }
+            ensureMovedExceptionIfInSchedule(todo.getRecurrenceId(), tomorrow, recurrence);
         }
 
         todo.updateDate(tomorrow);
@@ -164,10 +169,15 @@ public class TodoService {
         LocalDate today = LocalDate.now();
         LocalDate originalDate = todo.getDate();
 
-        // 반복 투두인 경우, 원래 날짜와 이동할 날짜에 예외 생성
+        // 반복 투두인 경우: 원래 날짜에 재생성 방지, 기존 투두 삭제 없이 옮기기만
         if (todo.getRecurrenceId() != null) {
             preventRecurrenceOccurrenceRecreation(todo.getRecurrenceId(), originalDate, userId);
-            preventDuplicateRecurrenceOccurrence(todo.getRecurrenceId(), today, userId);
+            Recurrence recurrence = recurrenceRepository.findById(todo.getRecurrenceId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+            if (recurrence.getUserId() != userId) {
+                throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+            }
+            ensureMovedExceptionIfInSchedule(todo.getRecurrenceId(), today, recurrence);
         }
 
         todo.updateDate(today);
@@ -458,7 +468,10 @@ public class TodoService {
             throw new BusinessException(ErrorCode.DUPLICATE_TODO_DATE);
         }
 
-        // 이미 예외가 존재하는지 확인
+        ensureMovedExceptionIfInSchedule(recurrenceId, targetDate, recurrence);
+    }
+
+    private void ensureMovedExceptionIfInSchedule(Long recurrenceId, LocalDate targetDate, Recurrence recurrence) {
         RecurrenceException existingException = recurrenceExceptionRepository
                 .findByRecurrenceIdAndOccurrenceDate(recurrenceId, targetDate)
                 .orElse(null);
@@ -467,7 +480,6 @@ public class TodoService {
             return;
         }
 
-        // 해당 날짜에 반복으로 생성될 예정인지 확인
         List<RecurrenceException> exceptions = recurrenceExceptionRepository.findByRecurrenceId(recurrenceId);
         Set<LocalDate> cancelledDates = exceptions.stream()
                 .map(RecurrenceException::getOccurrenceDate)
@@ -477,7 +489,6 @@ public class TodoService {
                 recurrence, targetDate, targetDate, cancelledDates
         );
 
-        // 해당 날짜에 반복으로 생성될 예정이면 MOVED 예외 생성
         if (!occurrenceDates.isEmpty() && occurrenceDates.contains(targetDate)) {
             RecurrenceException exception = RecurrenceException.builder()
                     .recurrenceId(recurrenceId)


### PR DESCRIPTION
## 📌 Related Issue
- close: #65

## 🚀 Description
## 기획 변경
- **오늘 하기 / 내일로 미루기 / 날짜 변경** 시, 대상 날짜에 이미 같은 반복 투두가 있거나 반복 주기와 겹쳐도 이동 가능하도록 변경

## 1. 오늘 하기(PATCH /{todoId}/today)/내일로 미루기(PATCH /{todoId}/tomorrow)
- 대상이 반복 주기와 겹치거나 해당 날짜에 반복 투두가 있어도 이동 허용
- 기존 투두는 삭제하지 않고, 옮기는 투두만 해당 날짜로 이동 (필요 시 MOVED 예외만 추가)

### 2. 날짜 변경 `PATCH /{todoId}/date`
- 대상 날짜에 반복 투두가 있어도 이동 허용
- 원래 날짜에 DELETED/MOVED 예외가 이미 있어도 이동 허용 (DETACHED는 기존 예외가 없을 때만 생성)
- `preventDuplicateRecurrenceOccurrence` 제거, `ensureMovedExceptionIfInSchedule`만 사용하도록 정리



## 📢 Notes

