### PR TITLE
fix: Todo 수정 시 Lost Update 방지 - 필드 단위 UPDATE 적용

### DIFF
--- a/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
@@ -82,6 +82,26 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     );
 
     @Modifying(clearAutomatically = true)
+    @Query("UPDATE Todo t SET t.description = :description WHERE t.id = :todoId AND t.deletedAt IS NULL AND t.category.userId = :userId")
+    int updateDescriptionByIdAndUserId(@Param("todoId") Long todoId, @Param("userId") Long userId, @Param("description") String description);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Todo t SET t.memo = :memo WHERE t.id = :todoId AND t.deletedAt IS NULL AND t.category.userId = :userId")
+    int updateMemoByIdAndUserId(@Param("todoId") Long todoId, @Param("userId") Long userId, @Param("memo") String memo);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Todo t SET t.date = :date WHERE t.id = :todoId AND t.deletedAt IS NULL AND t.recurrenceId IS NULL AND t.category.userId = :userId")
+    int updateDateByIdAndUserIdForNonRecurring(@Param("todoId") Long todoId, @Param("userId") Long userId, @Param("date") LocalDate date);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Todo t SET t.category = (SELECT c FROM Category c WHERE c.id = :categoryId AND c.userId = :userId) WHERE t.id = :todoId AND t.deletedAt IS NULL AND t.category.userId = :userId")
+    int updateCategoryByIdAndUserId(@Param("todoId") Long todoId, @Param("userId") Long userId, @Param("categoryId") Long categoryId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Todo t SET t.recurrenceId = :recurrenceId WHERE t.id = :todoId AND t.deletedAt IS NULL AND t.category.userId = :userId")
+    int updateRecurrenceIdByIdAndUserId(@Param("todoId") Long todoId, @Param("userId") Long userId, @Param("recurrenceId") Long recurrenceId);
+
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Todo t WHERE t.category.id IN " +
             "(SELECT c.id FROM Category c WHERE c.userId = :userId)")
     void deleteAllByUserId(@Param("userId") Long userId);

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
@@ -30,7 +30,12 @@ public class RecurrenceService {
     @Transactional
     public TodoResponse createRecurrence(Long userId, RecurrenceCreateRequest request) {
         Todo originalTodo = todoRepository.findById(request.getTodoId())
+                .filter(t -> !t.isDeleted())
                 .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        if (!originalTodo.getCategory().getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
 
         Recurrence recurrence = Recurrence.builder()
                 .userId(userId)
@@ -49,10 +54,13 @@ public class RecurrenceService {
 
         Recurrence savedRecurrence = recurrenceRepository.save(recurrence);
 
-        // 원본 투두에 recurrenceId 연결
-        originalTodo.setRecurrenceId(savedRecurrence.getId());
+        // 원본 투두에 recurrenceId만 갱신 (Lost Update 방지용 필드 단위 UPDATE)
+        int updated = todoRepository.updateRecurrenceIdByIdAndUserId(
+                request.getTodoId(), userId, savedRecurrence.getId());
+        if (updated == 0) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
 
-        // Todo 의미 확인 필요
         RecurrenceException exception = RecurrenceException.builder()
                 .recurrenceId(savedRecurrence.getId())
                 .occurrenceDate(originalTodo.getDate())
@@ -60,10 +68,9 @@ public class RecurrenceService {
                 .build();
         recurrenceExceptionRepository.save(exception);
 
-        // 반복 규칙만 저장하고, 투두는 대량 생성하지 않음
-        // 가상 회차는 조회 시 동적으로 생성됨
-
-        return TodoResponse.from(originalTodo);
+        Todo todo = todoRepository.findById(request.getTodoId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+        return TodoResponse.from(todo);
     }
 
     /**

--- a/src/main/java/basakan/fryday/service/todo/TodoService.java
+++ b/src/main/java/basakan/fryday/service/todo/TodoService.java
@@ -78,11 +78,12 @@ public class TodoService {
 
     @Transactional
     public MemoResponse updateMemo(Long todoId, Long userId, MemoRequest request) {
+        int updated = todoRepository.updateMemoByIdAndUserId(todoId, userId, request.getMemo());
+        if (updated == 0) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
         Todo todo = todoRepository.findById(todoId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
-
-        todo.updateMemo(request.getMemo());
-
         return MemoResponse.from(todo.getId(), todo.getMemo());
     }
 
@@ -190,6 +191,19 @@ public class TodoService {
 
     @Transactional
     public TodoResponse updateTodoDate(Long todoId, Long userId, TodoDateUpdateRequest request) {
+        if (request.getDate().isBefore(LocalDate.now())) {
+            throw new BusinessException(ErrorCode.PAST_DATE_NOT_ALLOWED);
+        }
+
+        // 일반 투두(반복 아님): date 필드만 갱신 (Lost Update 방지)
+        int updated = todoRepository.updateDateByIdAndUserIdForNonRecurring(todoId, userId, request.getDate());
+        if (updated > 0) {
+            Todo todo = todoRepository.findById(todoId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+            return TodoResponse.from(todo);
+        }
+
+        // 반복 투두인 경우
         Todo todo = todoRepository.findById(todoId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
 
@@ -197,76 +211,55 @@ public class TodoService {
             throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
         }
 
-        if (request.getDate().isBefore(LocalDate.now())) {
-            throw new BusinessException(ErrorCode.PAST_DATE_NOT_ALLOWED);
+        if (todo.getRecurrenceId() == null) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
         }
 
-        // 반복 투두인 경우 자동으로 detach 처리
-        if (todo.getRecurrenceId() != null) {
-            Long recurrenceId = todo.getRecurrenceId();
-            LocalDate occurrenceDate = todo.getDate();
-            LocalDate newDate = request.getDate();
+        Long recurrenceId = todo.getRecurrenceId();
+        LocalDate occurrenceDate = todo.getDate();
+        LocalDate newDate = request.getDate();
 
-            // Recurrence 검증
-            Recurrence recurrence = recurrenceRepository.findById(recurrenceId)
-                    .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+        Recurrence recurrence = recurrenceRepository.findById(recurrenceId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
 
-            if (recurrence.getUserId() != userId) {
-                throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
-            }
-
-            // 이미 예외가 존재하는지 확인
-            RecurrenceException existingException = recurrenceExceptionRepository
-                    .findByRecurrenceIdAndOccurrenceDate(recurrenceId, occurrenceDate)
-                    .orElse(null);
-
-            // DETACHED 예외가 이미 존재하면 이미 분리된 투두
-            if (existingException != null && existingException.getType() == RecurrenceException.ExceptionType.DETACHED) {
-                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
-            }
-
-            boolean shouldCreateDetached = (existingException == null);
-
-            // 날짜 변경: 대상 날짜에 이미 반복 투두가 있어도 이동 허용.
-            if (!occurrenceDate.equals(newDate)) {
-                todo.updateDate(newDate);
-                // displayOrder 재계산
-                Long maxOrder = todoRepository.findMaxDisplayOrder(userId, newDate);
-                long displayOrder = (maxOrder == null) ? 1 : maxOrder + 1;
-                todo.updateDisplayOrder(displayOrder);
-            }
-
-            todo.setRecurrenceId(null);
-
-            if (shouldCreateDetached) {
-                RecurrenceException exception = RecurrenceException.builder()
-                        .recurrenceId(recurrenceId)
-                        .occurrenceDate(occurrenceDate)
-                        .type(RecurrenceException.ExceptionType.DETACHED)
-                        .detachedTodoId(todo.getId())
-                        .build();
-                recurrenceExceptionRepository.save(exception);
-            }
-
-            return TodoResponse.from(todo);
+        if (recurrence.getUserId() != userId) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
         }
 
-        // 일반 투두인 경우 기존 로직
-        todo.updateDate(request.getDate());
+        RecurrenceException existingException = recurrenceExceptionRepository
+                .findByRecurrenceIdAndOccurrenceDate(recurrenceId, occurrenceDate)
+                .orElse(null);
+
+        if (existingException != null && existingException.getType() == RecurrenceException.ExceptionType.DETACHED) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        boolean shouldCreateDetached = (existingException == null);
+
+        if (!occurrenceDate.equals(newDate)) {
+            todo.updateDate(newDate);
+            Long maxOrder = todoRepository.findMaxDisplayOrder(userId, newDate);
+            long displayOrder = (maxOrder == null) ? 1 : maxOrder + 1;
+            todo.updateDisplayOrder(displayOrder);
+        }
+
+        todo.setRecurrenceId(null);
+
+        if (shouldCreateDetached) {
+            RecurrenceException exception = RecurrenceException.builder()
+                    .recurrenceId(recurrenceId)
+                    .occurrenceDate(occurrenceDate)
+                    .type(RecurrenceException.ExceptionType.DETACHED)
+                    .detachedTodoId(todo.getId())
+                    .build();
+            recurrenceExceptionRepository.save(exception);
+        }
 
         return TodoResponse.from(todo);
     }
 
     @Transactional
     public TodoResponse updateCategory(Long todoId, Long userId, TodoCategoryUpdateRequest request) {
-        Todo todo = todoRepository.findById(todoId)
-                .filter(t -> !t.isDeleted())
-                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
-
-        if (!todo.getCategory().getUserId().equals(userId)) {
-            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
-        }
-
         Category newCategory = categoryRepository.findById(request.getCategoryId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
 
@@ -274,8 +267,12 @@ public class TodoService {
             throw new BusinessException(ErrorCode.CATEGORY_NOT_FOUND);
         }
 
-        todo.updateCategory(newCategory);
-
+        int updated = todoRepository.updateCategoryByIdAndUserId(todoId, userId, request.getCategoryId());
+        if (updated == 0) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
+        Todo todo = todoRepository.findById(todoId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
         return TodoResponse.from(todo);
     }
 
@@ -381,16 +378,12 @@ public class TodoService {
 
     @Transactional
     public TodoResponse updateDescription(Long todoId, Long userId, TodoDescriptionUpdateRequest request) {
-        Todo todo = todoRepository.findById(todoId)
-                .filter(t -> !t.isDeleted())
-                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
-
-        if (!todo.getCategory().getUserId().equals(userId)) {
+        int updated = todoRepository.updateDescriptionByIdAndUserId(todoId, userId, request.getDescription());
+        if (updated == 0) {
             throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
         }
-
-        todo.updateDescription(request.getDescription());
-
+        Todo todo = todoRepository.findById(todoId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
         return TodoResponse.from(todo);
     }
 


### PR DESCRIPTION
## 📌 Related Issue
- close: #76 

## 🚀 Description

Todo를 대상으로 **updateDescription, updateMemo, updateTodoDate, updateCategory, createRecurringTodo** 등이 동시에 호출될 때, 마지막에 커밋된 트랜잭션만 반영되고 나머지 변경이 덮어써지는 **Lost Update** 문제를 해결.

### 해결 방식: `@Modifying` + `@Query`로 특정 컬럼만 UPDATE

- **기존**: 각 API가 `findById` → 엔티티 필드 수정 → 트랜잭션 커밋 시 JPA가 **엔티티 전체를 한 번에 UPDATE**. 동시 요청 시 각 트랜잭션이 가진 “스냅샷” 중 마지막 커밋만 DB에 남음.
- **변경**: **필드별로** `UPDATE todo SET description = :desc WHERE id = :id AND ...` 형태의 JPQL을 직접 실행하도록 수정.
  - `TodoRepository`에 `updateDescriptionByIdAndUserId`, `updateMemoByIdAndUserId`, `updateDateByIdAndUserIdForNonRecurring`, `updateCategoryByIdAndUserId`, `updateRecurrenceIdByIdAndUserId` 메서드 추가.
  - 각 메서드는 `@Modifying(clearAutomatically = true)` + `@Query`로 **해당 컬럼만** 갱신.
- **Lost Update가 해결되는 이유**
  - description만 바꾸는 API는 **description 컬럼만** UPDATE하고, memo만 바꾸는 API는 **memo 컬럼만** UPDATE. 서로 다른 컬럼을 갱신하므로 한 트랜잭션이 다른 트랜잭션이 수정한 필드를 덮어쓰지 않음.
  - `clearAutomatically = true`로 수정 후 1차 캐시를 비워, 이후 `findById` 시 DB 기준 최신 상태를 사용하도록 함.

### 낙관적/비관적 락이 아닌 이 방식을 선택한 이유

- **낙관적 락 (@Version)**: 충돌 시 저장 실패 → 재시도/알림 필요. 재시도가 반복될 수 있어, 그렇게 되면 사용자 경험이 떨어진다는 판단. 이번에는 필드 단위 UPDATE로 충돌 자체를 줄이는 쪽이 더 적합하다고 판단.
- **비관적 락 (PESSIMISTIC_WRITE)**: 같은 행을 수정하는 요청이 직렬화되어 대기 시간이 길어질 수 있고, Deadlock 위험. description / memo / date / category / recurrenceId를 **서로 다른 API**가 각각 수정하는 구조이므로, 락 없이 “컬럼만 갱신”하는 것만으로 Lost Update를 막을 수 있어 사용하지 않음. 
- **필드 단위 UPDATE**: 서로 다른 필드를 동시에 바꿀 때 덮어쓰기가 발생하지 않고, 락·재시도 없이 구현이 단순하여 이번 API 구조에 맞는 방식으로 선택함.


## 📢 Notes

- `updateTodoDate`는 **반복 투두가 아닌 경우**만 필드 단위 UPDATE를 사용하고, 반복 투두(detach 등)는 기존 findById 기반 로직 유지