### PR TITLE
최초 회원가입 플로우 수정

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -24,24 +24,28 @@
 |===
 |상태 |설명 |다음 화면
 
-|`NEEDS_NICKNAME`
-|닉네임 설정이 필요한 상태 (최초 가입 첫 단계)
-|닉네임 설정 화면
-
 |`NEEDS_AGREEMENT`
-|개인정보 수집 및 이용 동의가 필요한 상태 (두 번째 단계)
+|개인정보 수집 및 이용 동의가 필요한 상태 (최초 가입 첫 단계)
 |개인정보 동의 화면
+
+|`NEEDS_NICKNAME`
+|닉네임 설정이 필요한 상태 (두 번째 단계)
+|닉네임 설정 화면
 
 |`NEEDS_ONBOARDING`
 |온보딩 화면 확인이 필요한 상태 (세 번째 단계)
 |온보딩 화면
+
+|`NEEDS_MARKETING`
+|마케팅 수신 동의가 필요한 상태 (네 번째 단계)
+|마케팅 수신 동의 화면
 
 |`COMPLETED`
 |모든 설정이 완료된 상태 (정상 로그인)
 |메인 화면
 |===
 
-NOTE: 온보딩은 NEEDS_NICKNAME → NEEDS_AGREEMENT → NEEDS_ONBOARDING → COMPLETED 순서로 진행됩니다.
+NOTE: 온보딩은 NEEDS_AGREEMENT → NEEDS_NICKNAME → NEEDS_ONBOARDING → NEEDS_MARKETING → COMPLETED 순서로 진행됩니다.
 
 ==== 요청 필드
 include::{snippets}/user-social-login/request-fields.adoc[]
@@ -68,17 +72,21 @@ include::{snippets}/user-social-login/response-fields.adoc[]
 |===
 |상태 |설명 |다음 화면
 
-|`NEEDS_NICKNAME`
-|닉네임 설정이 필요한 상태 (최초 가입 첫 단계)
-|닉네임 설정 화면
-
 |`NEEDS_AGREEMENT`
-|개인정보 수집 및 이용 동의가 필요한 상태 (두 번째 단계)
+|개인정보 수집 및 이용 동의가 필요한 상태 (최초 가입 첫 단계)
 |개인정보 동의 화면
+
+|`NEEDS_NICKNAME`
+|닉네임 설정이 필요한 상태 (두 번째 단계)
+|닉네임 설정 화면
 
 |`NEEDS_ONBOARDING`
 |온보딩 화면 확인이 필요한 상태 (세 번째 단계)
 |온보딩 화면
+
+|`NEEDS_MARKETING`
+|마케팅 수신 동의가 필요한 상태 (네 번째 단계)
+|마케팅 수신 동의 화면
 
 |`COMPLETED`
 |모든 설정이 완료된 상태 (정상 로그인)
@@ -126,24 +134,7 @@ include::{snippets}/user-nickname-check-unavailable/http-response.adoc[]
 ===== 응답 필드
 include::{snippets}/user-nickname-check-unavailable/response-fields.adoc[]
 
-=== 닉네임 설정 (온보딩 1단계)
-`POST /api/users/me/nickname`
-
-닉네임을 최초로 설정합니다. (인증 필요)
-
-==== 요청 필드
-include::{snippets}/user-nickname-set/request-fields.adoc[]
-
-==== HTTP 요청 예시
-include::{snippets}/user-nickname-set/http-request.adoc[]
-
-==== HTTP 응답 예시
-include::{snippets}/user-nickname-set/http-response.adoc[]
-
-==== 응답 필드
-include::{snippets}/user-nickname-set/response-fields.adoc[]
-
-=== 개인정보 동의 (온보딩 2단계)
+=== 개인정보 동의 (온보딩 1단계)
 `POST /api/users/me/consent`
 
 개인정보 수집 및 이용에 동의합니다. (인증 필요)
@@ -160,6 +151,23 @@ include::{snippets}/user-consent/http-response.adoc[]
 ==== 응답 필드
 include::{snippets}/user-consent/response-fields.adoc[]
 
+=== 닉네임 설정 (온보딩 2단계)
+`POST /api/users/me/nickname`
+
+닉네임을 최초로 설정합니다. (인증 필요)
+
+==== 요청 필드
+include::{snippets}/user-nickname-set/request-fields.adoc[]
+
+==== HTTP 요청 예시
+include::{snippets}/user-nickname-set/http-request.adoc[]
+
+==== HTTP 응답 예시
+include::{snippets}/user-nickname-set/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/user-nickname-set/response-fields.adoc[]
+
 === 온보딩 완료 (온보딩 3단계)
 `POST /api/users/me/onboarding`
 
@@ -173,6 +181,23 @@ include::{snippets}/user-onboarding/http-response.adoc[]
 
 ==== 응답 필드
 include::{snippets}/user-onboarding/response-fields.adoc[]
+
+=== 마케팅 수신 동의 (온보딩 4단계)
+`PATCH /api/users/me/marketing`
+
+마케팅 정보 수신 동의를 설정합니다. (인증 필요)
+
+==== 요청 필드
+include::{snippets}/user-marketing-consent/request-fields.adoc[]
+
+==== HTTP 요청 예시
+include::{snippets}/user-marketing-consent/http-request.adoc[]
+
+==== HTTP 응답 예시
+include::{snippets}/user-marketing-consent/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/user-marketing-consent/response-fields.adoc[]
 
 === 닉네임 수정
 `PATCH /api/users/me/nickname`

--- a/src/main/java/basakan/fryday/common/ErrorCode.java
+++ b/src/main/java/basakan/fryday/common/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
     INVALID_NICKNAME_LENGTH(HttpStatus.BAD_REQUEST, "닉네임은 2자 이상 10자 이하로 입력해주세요."),
     FCM_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "FCM 토큰이 유효하지 않은 형식입니다."),
+    AGREEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "동의 정보를 찾을 수 없습니다."),
 
     // Device
     DEVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "디바이스를 찾을 수 없습니다."),

--- a/src/main/java/basakan/fryday/controller/user/UserController.java
+++ b/src/main/java/basakan/fryday/controller/user/UserController.java
@@ -8,6 +8,7 @@ import basakan.fryday.controller.user.response.NicknameCheckResponse;
 import basakan.fryday.controller.user.response.RefreshTokenResponse;
 import basakan.fryday.controller.user.request.RefreshTokenRequest;
 import basakan.fryday.controller.user.request.ConsentRequest;
+import basakan.fryday.controller.user.request.MarketingConsentRequest;
 import basakan.fryday.controller.user.request.SetNicknameRequest;
 import basakan.fryday.controller.user.request.UpdateNicknameRequest;
 import basakan.fryday.controller.user.request.UpdateFcmTokenRequest;
@@ -64,7 +65,7 @@ public class UserController {
 
     @PostMapping("/me/consent")
     public ResponseEntity<MessageResponse> agreeConsent(@Valid @RequestBody ConsentRequest request) {
-        userAppService.agreeConsent(request.privacyRequired(), request.pushNotificationOptional());
+        userAppService.agreeConsent(request.privacyRequired());
         return ResponseEntity.ok(new MessageResponse("개인정보 수집 및 이용에 동의하였습니다."));
     }
 
@@ -72,6 +73,12 @@ public class UserController {
     public ResponseEntity<MessageResponse> completeOnboarding() {
         userAppService.completeOnboarding();
         return ResponseEntity.ok(new MessageResponse("온보딩을 완료하였습니다."));
+    }
+
+    @PatchMapping("/me/marketing")
+    public ResponseEntity<MessageResponse> agreeMarketing(@Valid @RequestBody MarketingConsentRequest request) {
+        userAppService.agreeMarketing(request.marketingOptional());
+        return ResponseEntity.ok(new MessageResponse("마케팅 수신 동의가 완료되었습니다."));
     }
 
     @DeleteMapping("/me")

--- a/src/main/java/basakan/fryday/controller/user/request/ConsentRequest.java
+++ b/src/main/java/basakan/fryday/controller/user/request/ConsentRequest.java
@@ -4,8 +4,6 @@ import jakarta.validation.constraints.AssertTrue;
 
 public record ConsentRequest(
         @AssertTrue(message = "개인정보 수집 및 이용 동의는 필수입니다.")
-        boolean privacyRequired,
-
-        boolean pushNotificationOptional
+        boolean privacyRequired
 ) {
 }

--- a/src/main/java/basakan/fryday/controller/user/request/MarketingConsentRequest.java
+++ b/src/main/java/basakan/fryday/controller/user/request/MarketingConsentRequest.java
@@ -1,0 +1,6 @@
+package basakan.fryday.controller.user.request;
+
+public record MarketingConsentRequest(
+        boolean marketingOptional
+) {
+}

--- a/src/main/java/basakan/fryday/domain/user/Agreement.java
+++ b/src/main/java/basakan/fryday/domain/user/Agreement.java
@@ -23,27 +23,37 @@ public class Agreement extends BaseEntity {
     @Column(name = "push_notification_agreed", nullable = false)
     private boolean pushNotificationAgreed = false;
 
+    @Column(name = "marketing_agreed", nullable = false)
+    private boolean marketingAgreed = false;
+
     @Builder
-    private Agreement(User user, boolean privacyAgreed, boolean pushNotificationAgreed) {
+    private Agreement(User user, boolean privacyAgreed, boolean pushNotificationAgreed, boolean marketingAgreed) {
         this.user = user;
         this.privacyAgreed = privacyAgreed;
         this.pushNotificationAgreed = pushNotificationAgreed;
+        this.marketingAgreed = marketingAgreed;
     }
 
-    public static Agreement create(User user, boolean privacyAgreed, boolean pushNotificationAgreed) {
+    public static Agreement create(User user, boolean privacyAgreed, boolean pushNotificationAgreed, boolean marketingAgreed) {
         return Agreement.builder()
                 .user(user)
                 .privacyAgreed(privacyAgreed)
                 .pushNotificationAgreed(pushNotificationAgreed)
+                .marketingAgreed(marketingAgreed)
                 .build();
     }
 
-    public void updateConsent(boolean privacyAgreed, boolean pushNotificationAgreed) {
+    public void updateConsent(boolean privacyAgreed, boolean pushNotificationAgreed, boolean marketingAgreed) {
         this.privacyAgreed = privacyAgreed;
         this.pushNotificationAgreed = pushNotificationAgreed;
+        this.marketingAgreed = marketingAgreed;
     }
 
     public void updatePushNotificationAgreement(boolean agreed) {
         this.pushNotificationAgreed = agreed;
+    }
+
+    public void updateMarketingAgreement(boolean agreed) {
+        this.marketingAgreed = agreed;
     }
 }

--- a/src/main/java/basakan/fryday/domain/user/OnboardingStatus.java
+++ b/src/main/java/basakan/fryday/domain/user/OnboardingStatus.java
@@ -1,16 +1,18 @@
 package basakan.fryday.domain.user;
 
 public enum OnboardingStatus {
-    NEEDS_NICKNAME,      // 1단계: 닉네임 설정 필요
-    NEEDS_AGREEMENT,     // 2단계: 개인정보 동의 필요
+    NEEDS_AGREEMENT,     // 1단계: 개인정보 동의 필요
+    NEEDS_NICKNAME,      // 2단계: 닉네임 설정 필요
     NEEDS_ONBOARDING,    // 3단계: 온보딩 화면 확인 필요
+    NEEDS_MARKETING,     // 4단계: 마케팅 수신 동의 필요
     COMPLETED;           // 완료 (모든 단계 통과)
 
     public OnboardingStatus getNextStep() {
         return switch (this) {
-            case NEEDS_NICKNAME -> NEEDS_AGREEMENT;
-            case NEEDS_AGREEMENT -> NEEDS_ONBOARDING;
-            case NEEDS_ONBOARDING -> COMPLETED;
+            case NEEDS_AGREEMENT -> NEEDS_NICKNAME;
+            case NEEDS_NICKNAME -> NEEDS_ONBOARDING;
+            case NEEDS_ONBOARDING -> NEEDS_MARKETING;
+            case NEEDS_MARKETING -> COMPLETED;
             case COMPLETED -> COMPLETED;
         };
     }

--- a/src/main/java/basakan/fryday/domain/user/User.java
+++ b/src/main/java/basakan/fryday/domain/user/User.java
@@ -26,7 +26,7 @@ public class User extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private OnboardingStatus onboardingStatus = OnboardingStatus.NEEDS_NICKNAME;
+    private OnboardingStatus onboardingStatus = OnboardingStatus.NEEDS_AGREEMENT;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -44,7 +44,7 @@ public class User extends BaseEntity {
         this.provider = provider;
         this.providerUserId = providerUserId;
         this.nickname = nickname;
-        this.onboardingStatus = onboardingStatus != null ? onboardingStatus : OnboardingStatus.NEEDS_NICKNAME;
+        this.onboardingStatus = onboardingStatus != null ? onboardingStatus : OnboardingStatus.NEEDS_AGREEMENT;
         this.accountStatus = accountStatus != null ? accountStatus : AccountStatus.ACTIVE;
         this.role = role != null ? role : Role.USER;
     }
@@ -53,23 +53,27 @@ public class User extends BaseEntity {
         return User.builder()
                 .provider(provider)
                 .providerUserId(providerUserId)
-                .onboardingStatus(OnboardingStatus.NEEDS_NICKNAME)
+                .onboardingStatus(OnboardingStatus.NEEDS_AGREEMENT)
                 .accountStatus(AccountStatus.ACTIVE)
                 .role(Role.USER)
                 .build();
     }
 
     public void completeAgreementStep() {
-        this.onboardingStatus = OnboardingStatus.NEEDS_ONBOARDING;
-    }
-
-    public void completeOnboardingStep() {
-        this.onboardingStatus = OnboardingStatus.COMPLETED;
+        this.onboardingStatus = OnboardingStatus.NEEDS_NICKNAME;
     }
 
     public void setNickname(String nickname) {
         this.nickname = nickname;
-        this.onboardingStatus = OnboardingStatus.NEEDS_AGREEMENT;
+        this.onboardingStatus = OnboardingStatus.NEEDS_ONBOARDING;
+    }
+
+    public void completeOnboardingStep() {
+        this.onboardingStatus = OnboardingStatus.NEEDS_MARKETING;
+    }
+
+    public void completeMarketingStep() {
+        this.onboardingStatus = OnboardingStatus.COMPLETED;
     }
 
     public void updateNickname(String nickname) {

--- a/src/main/java/basakan/fryday/service/user/UserAppService.java
+++ b/src/main/java/basakan/fryday/service/user/UserAppService.java
@@ -44,14 +44,24 @@ public class UserAppService {
     private final UserDeviceWriteService userDeviceWriteService;
     private final CategoryService categoryService;
 
-    public void agreeConsent(boolean privacyRequired, boolean pushNotificationOptional) {
+    public void agreeConsent(boolean privacyRequired) {
         Long userId = UserContext.getCurrentUserId();
         User user = userReadService.findById(userId);
 
         Agreement agreement = userReadService.findAgreementByUser(user)
-                .orElseGet(() -> Agreement.create(user, privacyRequired, pushNotificationOptional));
+                .orElseGet(() -> Agreement.create(user, privacyRequired, false, false));
 
-        userWriteService.agreeConsent(user, agreement, privacyRequired, pushNotificationOptional);
+        userWriteService.agreeConsent(user, agreement, privacyRequired);
+    }
+
+    public void agreeMarketing(boolean marketingOptional) {
+        Long userId = UserContext.getCurrentUserId();
+        User user = userReadService.findById(userId);
+
+        Agreement agreement = userReadService.findAgreementByUser(user)
+                .orElseThrow(() -> new BusinessException(ErrorCode.AGREEMENT_NOT_FOUND));
+
+        userWriteService.agreeMarketing(user, agreement, marketingOptional);
     }
 
     public void completeOnboarding() {
@@ -86,7 +96,7 @@ public class UserAppService {
         User user = userReadService.findById(userId);
 
         Agreement agreement = userReadService.findAgreementByUser(user)
-                .orElseGet(() -> Agreement.create(user, false, pushNotificationEnabled));
+                .orElseGet(() -> Agreement.create(user, false, pushNotificationEnabled, false));
 
         userWriteService.updateNotificationSettings(agreement, pushNotificationEnabled);
     }

--- a/src/main/java/basakan/fryday/service/user/UserWriteService.java
+++ b/src/main/java/basakan/fryday/service/user/UserWriteService.java
@@ -21,10 +21,17 @@ public class UserWriteService {
     private final AgreementJpaRepository agreementRepository;
     private final basakan.fryday.service.fcm.UserDeviceWriteService userDeviceWriteService;
 
-    public void agreeConsent(User user, Agreement agreement, boolean privacyAgreed, boolean pushNotificationAgreed) {
-        agreement.updateConsent(privacyAgreed, pushNotificationAgreed);
+    public void agreeConsent(User user, Agreement agreement, boolean privacyAgreed) {
+        agreement.updateConsent(privacyAgreed, false, false);
         agreementRepository.save(agreement);
         user.completeAgreementStep();
+        userJpaRepository.save(user);
+    }
+
+    public void agreeMarketing(User user, Agreement agreement, boolean marketingAgreed) {
+        agreement.updateMarketingAgreement(marketingAgreed);
+        agreementRepository.save(agreement);
+        user.completeMarketingStep();
         userJpaRepository.save(user);
     }
 

--- a/src/test/java/basakan/fryday/controller/user/UserControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/user/UserControllerTest.java
@@ -95,7 +95,7 @@ class UserControllerTest extends RestDocsSupport {
                                 fieldWithPath("fcmToken").type(JsonFieldType.STRING).description("FCM 푸시 토큰").optional()
                         ),
                         responseFields(
-                                fieldWithPath("onboardingStatus").type(JsonFieldType.STRING).description("온보딩 상태 (NEEDS_NICKNAME, NEEDS_AGREEMENT, NEEDS_ONBOARDING, COMPLETED)"),
+                                fieldWithPath("onboardingStatus").type(JsonFieldType.STRING).description("온보딩 상태 (NEEDS_AGREEMENT, NEEDS_NICKNAME, NEEDS_ONBOARDING, NEEDS_MARKETING, COMPLETED)"),
                                 fieldWithPath("accessToken").type(JsonFieldType.STRING).description("JWT Access Token"),
                                 fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("JWT Refresh Token"),
                                 fieldWithPath("deviceId").type(JsonFieldType.STRING).description("디바이스 ID"),
@@ -153,7 +153,7 @@ class UserControllerTest extends RestDocsSupport {
                                 fieldWithPath("fcmToken").type(JsonFieldType.STRING).description("FCM 푸시 토큰").optional()
                         ),
                         responseFields(
-                                fieldWithPath("onboardingStatus").type(JsonFieldType.STRING).description("온보딩 상태 (NEEDS_NICKNAME, NEEDS_AGREEMENT, NEEDS_ONBOARDING, COMPLETED)"),
+                                fieldWithPath("onboardingStatus").type(JsonFieldType.STRING).description("온보딩 상태 (NEEDS_AGREEMENT, NEEDS_NICKNAME, NEEDS_ONBOARDING, NEEDS_MARKETING, COMPLETED)"),
                                 fieldWithPath("accessToken").type(JsonFieldType.STRING).description("JWT Access Token"),
                                 fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("JWT Refresh Token"),
                                 fieldWithPath("deviceId").type(JsonFieldType.STRING).description("디바이스 ID"),
@@ -170,9 +170,9 @@ class UserControllerTest extends RestDocsSupport {
     @WithMockUser
     void agreeConsent() throws Exception {
         // given
-        ConsentRequest request = new ConsentRequest(true, false);
+        ConsentRequest request = new ConsentRequest(true);
 
-        doNothing().when(userAppService).agreeConsent(anyBoolean(), anyBoolean());
+        doNothing().when(userAppService).agreeConsent(anyBoolean());
 
         // when & then
         mockMvc.perform(post("/api/users/me/consent")
@@ -183,8 +183,7 @@ class UserControllerTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.message").value("개인정보 수집 및 이용에 동의하였습니다."))
                 .andDo(document("user-consent",
                         requestFields(
-                                fieldWithPath("privacyRequired").type(JsonFieldType.BOOLEAN).description("개인정보 수집 및 이용 동의 (필수)"),
-                                fieldWithPath("pushNotificationOptional").type(JsonFieldType.BOOLEAN).description("푸시 알림 수신 동의 (선택)")
+                                fieldWithPath("privacyRequired").type(JsonFieldType.BOOLEAN).description("개인정보 수집 및 이용 동의 (필수)")
                         ),
                         responseFields(
                                 fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")
@@ -197,7 +196,7 @@ class UserControllerTest extends RestDocsSupport {
     @WithMockUser
     void agreeConsent_FailWhenPrivacyNotAgreed() throws Exception {
         // given
-        ConsentRequest request = new ConsentRequest(false, true);
+        ConsentRequest request = new ConsentRequest(false);
 
         // when & then
         mockMvc.perform(post("/api/users/me/consent")
@@ -368,6 +367,32 @@ class UserControllerTest extends RestDocsSupport {
                 .andDo(document("user-notification-settings-update",
                         requestFields(
                                 fieldWithPath("pushNotificationEnabled").type(JsonFieldType.BOOLEAN).description("푸시 알림 수신 여부 (true: 수신, false: 거부)")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("마케팅 수신 동의 API")
+    @WithMockUser
+    void agreeMarketing() throws Exception {
+        // given
+        MarketingConsentRequest request = new MarketingConsentRequest(true);
+
+        doNothing().when(userAppService).agreeMarketing(anyBoolean());
+
+        // when & then
+        mockMvc.perform(patch("/api/users/me/marketing")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("마케팅 수신 동의가 완료되었습니다."))
+                .andDo(document("user-marketing-consent",
+                        requestFields(
+                                fieldWithPath("marketingOptional").type(JsonFieldType.BOOLEAN).description("마케팅 정보 수신 동의 (선택)")
                         ),
                         responseFields(
                                 fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")


### PR DESCRIPTION
## 📌 Related Issue
- close: #

## 🚀 Description
### 최초 회원가입 플로우 수정
- Agreement에 marketingAgreed 컬럼 추가
- OnboardingStatus 순서 변경 (AGREEMENT → NICKNAME → ONBOARDING → MARKETING → COMPLETED)
- User 초기 상태를 NEEDS_AGREEMENT로 변경

## 📢 Notes

