### PR TITLE
회원탈퇴 로직 추가 및 Push 알림 설정 Entity 변경

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -230,6 +230,37 @@ include::{snippets}/user-withdraw/http-response.adoc[]
 ==== 응답 필드
 include::{snippets}/user-withdraw/response-fields.adoc[]
 
+=== 알림 설정 조회
+`GET /api/users/me/notification-settings`
+
+현재 디바이스의 푸시 알림 수신 여부와 마케팅 수신 동의 여부를 조회합니다. (인증 필요)
+
+==== HTTP 요청 예시
+include::{snippets}/user-notification-settings-get/http-request.adoc[]
+
+==== HTTP 응답 예시
+include::{snippets}/user-notification-settings-get/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/user-notification-settings-get/response-fields.adoc[]
+
+=== 알림 설정 변경
+`PATCH /api/users/me/notification-settings`
+
+현재 디바이스의 푸시 알림 수신 여부를 변경합니다. (인증 필요)
+
+==== 요청 필드
+include::{snippets}/user-notification-settings-update/request-fields.adoc[]
+
+==== HTTP 요청 예시
+include::{snippets}/user-notification-settings-update/http-request.adoc[]
+
+==== HTTP 응답 예시
+include::{snippets}/user-notification-settings-update/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/user-notification-settings-update/response-fields.adoc[]
+
 == 월간 리포트(Monthly Report)
 
 === 월간 리포트 조회

--- a/src/main/java/basakan/fryday/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/basakan/fryday/common/security/JwtAuthenticationFilter.java
@@ -44,13 +44,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 // JWT에서 accountStatus 검증 (DB 조회 없이!)
                 if (accountStatus != null && "ACTIVE".equals(accountStatus)) {
-                    UserPrincipal principal = new UserPrincipal(userId, deviceId);
                     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                            principal,
+                            userId,
                             null,
                             List.of(new SimpleGrantedAuthority("ROLE_" + role))
                     );
-                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    authentication.setDetails(deviceId);
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 } else {
                     log.debug("User is not active. accountStatus: {}", accountStatus);

--- a/src/main/java/basakan/fryday/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/basakan/fryday/common/security/JwtAuthenticationFilter.java
@@ -10,7 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;

--- a/src/main/java/basakan/fryday/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/basakan/fryday/common/security/JwtAuthenticationFilter.java
@@ -40,11 +40,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 Long userId = Long.parseLong(claims.getSubject());
                 String role = claims.get("role", String.class);
                 String accountStatus = claims.get("accountStatus", String.class);
+                String deviceId = claims.get("deviceId", String.class);
 
                 // JWT에서 accountStatus 검증 (DB 조회 없이!)
                 if (accountStatus != null && "ACTIVE".equals(accountStatus)) {
+                    UserPrincipal principal = new UserPrincipal(userId, deviceId);
                     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                            userId,
+                            principal,
                             null,
                             List.of(new SimpleGrantedAuthority("ROLE_" + role))
                     );

--- a/src/main/java/basakan/fryday/common/security/JwtTokenProvider.java
+++ b/src/main/java/basakan/fryday/common/security/JwtTokenProvider.java
@@ -27,7 +27,7 @@ public class JwtTokenProvider {
         return Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
     }
 
-    public String generateAccessToken(Long userId, User.Role role, User.AccountStatus accountStatus) {
+    public String generateAccessToken(Long userId, User.Role role, User.AccountStatus accountStatus, String deviceId) {
         Date now = new Date();
         Date expiration = new Date(now.getTime() + accessTokenExpiration);
 
@@ -35,6 +35,7 @@ public class JwtTokenProvider {
                 .subject(String.valueOf(userId))
                 .claim("role", role.name())
                 .claim("accountStatus", accountStatus.name())
+                .claim("deviceId", deviceId)
                 .issuedAt(now)
                 .expiration(expiration)
                 .signWith(getSigningKey())

--- a/src/main/java/basakan/fryday/common/security/RefreshTokenRepository.java
+++ b/src/main/java/basakan/fryday/common/security/RefreshTokenRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -58,5 +59,19 @@ public class RefreshTokenRepository {
     public void delete(String refreshToken) {
         String key = KEY_PREFIX + refreshToken;
         redisTemplate.delete(key);
+    }
+
+    public void deleteAllByUserId(Long userId) {
+        String prefix = userId + ":";
+        Set<String> keys = redisTemplate.keys(KEY_PREFIX + "*");
+        if (keys == null || keys.isEmpty()) {
+            return;
+        }
+        for (String key : keys) {
+            String value = redisTemplate.opsForValue().get(key);
+            if (value != null && value.startsWith(prefix)) {
+                redisTemplate.delete(key);
+            }
+        }
     }
 }

--- a/src/main/java/basakan/fryday/common/security/UserContext.java
+++ b/src/main/java/basakan/fryday/common/security/UserContext.java
@@ -9,18 +9,20 @@ public class UserContext {
     }
 
     public static Long getCurrentUserId() {
-        return getCurrentPrincipal().userId();
+        Authentication authentication = getAuthentication();
+        return (Long) authentication.getPrincipal();
     }
 
     public static String getCurrentDeviceId() {
-        return getCurrentPrincipal().deviceId();
+        Authentication authentication = getAuthentication();
+        return (String) authentication.getDetails();
     }
 
-    private static UserPrincipal getCurrentPrincipal() {
+    private static Authentication getAuthentication() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !authentication.isAuthenticated()) {
             throw new IllegalStateException("인증되지 않은 사용자입니다.");
         }
-        return (UserPrincipal) authentication.getPrincipal();
+        return authentication;
     }
 }

--- a/src/main/java/basakan/fryday/common/security/UserContext.java
+++ b/src/main/java/basakan/fryday/common/security/UserContext.java
@@ -15,7 +15,11 @@ public class UserContext {
 
     public static String getCurrentDeviceId() {
         Authentication authentication = getAuthentication();
-        return (String) authentication.getDetails();
+        Object details = authentication.getDetails();
+        if (details == null) {
+            throw new IllegalStateException("디바이스 정보가 없습니다. 재로그인이 필요합니다.");
+        }
+        return (String) details;
     }
 
     private static Authentication getAuthentication() {

--- a/src/main/java/basakan/fryday/common/security/UserContext.java
+++ b/src/main/java/basakan/fryday/common/security/UserContext.java
@@ -9,10 +9,18 @@ public class UserContext {
     }
 
     public static Long getCurrentUserId() {
+        return getCurrentPrincipal().userId();
+    }
+
+    public static String getCurrentDeviceId() {
+        return getCurrentPrincipal().deviceId();
+    }
+
+    private static UserPrincipal getCurrentPrincipal() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !authentication.isAuthenticated()) {
             throw new IllegalStateException("인증되지 않은 사용자입니다.");
         }
-        return (Long) authentication.getPrincipal();
+        return (UserPrincipal) authentication.getPrincipal();
     }
 }

--- a/src/main/java/basakan/fryday/common/security/UserPrincipal.java
+++ b/src/main/java/basakan/fryday/common/security/UserPrincipal.java
@@ -1,0 +1,4 @@
+package basakan.fryday.common.security;
+
+public record UserPrincipal(Long userId, String deviceId) {
+}

--- a/src/main/java/basakan/fryday/common/security/UserPrincipal.java
+++ b/src/main/java/basakan/fryday/common/security/UserPrincipal.java
@@ -1,4 +1,0 @@
-package basakan.fryday.common.security;
-
-public record UserPrincipal(Long userId, String deviceId) {
-}

--- a/src/main/java/basakan/fryday/common/service/push/FcmPushService.java
+++ b/src/main/java/basakan/fryday/common/service/push/FcmPushService.java
@@ -35,7 +35,7 @@ public class FcmPushService implements PushService {
             return;
         }
 
-        List<UserDevice> devices = userDeviceRepository.findAllByUserIdAndIsActiveTrue(user.getId());
+        List<UserDevice> devices = userDeviceRepository.findAllByUserIdAndIsActiveTrueAndPushNotificationAgreedTrue(user.getId());
 
         if (devices.isEmpty()) {
             log.warn("No active devices found for userId={}", user.getId());

--- a/src/main/java/basakan/fryday/controller/user/UserController.java
+++ b/src/main/java/basakan/fryday/controller/user/UserController.java
@@ -14,6 +14,7 @@ import basakan.fryday.controller.user.request.UpdateNicknameRequest;
 import basakan.fryday.controller.user.request.UpdateFcmTokenRequest;
 import basakan.fryday.controller.user.request.LogoutRequest;
 import basakan.fryday.controller.user.request.NotificationSettingsRequest;
+import basakan.fryday.controller.user.response.NotificationSettingsResponse;
 import basakan.fryday.service.auth.dto.SocialLoginDto;
 import basakan.fryday.service.user.UserAppService;
 import jakarta.validation.Valid;
@@ -78,7 +79,7 @@ public class UserController {
     @PatchMapping("/me/marketing")
     public ResponseEntity<MessageResponse> agreeMarketing(@Valid @RequestBody MarketingConsentRequest request) {
         userAppService.agreeMarketing(request.marketingOptional());
-        return ResponseEntity.ok(new MessageResponse("마케팅 수신 동의가 완료되었습니다."));
+        return ResponseEntity.ok(new MessageResponse("마케팅 수신 정보가 성공적으로 변경되었습니다."));
     }
 
     @DeleteMapping("/me")
@@ -103,6 +104,12 @@ public class UserController {
     public ResponseEntity<MessageResponse> logout(@Valid @RequestBody LogoutRequest request) {
         userAppService.logout(request.deviceId(), request.refreshToken());
         return ResponseEntity.ok(new MessageResponse("로그아웃이 완료되었습니다."));
+    }
+
+    @GetMapping("/me/notification-settings")
+    public ResponseEntity<NotificationSettingsResponse> getNotificationSettings() {
+        NotificationSettingsResponse response = userAppService.getNotificationSettings();
+        return ResponseEntity.ok(response);
     }
 
     @PatchMapping("/me/notification-settings")

--- a/src/main/java/basakan/fryday/controller/user/response/NotificationSettingsResponse.java
+++ b/src/main/java/basakan/fryday/controller/user/response/NotificationSettingsResponse.java
@@ -1,0 +1,10 @@
+package basakan.fryday.controller.user.response;
+
+public record NotificationSettingsResponse(
+        boolean pushNotificationEnabled,
+        boolean marketingAgreed
+) {
+    public static NotificationSettingsResponse of(boolean pushNotificationEnabled, boolean marketingAgreed) {
+        return new NotificationSettingsResponse(pushNotificationEnabled, marketingAgreed);
+    }
+}

--- a/src/main/java/basakan/fryday/domain/user/Agreement.java
+++ b/src/main/java/basakan/fryday/domain/user/Agreement.java
@@ -20,37 +20,27 @@ public class Agreement extends BaseEntity {
     @Column(nullable = false)
     private boolean privacyAgreed = false;
 
-    @Column(name = "push_notification_agreed", nullable = false)
-    private boolean pushNotificationAgreed = false;
-
     @Column(name = "marketing_agreed", nullable = false)
     private boolean marketingAgreed = false;
 
     @Builder
-    private Agreement(User user, boolean privacyAgreed, boolean pushNotificationAgreed, boolean marketingAgreed) {
+    private Agreement(User user, boolean privacyAgreed, boolean marketingAgreed) {
         this.user = user;
         this.privacyAgreed = privacyAgreed;
-        this.pushNotificationAgreed = pushNotificationAgreed;
         this.marketingAgreed = marketingAgreed;
     }
 
-    public static Agreement create(User user, boolean privacyAgreed, boolean pushNotificationAgreed, boolean marketingAgreed) {
+    public static Agreement create(User user, boolean privacyAgreed, boolean marketingAgreed) {
         return Agreement.builder()
                 .user(user)
                 .privacyAgreed(privacyAgreed)
-                .pushNotificationAgreed(pushNotificationAgreed)
                 .marketingAgreed(marketingAgreed)
                 .build();
     }
 
-    public void updateConsent(boolean privacyAgreed, boolean pushNotificationAgreed, boolean marketingAgreed) {
+    public void updateConsent(boolean privacyAgreed, boolean marketingAgreed) {
         this.privacyAgreed = privacyAgreed;
-        this.pushNotificationAgreed = pushNotificationAgreed;
         this.marketingAgreed = marketingAgreed;
-    }
-
-    public void updatePushNotificationAgreement(boolean agreed) {
-        this.pushNotificationAgreed = agreed;
     }
 
     public void updateMarketingAgreement(boolean agreed) {

--- a/src/main/java/basakan/fryday/domain/user/UserDevice.java
+++ b/src/main/java/basakan/fryday/domain/user/UserDevice.java
@@ -33,6 +33,9 @@ public class UserDevice extends BaseEntity {
     @Column(length = 100)
     private String deviceName;  // "iPhone 14 Pro", "Galaxy S23" 등
 
+    @Column(name = "push_notification_agreed", nullable = false)
+    private boolean pushNotificationAgreed = false;
+
     @Column(nullable = false)
     private Boolean isActive = true;
 
@@ -48,6 +51,10 @@ public class UserDevice extends BaseEntity {
         this.deviceName = deviceName;
         this.isActive = true;
         this.lastUsedAt = LocalDateTime.now();
+    }
+
+    public void updatePushNotificationAgreement(boolean agreed) {
+        this.pushNotificationAgreed = agreed;
     }
 
     public void updateFcmToken(String fcmToken) {

--- a/src/main/java/basakan/fryday/repository/CategoryRepository.java
+++ b/src/main/java/basakan/fryday/repository/CategoryRepository.java
@@ -17,5 +17,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     Long findMaxDisplayOrder(@Param("userId") Long userId);
 
     List<Category> findAllByUserIdAndDeletedAtIsNullOrderByDisplayOrderAsc(Long userId);
+
+    void deleteAllByUserId(Long userId);
 }
 

--- a/src/main/java/basakan/fryday/repository/DailyResultRepository.java
+++ b/src/main/java/basakan/fryday/repository/DailyResultRepository.java
@@ -11,4 +11,6 @@ public interface DailyResultRepository extends JpaRepository<DailyResult, Long> 
     Optional<DailyResult> findByUserIdAndDate(Long userId, LocalDate date);
 
     List<DailyResult> findAllByUserIdAndDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/basakan/fryday/repository/auth/AgreementJpaRepository.java
+++ b/src/main/java/basakan/fryday/repository/auth/AgreementJpaRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 public interface AgreementJpaRepository extends JpaRepository<Agreement, Long> {
 
     Optional<Agreement> findByUser(User user);
+
+    void deleteByUser(User user);
 }

--- a/src/main/java/basakan/fryday/repository/auth/AgreementJpaRepository.java
+++ b/src/main/java/basakan/fryday/repository/auth/AgreementJpaRepository.java
@@ -3,17 +3,10 @@ package basakan.fryday.repository.auth;
 import basakan.fryday.domain.user.Agreement;
 import basakan.fryday.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface AgreementJpaRepository extends JpaRepository<Agreement, Long> {
 
     Optional<Agreement> findByUser(User user);
-
-    @Query("SELECT a.user FROM Agreement a " +
-            "WHERE a.pushNotificationAgreed = true " +
-            "AND a.user.accountStatus = 'ACTIVE'")
-    List<User> findAllUsersWithPushNotificationEnabled();
 }

--- a/src/main/java/basakan/fryday/repository/auth/UserDeviceRepository.java
+++ b/src/main/java/basakan/fryday/repository/auth/UserDeviceRepository.java
@@ -28,4 +28,6 @@ public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
     void deleteByUserIdAndIsActiveFalse(Long userId);
 
     List<UserDevice> findAllByUserIdAndIsActiveTrueAndPushNotificationAgreedTrue(Long userId);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/basakan/fryday/repository/auth/UserDeviceRepository.java
+++ b/src/main/java/basakan/fryday/repository/auth/UserDeviceRepository.java
@@ -26,4 +26,6 @@ public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
     List<UserDevice> findByIsActiveFalseAndLastUsedAtBefore(LocalDateTime dateTime);
 
     void deleteByUserIdAndIsActiveFalse(Long userId);
+
+    List<UserDevice> findAllByUserIdAndIsActiveTrueAndPushNotificationAgreedTrue(Long userId);
 }

--- a/src/main/java/basakan/fryday/repository/auth/UserJpaRepository.java
+++ b/src/main/java/basakan/fryday/repository/auth/UserJpaRepository.java
@@ -5,6 +5,7 @@ import basakan.fryday.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,4 +19,6 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u.id FROM User u WHERE u.accountStatus = 'ACTIVE'")
     List<Long> findAllActiveUserIds();
+
+    List<User> findAllByAccountStatusAndWithdrawnAtBefore(User.AccountStatus accountStatus, LocalDateTime threshold);
 }

--- a/src/main/java/basakan/fryday/repository/report/MonthlyReportRepository.java
+++ b/src/main/java/basakan/fryday/repository/report/MonthlyReportRepository.java
@@ -19,4 +19,6 @@ public interface MonthlyReportRepository extends JpaRepository<MonthlyReport, Lo
     );
 
     boolean existsByUserIdAndYearAndMonth(Long userId, int year, int month);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/basakan/fryday/repository/todo/RecurrenceExceptionRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/RecurrenceExceptionRepository.java
@@ -2,13 +2,13 @@ package basakan.fryday.repository.todo;
 
 import basakan.fryday.domain.todo.RecurrenceException;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 public interface RecurrenceExceptionRepository extends JpaRepository<RecurrenceException, Long> {
 
@@ -16,4 +16,9 @@ public interface RecurrenceExceptionRepository extends JpaRepository<RecurrenceE
 
     @Query("SELECT re FROM RecurrenceException re WHERE re.recurrenceId = :recurrenceId")
     List<RecurrenceException> findByRecurrenceId(@Param("recurrenceId") Long recurrenceId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM RecurrenceException re WHERE re.recurrenceId IN " +
+            "(SELECT r.id FROM Recurrence r WHERE r.userId = :userId)")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/basakan/fryday/repository/todo/RecurrenceRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/RecurrenceRepository.java
@@ -17,4 +17,6 @@ public interface RecurrenceRepository extends JpaRepository<Recurrence, Long> {
            "AND (r.endDate IS NULL OR r.endDate >= :date) " +
            "AND r.startDate <= :date")
     List<Recurrence> findByUserIdAndDateRange(@Param("userId") Long userId, @Param("date") LocalDate date);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/basakan/fryday/repository/todo/TodoAlarmRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/TodoAlarmRepository.java
@@ -22,10 +22,8 @@ public interface TodoAlarmRepository extends JpaRepository<TodoAlarm, Long> {
     @Query("SELECT ta FROM TodoAlarm ta " +
             "JOIN FETCH ta.user u " +
             "JOIN FETCH ta.todo t " +
-            "JOIN Agreement a ON a.user = u " +
             "WHERE ta.status = :status " +
             "AND ta.notifyAt <= :notifyAt " +
-            "AND a.pushNotificationAgreed = true " +
             "AND u.accountStatus = 'ACTIVE' " +
             "AND t.deletedAt IS NULL")
     List<TodoAlarm> findAllByStatusAndNotifyAtBeforeOrEqual(

--- a/src/main/java/basakan/fryday/repository/todo/TodoAlarmRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/TodoAlarmRepository.java
@@ -2,6 +2,7 @@ package basakan.fryday.repository.todo;
 
 import basakan.fryday.domain.todo.TodoAlarm;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -32,4 +33,8 @@ public interface TodoAlarmRepository extends JpaRepository<TodoAlarm, Long> {
     );
 
     void deleteByTodoId(Long todoId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM TodoAlarm ta WHERE ta.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
@@ -81,6 +81,11 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
         @Param("month") int month
     );
 
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Todo t WHERE t.category.id IN " +
+            "(SELECT c.id FROM Category c WHERE c.userId = :userId)")
+    void deleteAllByUserId(@Param("userId") Long userId);
+
     @Query("SELECT CAST(COUNT(DISTINCT DATE(t.date)) AS int) " +
            "FROM Todo t " +
            "JOIN t.category c " +

--- a/src/main/java/basakan/fryday/scheduler/BurntAlarmScheduler.java
+++ b/src/main/java/basakan/fryday/scheduler/BurntAlarmScheduler.java
@@ -2,7 +2,7 @@ package basakan.fryday.scheduler;
 
 import basakan.fryday.common.service.push.PushService;
 import basakan.fryday.domain.user.User;
-import basakan.fryday.repository.auth.AgreementJpaRepository;
+import basakan.fryday.repository.auth.UserJpaRepository;
 import basakan.fryday.repository.todo.TodoRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
-import java.util.Set;
 
 /**
  * 실패 확정 알림 스케줄러 (Alarm-002)
@@ -28,7 +27,7 @@ public class BurntAlarmScheduler {
 
     private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
 
-    private final AgreementJpaRepository agreementJpaRepository;
+    private final UserJpaRepository userJpaRepository;
     private final TodoRepository todoRepository;
     private final PushService pushService;
 
@@ -38,13 +37,6 @@ public class BurntAlarmScheduler {
         LocalDate yesterday = LocalDate.now(KOREA_ZONE).minusDays(1);
         log.info("Burnt Alarm start: {}", yesterday);
 
-        List<User> usersWithPushEnabled = agreementJpaRepository.findAllUsersWithPushNotificationEnabled();
-
-        if (usersWithPushEnabled.isEmpty()) {
-            log.info("No users with push notification enabled");
-            return;
-        }
-
         List<Long> userIdsWithBurntTodos = todoRepository.findUserIdsWithBurntTodosByDate(yesterday);
 
         if (userIdsWithBurntTodos.isEmpty()) {
@@ -52,10 +44,7 @@ public class BurntAlarmScheduler {
             return;
         }
 
-        Set<Long> burntUserIds = Set.copyOf(userIdsWithBurntTodos);
-        List<User> targetUsers = usersWithPushEnabled.stream()
-                .filter(user -> burntUserIds.contains(user.getId()))
-                .toList();
+        List<User> targetUsers = userJpaRepository.findAllById(userIdsWithBurntTodos);
 
         int notificationCount = 0;
 

--- a/src/main/java/basakan/fryday/scheduler/DeadlineAlarmScheduler.java
+++ b/src/main/java/basakan/fryday/scheduler/DeadlineAlarmScheduler.java
@@ -3,7 +3,7 @@ package basakan.fryday.scheduler;
 import basakan.fryday.common.service.push.PushService;
 import basakan.fryday.domain.todo.Todo.Status;
 import basakan.fryday.domain.user.User;
-import basakan.fryday.repository.auth.AgreementJpaRepository;
+import basakan.fryday.repository.auth.UserJpaRepository;
 import basakan.fryday.repository.todo.TodoRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
-import java.util.Set;
 
 /**
  * 마감 임박 알림 스케줄러 (Alarm-001)
@@ -29,7 +28,7 @@ public class DeadlineAlarmScheduler {
 
     private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
 
-    private final AgreementJpaRepository agreementJpaRepository;
+    private final UserJpaRepository userJpaRepository;
     private final TodoRepository todoRepository;
     private final PushService pushService;
 
@@ -38,13 +37,6 @@ public class DeadlineAlarmScheduler {
     public void sendDeadlineAlarm() {
         LocalDate today = LocalDate.now(KOREA_ZONE);
         log.info("Deadline Alarm start: {}", today);
-
-        List<User> usersWithPushEnabled = agreementJpaRepository.findAllUsersWithPushNotificationEnabled();
-
-        if (usersWithPushEnabled.isEmpty()) {
-            log.info("No users with push notification enabled");
-            return;
-        }
 
         List<Long> userIdsWithIncompleteTodos = todoRepository.findUserIdsWithTodosByDateAndStatus(
                 today, Status.IN_PROGRESS
@@ -55,10 +47,7 @@ public class DeadlineAlarmScheduler {
             return;
         }
 
-        Set<Long> incompleteUserIds = Set.copyOf(userIdsWithIncompleteTodos);
-        List<User> targetUsers = usersWithPushEnabled.stream()
-                .filter(user -> incompleteUserIds.contains(user.getId()))
-                .toList();
+        List<User> targetUsers = userJpaRepository.findAllById(userIdsWithIncompleteTodos);
 
         int notificationCount = 0;
 

--- a/src/main/java/basakan/fryday/scheduler/EncourageAlarmScheduler.java
+++ b/src/main/java/basakan/fryday/scheduler/EncourageAlarmScheduler.java
@@ -2,7 +2,7 @@ package basakan.fryday.scheduler;
 
 import basakan.fryday.common.service.push.PushService;
 import basakan.fryday.domain.user.User;
-import basakan.fryday.repository.auth.AgreementJpaRepository;
+import basakan.fryday.repository.auth.UserJpaRepository;
 import basakan.fryday.repository.todo.TodoRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,7 +28,7 @@ public class EncourageAlarmScheduler {
 
     private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
 
-    private final AgreementJpaRepository agreementJpaRepository;
+    private final UserJpaRepository userJpaRepository;
     private final TodoRepository todoRepository;
     private final PushService pushService;
 
@@ -38,24 +38,26 @@ public class EncourageAlarmScheduler {
         LocalDate today = LocalDate.now(KOREA_ZONE);
         log.info("Encourage Alarm start: {}", today);
 
-        List<User> usersWithPushEnabled = agreementJpaRepository.findAllUsersWithPushNotificationEnabled();
+        List<Long> activeUserIds = userJpaRepository.findAllActiveUserIds();
 
-        if (usersWithPushEnabled.isEmpty()) {
-            log.info("No users with push notification enabled");
+        if (activeUserIds.isEmpty()) {
+            log.info("No active users found");
             return;
         }
 
         List<Long> userIdsWithTodos = todoRepository.findUserIdsWithTodosByDate(today);
         Set<Long> hasToDoUserIds = Set.copyOf(userIdsWithTodos);
 
-        List<User> targetUsers = usersWithPushEnabled.stream()
-                .filter(user -> !hasToDoUserIds.contains(user.getId()))
+        List<Long> targetUserIds = activeUserIds.stream()
+                .filter(id -> !hasToDoUserIds.contains(id))
                 .toList();
 
-        if (targetUsers.isEmpty()) {
+        if (targetUserIds.isEmpty()) {
             log.info("All users already have todos for {}", today);
             return;
         }
+
+        List<User> targetUsers = userJpaRepository.findAllById(targetUserIds);
 
         int notificationCount = 0;
 

--- a/src/main/java/basakan/fryday/scheduler/WithdrawnAccountCleanupScheduler.java
+++ b/src/main/java/basakan/fryday/scheduler/WithdrawnAccountCleanupScheduler.java
@@ -1,0 +1,45 @@
+package basakan.fryday.scheduler;
+
+import basakan.fryday.domain.user.User;
+import basakan.fryday.repository.auth.UserJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 탈퇴 계정 정리 스케줄러
+ * - 매일 00:30에 실행
+ * - 탈퇴 후 7일이 경과한 계정을 삭제
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WithdrawnAccountCleanupScheduler {
+
+    private final UserJpaRepository userJpaRepository;
+
+    @Scheduled(cron = "0 30 0 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void cleanupWithdrawnAccounts() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(7);
+        log.info("Withdrawn account cleanup start: threshold={}", threshold);
+
+        List<User> expiredUsers = userJpaRepository.findAllByAccountStatusAndWithdrawnAtBefore(
+                User.AccountStatus.WITHDRAWN, threshold
+        );
+
+        if (expiredUsers.isEmpty()) {
+            log.info("No expired withdrawn accounts found");
+            return;
+        }
+
+        userJpaRepository.deleteAll(expiredUsers);
+
+        log.info("Withdrawn account cleanup end: deleted={}", expiredUsers.size());
+    }
+}

--- a/src/main/java/basakan/fryday/scheduler/WithdrawnAccountCleanupScheduler.java
+++ b/src/main/java/basakan/fryday/scheduler/WithdrawnAccountCleanupScheduler.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 /**
@@ -26,7 +27,7 @@ public class WithdrawnAccountCleanupScheduler {
     @Scheduled(cron = "0 30 0 * * *", zone = "Asia/Seoul")
     @Transactional
     public void cleanupWithdrawnAccounts() {
-        LocalDateTime threshold = LocalDateTime.now().minusDays(7);
+        LocalDateTime threshold = LocalDateTime.now(ZoneId.of("Asia/Seoul")).minusDays(7);
         log.info("Withdrawn account cleanup start: threshold={}", threshold);
 
         List<User> expiredUsers = userJpaRepository.findAllByAccountStatusAndWithdrawnAtBefore(

--- a/src/main/java/basakan/fryday/service/fcm/UserDeviceWriteService.java
+++ b/src/main/java/basakan/fryday/service/fcm/UserDeviceWriteService.java
@@ -1,5 +1,7 @@
 package basakan.fryday.service.fcm;
 
+import basakan.fryday.common.ErrorCode;
+import basakan.fryday.common.exception.BusinessException;
 import basakan.fryday.domain.user.UserDevice;
 import basakan.fryday.repository.auth.UserDeviceRepository;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +33,12 @@ public class UserDeviceWriteService {
 
     public void updateFcmToken(UserDevice userDevice, String fcmToken) {
         userDevice.updateFcmToken(fcmToken);
+    }
+
+    public void updatePushNotificationAgreement(Long userId, String deviceId, boolean agreed) {
+        UserDevice device = userDeviceRepository.findByUserIdAndDeviceId(userId, deviceId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.DEVICE_NOT_FOUND));
+        device.updatePushNotificationAgreement(agreed);
     }
 
     public void deactivateDevice(UserDevice userDevice) {

--- a/src/main/java/basakan/fryday/service/user/UserAppService.java
+++ b/src/main/java/basakan/fryday/service/user/UserAppService.java
@@ -9,6 +9,7 @@ import basakan.fryday.common.security.JwtTokenProvider;
 import basakan.fryday.common.security.RefreshTokenRepository;
 import basakan.fryday.common.security.UserContext;
 import basakan.fryday.controller.user.response.NicknameCheckResponse;
+import basakan.fryday.controller.user.response.NotificationSettingsResponse;
 import basakan.fryday.controller.user.response.RefreshTokenResponse;
 import basakan.fryday.domain.user.Agreement;
 import basakan.fryday.domain.user.User;
@@ -49,7 +50,7 @@ public class UserAppService {
         User user = userReadService.findById(userId);
 
         Agreement agreement = userReadService.findAgreementByUser(user)
-                .orElseGet(() -> Agreement.create(user, privacyRequired, false, false));
+                .orElseGet(() -> Agreement.create(user, privacyRequired, false));
 
         userWriteService.agreeConsent(user, agreement, privacyRequired);
     }
@@ -69,7 +70,6 @@ public class UserAppService {
         User user = userReadService.findById(userId);
         userWriteService.completeOnboarding(user);
 
-        // 온보딩 완료 시 기본 카테고리 생성
         categoryService.initDefaultCategories(userId);
     }
 
@@ -91,14 +91,27 @@ public class UserAppService {
         userWriteService.updateNickname(user, nickname);
     }
 
-    public void updateNotificationSettings(boolean pushNotificationEnabled) {
+    @Transactional(readOnly = true)
+    public NotificationSettingsResponse getNotificationSettings() {
         Long userId = UserContext.getCurrentUserId();
+        String deviceId = UserContext.getCurrentDeviceId();
         User user = userReadService.findById(userId);
 
-        Agreement agreement = userReadService.findAgreementByUser(user)
-                .orElseGet(() -> Agreement.create(user, false, pushNotificationEnabled, false));
+        UserDevice device = userDeviceReadService.findByUserIdAndDeviceId(userId, deviceId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.DEVICE_NOT_FOUND));
 
-        userWriteService.updateNotificationSettings(agreement, pushNotificationEnabled);
+        boolean marketingAgreed = userReadService.findAgreementByUser(user)
+                .map(Agreement::isMarketingAgreed)
+                .orElse(false);
+
+        return NotificationSettingsResponse.of(device.isPushNotificationAgreed(), marketingAgreed);
+    }
+
+    public void updateNotificationSettings(boolean pushNotificationEnabled) {
+        Long userId = UserContext.getCurrentUserId();
+        String deviceId = UserContext.getCurrentDeviceId();
+
+        userDeviceWriteService.updatePushNotificationAgreement(userId, deviceId, pushNotificationEnabled);
     }
 
     public NicknameCheckResponse checkNicknameAvailability(String nickname) {
@@ -166,7 +179,7 @@ public class UserAppService {
                         )
                 );
 
-        String accessToken = jwtTokenProvider.generateAccessToken(user.getId(), user.getRole(), user.getAccountStatus());
+        String accessToken = jwtTokenProvider.generateAccessToken(user.getId(), user.getRole(), user.getAccountStatus(), serviceDto.deviceId());
         String refreshToken = refreshTokenRepository.generateAndSave(user.getId(), serviceDto.deviceId());
 
         return SocialLoginDto.from(user, socialUserInfo.provider(), accessToken, refreshToken, serviceDto.deviceId());
@@ -201,7 +214,7 @@ public class UserAppService {
 
         refreshTokenRepository.delete(oldRefreshToken);
 
-        String newAccessToken = jwtTokenProvider.generateAccessToken(user.getId(), user.getRole(), user.getAccountStatus());
+        String newAccessToken = jwtTokenProvider.generateAccessToken(user.getId(), user.getRole(), user.getAccountStatus(), deviceId);
         String newRefreshToken = refreshTokenRepository.generateAndSave(user.getId(), deviceId);
 
         return RefreshTokenResponse.of(newAccessToken, newRefreshToken);

--- a/src/main/java/basakan/fryday/service/user/UserWriteService.java
+++ b/src/main/java/basakan/fryday/service/user/UserWriteService.java
@@ -22,7 +22,7 @@ public class UserWriteService {
     private final basakan.fryday.service.fcm.UserDeviceWriteService userDeviceWriteService;
 
     public void agreeConsent(User user, Agreement agreement, boolean privacyAgreed) {
-        agreement.updateConsent(privacyAgreed, false, false);
+        agreement.updateConsent(privacyAgreed, false);
         agreementRepository.save(agreement);
         user.completeAgreementStep();
         userJpaRepository.save(user);
@@ -68,10 +68,6 @@ public class UserWriteService {
         userJpaRepository.save(user);
     }
 
-    public void updateNotificationSettings(Agreement agreement, boolean pushNotificationEnabled) {
-        agreement.updatePushNotificationAgreement(pushNotificationEnabled);
-        agreementRepository.save(agreement);
-    }
 
     private void validateNicknameLength(String nickname) {
         if (nickname == null || nickname.length() < 2 || nickname.length() > 10) {

--- a/src/main/java/basakan/fryday/service/user/UserWriteService.java
+++ b/src/main/java/basakan/fryday/service/user/UserWriteService.java
@@ -5,9 +5,18 @@ import basakan.fryday.common.exception.BusinessException;
 import basakan.fryday.common.exception.auth.UserReregisterNotAllowedException;
 import basakan.fryday.domain.user.Agreement;
 import basakan.fryday.domain.user.User;
+import basakan.fryday.repository.CategoryRepository;
+import basakan.fryday.repository.DailyResultRepository;
 import basakan.fryday.repository.auth.AgreementJpaRepository;
+import basakan.fryday.repository.auth.UserDeviceRepository;
 import basakan.fryday.repository.auth.UserJpaRepository;
+import basakan.fryday.common.security.RefreshTokenRepository;
 import basakan.fryday.repository.auth.client.SocialUserInfo;
+import basakan.fryday.repository.report.MonthlyReportRepository;
+import basakan.fryday.repository.todo.RecurrenceExceptionRepository;
+import basakan.fryday.repository.todo.RecurrenceRepository;
+import basakan.fryday.repository.todo.TodoAlarmRepository;
+import basakan.fryday.repository.todo.TodoRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,7 +28,15 @@ public class UserWriteService {
 
     private final UserJpaRepository userJpaRepository;
     private final AgreementJpaRepository agreementRepository;
-    private final basakan.fryday.service.fcm.UserDeviceWriteService userDeviceWriteService;
+    private final UserDeviceRepository userDeviceRepository;
+    private final TodoAlarmRepository todoAlarmRepository;
+    private final RecurrenceExceptionRepository recurrenceExceptionRepository;
+    private final TodoRepository todoRepository;
+    private final RecurrenceRepository recurrenceRepository;
+    private final CategoryRepository categoryRepository;
+    private final MonthlyReportRepository monthlyReportRepository;
+    private final DailyResultRepository dailyResultRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     public void agreeConsent(User user, Agreement agreement, boolean privacyAgreed) {
         agreement.updateConsent(privacyAgreed, false);
@@ -60,11 +77,24 @@ public class UserWriteService {
     }
 
     public void withdraw(User user) {
+        Long userId = user.getId();
+
+        // Redis refresh token 삭제
+        refreshTokenRepository.deleteAllByUserId(userId);
+
+        // 연관 데이터 삭제 (FK 순서 고려)
+        todoAlarmRepository.deleteAllByUserId(userId);
+        recurrenceExceptionRepository.deleteAllByUserId(userId);
+        todoRepository.deleteAllByUserId(userId);
+        recurrenceRepository.deleteAllByUserId(userId);
+        categoryRepository.deleteAllByUserId(userId);
+        monthlyReportRepository.deleteAllByUserId(userId);
+        dailyResultRepository.deleteAllByUserId(userId);
+        userDeviceRepository.deleteAllByUserId(userId);
+        agreementRepository.deleteByUser(user);
+
+        // 계정 상태 변경 (7일 후 스케줄러가 User 삭제)
         user.withdraw();
-
-        // 모든 디바이스 비활성화 (삭제하지 않음)
-        userDeviceWriteService.deactivateAllByUserId(user.getId());
-
         userJpaRepository.save(user);
     }
 

--- a/src/test/java/basakan/fryday/controller/user/UserControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/user/UserControllerTest.java
@@ -6,6 +6,7 @@ import basakan.fryday.common.security.JwtAuthenticationFilter;
 import basakan.fryday.common.security.JwtTokenProvider;
 import basakan.fryday.controller.user.request.*;
 import basakan.fryday.controller.user.response.NicknameCheckResponse;
+import basakan.fryday.controller.user.response.NotificationSettingsResponse;
 import basakan.fryday.domain.user.AuthProvider;
 import basakan.fryday.domain.user.OnboardingStatus;
 import basakan.fryday.domain.user.User;
@@ -349,6 +350,30 @@ class UserControllerTest extends RestDocsSupport {
     }
 
     @Test
+    @DisplayName("알림 설정 조회 API")
+    @WithMockUser
+    void getNotificationSettings() throws Exception {
+        // given
+        NotificationSettingsResponse mockResponse = NotificationSettingsResponse.of(true, false);
+
+        given(userAppService.getNotificationSettings())
+                .willReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/users/me/notification-settings"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pushNotificationEnabled").value(true))
+                .andExpect(jsonPath("$.marketingAgreed").value(false))
+                .andDo(document("user-notification-settings-get",
+                        responseFields(
+                                fieldWithPath("pushNotificationEnabled").type(JsonFieldType.BOOLEAN).description("현재 디바이스의 푸시 알림 수신 여부"),
+                                fieldWithPath("marketingAgreed").type(JsonFieldType.BOOLEAN).description("마케팅 정보 수신 동의 여부")
+                        )
+                ));
+    }
+
+    @Test
     @DisplayName("알림 설정 변경 API")
     @WithMockUser
     void updateNotificationSettings() throws Exception {
@@ -366,7 +391,7 @@ class UserControllerTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.message").value("알림 설정이 성공적으로 변경되었습니다."))
                 .andDo(document("user-notification-settings-update",
                         requestFields(
-                                fieldWithPath("pushNotificationEnabled").type(JsonFieldType.BOOLEAN).description("푸시 알림 수신 여부 (true: 수신, false: 거부)")
+                                fieldWithPath("pushNotificationEnabled").type(JsonFieldType.BOOLEAN).description("현재 디바이스의 푸시 알림 수신 여부 (true: 수신, false: 거부)")
                         ),
                         responseFields(
                                 fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")
@@ -389,7 +414,7 @@ class UserControllerTest extends RestDocsSupport {
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("마케팅 수신 동의가 완료되었습니다."))
+                .andExpect(jsonPath("$.message").value("마케팅 수신 정보가 성공적으로 변경되었습니다."))
                 .andDo(document("user-marketing-consent",
                         requestFields(
                                 fieldWithPath("marketingOptional").type(JsonFieldType.BOOLEAN).description("마케팅 정보 수신 동의 (선택)")


### PR DESCRIPTION
  ## 📌 Related Issue                                                                                                                                                                                                              
  - close: #                                                                                                                                                                                                                       
                                                                                                                                                                                                                                   
  ## 🚀 Description                                                                                                                                                                                                                
                                                                                                                                                                                                                                   
  ### 1. JWT accessToken에 deviceId 추가                                                                                                                                                                                           
  - accessToken 생성 시 `deviceId` claim 추가                                                                                                                                                                                      
  - `JwtAuthenticationFilter`에서 deviceId 추출 후 `authentication.details`에 저장                                                                                                                                                 
  - `UserContext.getCurrentDeviceId()`로 어디서든 현재 디바이스 ID 조회 가능                                                                                                                                                       
                                                                                                                                                                                                                                   
  ### 2. 푸시 알림 설정을 디바이스 단위로 이동                                                                                                                                                                                     
  - `Agreement.pushNotificationAgreed` → `UserDevice.pushNotificationAgreed`로 이동                                                                                                                                                
  - `FcmPushService`에서 디바이스별 푸시 활성 여부 필터링                                                                                                                                                                          
  - 스케줄러(Deadline/Burnt/Encourage)에서 Agreement 의존 제거                                                                                                                                                                     
                                                                                                                                                                                                                                   
  ### 3. 알림 설정 조회 API 추가                                                                                                                                                                                                   
  - `GET /api/users/me/notification-settings` 엔드포인트 추가                                                                                                                                                                      
  - 현재 디바이스의 푸시 알림 여부 + 마케팅 수신 여부 조회                                                                                                                                                                         
  - REST Docs 문서화 반영                                                                                                                                                                                                          
                                                                                                                                                                                                                                   
  ### 4. 회원 탈퇴 시 연관 데이터 전체 삭제                                                                                                                                                                                        
  - 탈퇴 시 Redis refresh token, TodoAlarm, RecurrenceException, Todo, Recurrence, Category, MonthlyReport, DailyResult, UserDevice, Agreement 순서대로 삭제                                                                       
  - FK 제약 순서를 고려한 안전한 삭제 순서 적용                                                                                                                                                                                    
  - JPQL `@Modifying` 벌크 삭제 적용 (TodoAlarm, RecurrenceException, Todo)                                                                                                                                                        
                                                                                                                                                                                                                                   
  ### 5. 탈퇴 7일 경과 계정 자동 삭제 스케줄러                                                                                                                                                                                     
  - `WithdrawnAccountCleanupScheduler` 매일 00:30(KST) 실행                                                                                                                                                                        
  - WITHDRAWN 상태 + withdrawnAt 7일 경과 계정 물리 삭제                                                                                                                                                                           
                                                                                                                                                                                                                                   
  ## 📢 Notes                                                                                                                                                                                                                      
  - 기존 JWT 토큰(deviceId claim 없음)으로 알림 설정 API 호출 시 재로그인 필요 (명시적 예외 처리)                                                                                                                                  
  - `Agreement.pushNotificationAgreed` 필드는 제거 완료 (UserDevice로 이관됨)                                                                                                                                                      
  - Redis `deleteAllByUserId`는 `KEYS *` 스캔 방식 — 유저 수 증가 시 `SCAN` 또는 보조 Set 키 방식으로 개선 필요 