### PR TITLE
소셜 로그인 이메일 정보 수집 추가

### DIFF
--- a/src/main/java/basakan/fryday/controller/user/response/SocialLoginResponse.java
+++ b/src/main/java/basakan/fryday/controller/user/response/SocialLoginResponse.java
@@ -27,6 +27,7 @@ public class SocialLoginResponse {
                 .provider(dto.provider())
                 .role(dto.role())
                 .nickname(dto.nickname())
+                .email(dto.email())
                 .build();
 
         return SocialLoginResponse.builder()
@@ -47,5 +48,6 @@ public class SocialLoginResponse {
         private AuthProvider provider;
         private User.Role role;
         private String nickname;
+        private String email;
     }
 }

--- a/src/main/java/basakan/fryday/domain/user/User.java
+++ b/src/main/java/basakan/fryday/domain/user/User.java
@@ -22,6 +22,8 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String providerUserId;
 
+    private String email;
+
     private String nickname;
 
     @Enumerated(EnumType.STRING)
@@ -39,24 +41,32 @@ public class User extends BaseEntity {
     private LocalDateTime withdrawnAt;
 
     @Builder
-    private User(AuthProvider provider, String providerUserId, String nickname,
+    private User(AuthProvider provider, String providerUserId, String email, String nickname,
                  OnboardingStatus onboardingStatus, AccountStatus accountStatus, Role role) {
         this.provider = provider;
         this.providerUserId = providerUserId;
+        this.email = email;
         this.nickname = nickname;
         this.onboardingStatus = onboardingStatus != null ? onboardingStatus : OnboardingStatus.NEEDS_AGREEMENT;
         this.accountStatus = accountStatus != null ? accountStatus : AccountStatus.ACTIVE;
         this.role = role != null ? role : Role.USER;
     }
 
-    public static User createNewUser(AuthProvider provider, String providerUserId) {
+    public static User createNewUser(AuthProvider provider, String providerUserId, String email) {
         return User.builder()
                 .provider(provider)
                 .providerUserId(providerUserId)
+                .email(email)
                 .onboardingStatus(OnboardingStatus.NEEDS_AGREEMENT)
                 .accountStatus(AccountStatus.ACTIVE)
                 .role(Role.USER)
                 .build();
+    }
+
+    public void updateEmail(String email) {
+        if (email != null) {
+            this.email = email;
+        }
     }
 
     public void completeAgreementStep() {

--- a/src/main/java/basakan/fryday/repository/auth/client/SocialUserInfo.java
+++ b/src/main/java/basakan/fryday/repository/auth/client/SocialUserInfo.java
@@ -4,6 +4,7 @@ import basakan.fryday.domain.user.AuthProvider;
 
 public record SocialUserInfo(
         AuthProvider provider,
-        String providerUserId
+        String providerUserId,
+        String email
 ) {
 }

--- a/src/main/java/basakan/fryday/repository/auth/client/apple/AppleOAuthClient.java
+++ b/src/main/java/basakan/fryday/repository/auth/client/apple/AppleOAuthClient.java
@@ -58,7 +58,10 @@ public class AppleOAuthClient implements SocialProviderClient {
                 throw new InvalidProviderTokenException();
             }
 
-            return new SocialUserInfo(AuthProvider.APPLE, subject);
+            // 7. email 추출 (최초 로그인 시에만 존재할 수 있음)
+            String email = claims.get("email", String.class);
+
+            return new SocialUserInfo(AuthProvider.APPLE, subject, email);
         } catch (InvalidProviderTokenException e) {
             throw e;
         } catch (Exception e) {

--- a/src/main/java/basakan/fryday/repository/auth/client/kakao/KakaoOAuthClient.java
+++ b/src/main/java/basakan/fryday/repository/auth/client/kakao/KakaoOAuthClient.java
@@ -42,7 +42,8 @@ public class KakaoOAuthClient implements SocialProviderClient {
                 throw new InvalidProviderTokenException();
             }
 
-            return new SocialUserInfo(AuthProvider.KAKAO, socialId);
+            String email = userResponse.getEmail();
+            return new SocialUserInfo(AuthProvider.KAKAO, socialId, email);
         } catch (InvalidProviderTokenException e) {
             throw e;
         } catch (Exception e) {

--- a/src/main/java/basakan/fryday/repository/auth/client/kakao/KakaoUserInfoResponse.java
+++ b/src/main/java/basakan/fryday/repository/auth/client/kakao/KakaoUserInfoResponse.java
@@ -11,7 +11,21 @@ class KakaoUserInfoResponse {
     @JsonProperty("id")
     private Long id;
 
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
     public String getSocialId() {
         return id != null ? String.valueOf(id) : null;
+    }
+
+    public String getEmail() {
+        return kakaoAccount != null ? kakaoAccount.getEmail() : null;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    static class KakaoAccount {
+        @JsonProperty("email")
+        private String email;
     }
 }

--- a/src/main/java/basakan/fryday/repository/auth/client/naver/NaverOAuthClient.java
+++ b/src/main/java/basakan/fryday/repository/auth/client/naver/NaverOAuthClient.java
@@ -42,7 +42,8 @@ public class NaverOAuthClient implements SocialProviderClient {
                 throw new InvalidProviderTokenException();
             }
 
-            return new SocialUserInfo(AuthProvider.NAVER, socialId);
+            String email = userResponse.getEmail();
+            return new SocialUserInfo(AuthProvider.NAVER, socialId, email);
         } catch (InvalidProviderTokenException e) {
             throw e;
         } catch (Exception e) {

--- a/src/main/java/basakan/fryday/repository/auth/client/naver/NaverUserInfoResponse.java
+++ b/src/main/java/basakan/fryday/repository/auth/client/naver/NaverUserInfoResponse.java
@@ -22,9 +22,16 @@ class NaverUserInfoResponse {
     static class ResponseData {
         @JsonProperty("id")
         private String id;
+
+        @JsonProperty("email")
+        private String email;
     }
 
     public String getSocialId() {
         return response != null ? response.getId() : null;
+    }
+
+    public String getEmail() {
+        return response != null ? response.getEmail() : null;
     }
 }

--- a/src/main/java/basakan/fryday/service/auth/dto/SocialLoginDto.java
+++ b/src/main/java/basakan/fryday/service/auth/dto/SocialLoginDto.java
@@ -11,6 +11,7 @@ public record SocialLoginDto(
         AuthProvider provider,
         User.Role role,
         String nickname,
+        String email,
         OnboardingStatus onboardingStatus,
         String accessToken,
         String refreshToken,
@@ -22,6 +23,7 @@ public record SocialLoginDto(
                 .provider(provider)
                 .role(user.getRole())
                 .nickname(user.getNickname())
+                .email(user.getEmail())
                 .onboardingStatus(user.getOnboardingStatus())
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)

--- a/src/main/java/basakan/fryday/service/user/UserAppService.java
+++ b/src/main/java/basakan/fryday/service/user/UserAppService.java
@@ -160,6 +160,9 @@ public class UserAppService {
                     ).orElseGet(() -> userWriteService.createUser(socialUserInfo));
 
             validateUserStatus(user);
+
+            // 기존 유저의 이메일이 없고 새로 받아온 이메일이 있으면 업데이트
+            userWriteService.updateEmailIfAbsent(user, socialUserInfo.email());
         }
 
         userDeviceReadService.findByUserIdAndDeviceId(user.getId(), serviceDto.deviceId())

--- a/src/main/java/basakan/fryday/service/user/UserWriteService.java
+++ b/src/main/java/basakan/fryday/service/user/UserWriteService.java
@@ -114,9 +114,17 @@ public class UserWriteService {
     public User createUser(SocialUserInfo socialUserInfo) {
         User newUser = User.createNewUser(
                 socialUserInfo.provider(),
-                socialUserInfo.providerUserId()
+                socialUserInfo.providerUserId(),
+                socialUserInfo.email()
         );
         return userJpaRepository.save(newUser);
+    }
+
+    public void updateEmailIfAbsent(User user, String email) {
+        if (user.getEmail() == null && email != null) {
+            user.updateEmail(email);
+            userJpaRepository.save(user);
+        }
     }
 
     public User handleWithdrawnUserReregister(User withdrawnUser, SocialUserInfo socialUserInfo) {

--- a/src/test/java/basakan/fryday/common/client/MockSocialProviderClient.java
+++ b/src/test/java/basakan/fryday/common/client/MockSocialProviderClient.java
@@ -21,7 +21,8 @@ public class MockSocialProviderClient implements SocialProviderClient {
     public SocialUserInfo getUserInfo(String accessToken, String idToken) {
         return new SocialUserInfo(
                 provider,
-                "mock-provider-user-id-" + accessToken
+                "mock-provider-user-id-" + accessToken,
+                "mock-email-" + accessToken + "@test.com"
         );
     }
 }

--- a/src/test/java/basakan/fryday/controller/user/UserControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/user/UserControllerTest.java
@@ -69,6 +69,7 @@ class UserControllerTest extends RestDocsSupport {
                 .onboardingStatus(OnboardingStatus.NEEDS_AGREEMENT)
                 .role(User.Role.USER)
                 .nickname(null)
+                .email("user@kakao.com")
                 .accessToken("jwt-access-token")
                 .refreshToken("jwt-refresh-token")
                 .deviceId("device-id-123")
@@ -103,7 +104,8 @@ class UserControllerTest extends RestDocsSupport {
                                 fieldWithPath("user.id").type(JsonFieldType.NUMBER).description("사용자 ID"),
                                 fieldWithPath("user.provider").type(JsonFieldType.STRING).description("소셜 로그인 제공자"),
                                 fieldWithPath("user.role").type(JsonFieldType.STRING).description("사용자 권한 (USER, ADMIN)"),
-                                fieldWithPath("user.nickname").type(JsonFieldType.STRING).description("사용자 닉네임").optional()
+                                fieldWithPath("user.nickname").type(JsonFieldType.STRING).description("사용자 닉네임").optional(),
+                                fieldWithPath("user.email").type(JsonFieldType.STRING).description("사용자 이메일 (소셜 제공자로부터 수집, 미동의 시 null)").optional()
                         )
                 ));
     }
@@ -127,6 +129,7 @@ class UserControllerTest extends RestDocsSupport {
                 .onboardingStatus(OnboardingStatus.NEEDS_AGREEMENT)
                 .role(User.Role.USER)
                 .nickname(null)
+                .email("user@privaterelay.appleid.com")
                 .accessToken("jwt-access-token")
                 .refreshToken("jwt-refresh-token")
                 .deviceId("device-id-123")
@@ -161,7 +164,8 @@ class UserControllerTest extends RestDocsSupport {
                                 fieldWithPath("user.id").type(JsonFieldType.NUMBER).description("사용자 ID"),
                                 fieldWithPath("user.provider").type(JsonFieldType.STRING).description("소셜 로그인 제공자"),
                                 fieldWithPath("user.role").type(JsonFieldType.STRING).description("사용자 권한 (USER, ADMIN)"),
-                                fieldWithPath("user.nickname").type(JsonFieldType.STRING).description("사용자 닉네임").optional()
+                                fieldWithPath("user.nickname").type(JsonFieldType.STRING).description("사용자 닉네임").optional(),
+                                fieldWithPath("user.email").type(JsonFieldType.STRING).description("사용자 이메일 (소셜 제공자로부터 수집, 미동의 시 null)").optional()
                         )
                 ));
     }


### PR DESCRIPTION
## 📌 Related Issue
- close: #

## 🚀 Description
소셜 로그인 시 이메일 정보를 수집하여 User 엔티티에 저장하는 기능을 추가했습니다.                                                                                             
                                                                                                                                                                                
  - 카카오, 네이버, 애플 OAuth 클라이언트에서 이메일 추출 로직 추가                                                                                                             
  - SocialUserInfo에 email 필드 추가                                                                                                                                            
  - User 엔티티에 email 컬럼 추가 (nullable)                                                                                                                                    
  - 신규 유저 생성 시 이메일 저장, 기존 유저 이메일 미존재 시 업데이트 처리                                                                                                     
  - 소셜 로그인 API 응답(SocialLoginResponse)에 email 필드 포함                                                                                                                 

## 📢 Notes
                                                                                                                                                                                
  - 애플의 경우 최초 로그인 시에만 이메일이 제공될 수 있습니다.                                                                                                                 
  - email 컬럼은 nullable이며, 소셜 프로바이더에서 이메일 동의를 하지 않은 경우 null로 저장됩니다.                                                                              
