### PR TITLE
온보딩 플로우 수정 - MARKETING 삭제

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -25,8 +25,8 @@
 |상태 |설명 |다음 화면
 
 |`NEEDS_AGREEMENT`
-|개인정보 수집 및 이용 동의가 필요한 상태 (최초 가입 첫 단계)
-|개인정보 동의 화면
+|약관 동의가 필요한 상태 (최초 가입 첫 단계)
+|약관 동의 화면
 
 |`NEEDS_NICKNAME`
 |닉네임 설정이 필요한 상태 (두 번째 단계)
@@ -36,16 +36,12 @@
 |온보딩 화면 확인이 필요한 상태 (세 번째 단계)
 |온보딩 화면
 
-|`NEEDS_MARKETING`
-|마케팅 수신 동의가 필요한 상태 (네 번째 단계)
-|마케팅 수신 동의 화면
-
 |`COMPLETED`
 |모든 설정이 완료된 상태 (정상 로그인)
 |메인 화면
 |===
 
-NOTE: 온보딩은 NEEDS_AGREEMENT → NEEDS_NICKNAME → NEEDS_ONBOARDING → NEEDS_MARKETING → COMPLETED 순서로 진행됩니다.
+NOTE: 온보딩은 NEEDS_AGREEMENT → NEEDS_NICKNAME → NEEDS_ONBOARDING → COMPLETED 순서로 진행됩니다.
 
 ==== 요청 필드
 include::{snippets}/user-social-login/request-fields.adoc[]
@@ -73,8 +69,8 @@ include::{snippets}/user-social-login/response-fields.adoc[]
 |상태 |설명 |다음 화면
 
 |`NEEDS_AGREEMENT`
-|개인정보 수집 및 이용 동의가 필요한 상태 (최초 가입 첫 단계)
-|개인정보 동의 화면
+|약관 동의가 필요한 상태 (최초 가입 첫 단계)
+|약관 동의 화면
 
 |`NEEDS_NICKNAME`
 |닉네임 설정이 필요한 상태 (두 번째 단계)
@@ -83,10 +79,6 @@ include::{snippets}/user-social-login/response-fields.adoc[]
 |`NEEDS_ONBOARDING`
 |온보딩 화면 확인이 필요한 상태 (세 번째 단계)
 |온보딩 화면
-
-|`NEEDS_MARKETING`
-|마케팅 수신 동의가 필요한 상태 (네 번째 단계)
-|마케팅 수신 동의 화면
 
 |`COMPLETED`
 |모든 설정이 완료된 상태 (정상 로그인)
@@ -134,10 +126,10 @@ include::{snippets}/user-nickname-check-unavailable/http-response.adoc[]
 ===== 응답 필드
 include::{snippets}/user-nickname-check-unavailable/response-fields.adoc[]
 
-=== 개인정보 동의 (온보딩 1단계)
+=== 약관 동의 (온보딩 1단계)
 `POST /api/users/me/consent`
 
-개인정보 수집 및 이용에 동의합니다. (인증 필요)
+이용약관, 개인정보 수집 및 이용, 마케팅 수신 동의를 한번에 처리합니다. (인증 필요)
 
 ==== 요청 필드
 include::{snippets}/user-consent/request-fields.adoc[]
@@ -182,10 +174,10 @@ include::{snippets}/user-onboarding/http-response.adoc[]
 ==== 응답 필드
 include::{snippets}/user-onboarding/response-fields.adoc[]
 
-=== 마케팅 수신 동의 (온보딩 4단계)
+=== 마케팅 수신 설정 변경
 `PATCH /api/users/me/marketing`
 
-마케팅 정보 수신 동의를 설정합니다. (인증 필요)
+마케팅 정보 수신 동의를 변경합니다. (인증 필요)
 
 ==== 요청 필드
 include::{snippets}/user-marketing-consent/request-fields.adoc[]

--- a/src/main/java/basakan/fryday/controller/user/UserController.java
+++ b/src/main/java/basakan/fryday/controller/user/UserController.java
@@ -66,8 +66,8 @@ public class UserController {
 
     @PostMapping("/me/consent")
     public ResponseEntity<MessageResponse> agreeConsent(@Valid @RequestBody ConsentRequest request) {
-        userAppService.agreeConsent(request.privacyRequired());
-        return ResponseEntity.ok(new MessageResponse("개인정보 수집 및 이용에 동의하였습니다."));
+        userAppService.agreeConsent(request.termsRequired(), request.privacyRequired(), request.marketingOptional());
+        return ResponseEntity.ok(new MessageResponse("약관 동의가 완료되었습니다."));
     }
 
     @PostMapping("/me/onboarding")

--- a/src/main/java/basakan/fryday/controller/user/request/ConsentRequest.java
+++ b/src/main/java/basakan/fryday/controller/user/request/ConsentRequest.java
@@ -3,7 +3,10 @@ package basakan.fryday.controller.user.request;
 import jakarta.validation.constraints.AssertTrue;
 
 public record ConsentRequest(
+        @AssertTrue(message = "이용약관 동의는 필수입니다.")
+        boolean termsRequired,
         @AssertTrue(message = "개인정보 수집 및 이용 동의는 필수입니다.")
-        boolean privacyRequired
+        boolean privacyRequired,
+        boolean marketingOptional
 ) {
 }

--- a/src/main/java/basakan/fryday/controller/user/response/SocialLoginResponse.java
+++ b/src/main/java/basakan/fryday/controller/user/response/SocialLoginResponse.java
@@ -4,6 +4,7 @@ import basakan.fryday.domain.user.AuthProvider;
 import basakan.fryday.domain.user.OnboardingStatus;
 import basakan.fryday.domain.user.User;
 import basakan.fryday.service.auth.dto.SocialLoginDto;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,6 +22,8 @@ public class SocialLoginResponse {
     private String accessToken;
     private String refreshToken;
     private String deviceId;
+    @JsonProperty("isNewDevice")
+    private boolean newDevice;
     private UserInfo user;
 
     public static SocialLoginResponse from(SocialLoginDto dto) {
@@ -38,6 +41,7 @@ public class SocialLoginResponse {
                 .accessToken(dto.accessToken())
                 .refreshToken(dto.refreshToken())
                 .deviceId(dto.deviceId())
+                .newDevice(dto.isNewDevice())
                 .user(userInfo)
                 .build();
     }

--- a/src/main/java/basakan/fryday/domain/user/Agreement.java
+++ b/src/main/java/basakan/fryday/domain/user/Agreement.java
@@ -17,6 +17,9 @@ public class Agreement extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false, unique = true)
     private User user;
 
+    @Column(name = "terms_agreed", nullable = false)
+    private boolean termsAgreed = false;
+
     @Column(nullable = false)
     private boolean privacyAgreed = false;
 
@@ -24,21 +27,24 @@ public class Agreement extends BaseEntity {
     private boolean marketingAgreed = false;
 
     @Builder
-    private Agreement(User user, boolean privacyAgreed, boolean marketingAgreed) {
+    private Agreement(User user, boolean termsAgreed, boolean privacyAgreed, boolean marketingAgreed) {
         this.user = user;
+        this.termsAgreed = termsAgreed;
         this.privacyAgreed = privacyAgreed;
         this.marketingAgreed = marketingAgreed;
     }
 
-    public static Agreement create(User user, boolean privacyAgreed, boolean marketingAgreed) {
+    public static Agreement create(User user, boolean termsAgreed, boolean privacyAgreed, boolean marketingAgreed) {
         return Agreement.builder()
                 .user(user)
+                .termsAgreed(termsAgreed)
                 .privacyAgreed(privacyAgreed)
                 .marketingAgreed(marketingAgreed)
                 .build();
     }
 
-    public void updateConsent(boolean privacyAgreed, boolean marketingAgreed) {
+    public void updateConsent(boolean termsAgreed, boolean privacyAgreed, boolean marketingAgreed) {
+        this.termsAgreed = termsAgreed;
         this.privacyAgreed = privacyAgreed;
         this.marketingAgreed = marketingAgreed;
     }

--- a/src/main/java/basakan/fryday/domain/user/OnboardingStatus.java
+++ b/src/main/java/basakan/fryday/domain/user/OnboardingStatus.java
@@ -1,18 +1,16 @@
 package basakan.fryday.domain.user;
 
 public enum OnboardingStatus {
-    NEEDS_AGREEMENT,     // 1단계: 개인정보 동의 필요
+    NEEDS_AGREEMENT,     // 1단계: 약관 동의 필요
     NEEDS_NICKNAME,      // 2단계: 닉네임 설정 필요
     NEEDS_ONBOARDING,    // 3단계: 온보딩 화면 확인 필요
-    NEEDS_MARKETING,     // 4단계: 마케팅 수신 동의 필요
-    COMPLETED;           // 완료 (모든 단계 통과)
+    COMPLETED;           // 완료
 
     public OnboardingStatus getNextStep() {
         return switch (this) {
             case NEEDS_AGREEMENT -> NEEDS_NICKNAME;
             case NEEDS_NICKNAME -> NEEDS_ONBOARDING;
-            case NEEDS_ONBOARDING -> NEEDS_MARKETING;
-            case NEEDS_MARKETING -> COMPLETED;
+            case NEEDS_ONBOARDING -> COMPLETED;
             case COMPLETED -> COMPLETED;
         };
     }

--- a/src/main/java/basakan/fryday/domain/user/User.java
+++ b/src/main/java/basakan/fryday/domain/user/User.java
@@ -79,10 +79,6 @@ public class User extends BaseEntity {
     }
 
     public void completeOnboardingStep() {
-        this.onboardingStatus = OnboardingStatus.NEEDS_MARKETING;
-    }
-
-    public void completeMarketingStep() {
         this.onboardingStatus = OnboardingStatus.COMPLETED;
     }
 

--- a/src/main/java/basakan/fryday/service/auth/dto/SocialLoginDto.java
+++ b/src/main/java/basakan/fryday/service/auth/dto/SocialLoginDto.java
@@ -18,9 +18,10 @@ public record SocialLoginDto(
         OnboardingStatus onboardingStatus,
         String accessToken,
         String refreshToken,
-        String deviceId
+        String deviceId,
+        boolean isNewDevice
 ) {
-    public static SocialLoginDto from(User user, AuthProvider provider, String accessToken, String refreshToken, String deviceId) {
+    public static SocialLoginDto from(User user, AuthProvider provider, String accessToken, String refreshToken, String deviceId, boolean isNewDevice) {
         return SocialLoginDto.builder()
                 .userId(user.getId())
                 .provider(provider)
@@ -32,6 +33,7 @@ public record SocialLoginDto(
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .deviceId(deviceId)
+                .isNewDevice(isNewDevice)
                 .build();
     }
 }

--- a/src/main/java/basakan/fryday/service/user/UserAppService.java
+++ b/src/main/java/basakan/fryday/service/user/UserAppService.java
@@ -45,14 +45,14 @@ public class UserAppService {
     private final UserDeviceWriteService userDeviceWriteService;
     private final CategoryService categoryService;
 
-    public void agreeConsent(boolean privacyRequired) {
+    public void agreeConsent(boolean termsRequired, boolean privacyRequired, boolean marketingOptional) {
         Long userId = UserContext.getCurrentUserId();
         User user = userReadService.findById(userId);
 
         Agreement agreement = userReadService.findAgreementByUser(user)
-                .orElseGet(() -> Agreement.create(user, privacyRequired, false));
+                .orElseGet(() -> Agreement.create(user, termsRequired, privacyRequired, marketingOptional));
 
-        userWriteService.agreeConsent(user, agreement, privacyRequired);
+        userWriteService.agreeConsent(user, agreement, termsRequired, privacyRequired, marketingOptional);
     }
 
     public void agreeMarketing(boolean marketingOptional) {
@@ -62,7 +62,7 @@ public class UserAppService {
         Agreement agreement = userReadService.findAgreementByUser(user)
                 .orElseThrow(() -> new BusinessException(ErrorCode.AGREEMENT_NOT_FOUND));
 
-        userWriteService.agreeMarketing(user, agreement, marketingOptional);
+        userWriteService.updateMarketingAgreement(agreement, marketingOptional);
     }
 
     public void completeOnboarding() {

--- a/src/main/java/basakan/fryday/service/user/UserAppService.java
+++ b/src/main/java/basakan/fryday/service/user/UserAppService.java
@@ -165,27 +165,30 @@ public class UserAppService {
             userWriteService.updateEmailIfAbsent(user, socialUserInfo.email());
         }
 
-        userDeviceReadService.findByUserIdAndDeviceId(user.getId(), serviceDto.deviceId())
-                .ifPresentOrElse(
-                        existingDevice -> {
-                            userDeviceWriteService.activateDevice(existingDevice);
-                            if (serviceDto.fcmToken() != null) {
-                                userDeviceWriteService.updateFcmToken(existingDevice, serviceDto.fcmToken());
-                            }
-                        },
-                        () -> userDeviceWriteService.createOrActivateDevice(
-                                user.getId(),
-                                serviceDto.deviceId(),
-                                serviceDto.deviceType(),
-                                serviceDto.deviceName(),
-                                serviceDto.fcmToken()
-                        )
-                );
+        boolean isNewDevice = userDeviceReadService
+                .findByUserIdAndDeviceId(user.getId(), serviceDto.deviceId())
+                .map(existingDevice -> {
+                    userDeviceWriteService.activateDevice(existingDevice);
+                    if (serviceDto.fcmToken() != null) {
+                        userDeviceWriteService.updateFcmToken(existingDevice, serviceDto.fcmToken());
+                    }
+                    return false;
+                })
+                .orElseGet(() -> {
+                    userDeviceWriteService.createOrActivateDevice(
+                            user.getId(),
+                            serviceDto.deviceId(),
+                            serviceDto.deviceType(),
+                            serviceDto.deviceName(),
+                            serviceDto.fcmToken()
+                    );
+                    return true;
+                });
 
         String accessToken = jwtTokenProvider.generateAccessToken(user.getId(), user.getRole(), user.getAccountStatus(), serviceDto.deviceId());
         String refreshToken = refreshTokenRepository.generateAndSave(user.getId(), serviceDto.deviceId());
 
-        return SocialLoginDto.from(user, socialUserInfo.provider(), accessToken, refreshToken, serviceDto.deviceId());
+        return SocialLoginDto.from(user, socialUserInfo.provider(), accessToken, refreshToken, serviceDto.deviceId(), isNewDevice);
     }
 
     public void updateDeviceFcmToken(String deviceId, String fcmToken) {

--- a/src/main/java/basakan/fryday/service/user/UserWriteService.java
+++ b/src/main/java/basakan/fryday/service/user/UserWriteService.java
@@ -36,18 +36,16 @@ public class UserWriteService {
     private final DailyResultRepository dailyResultRepository;
     private final RefreshTokenRepository refreshTokenRepository;
 
-    public void agreeConsent(User user, Agreement agreement, boolean privacyAgreed) {
-        agreement.updateConsent(privacyAgreed, false);
+    public void agreeConsent(User user, Agreement agreement, boolean termsAgreed, boolean privacyAgreed, boolean marketingAgreed) {
+        agreement.updateConsent(termsAgreed, privacyAgreed, marketingAgreed);
         agreementRepository.save(agreement);
         user.completeAgreementStep();
         userJpaRepository.save(user);
     }
 
-    public void agreeMarketing(User user, Agreement agreement, boolean marketingAgreed) {
+    public void updateMarketingAgreement(Agreement agreement, boolean marketingAgreed) {
         agreement.updateMarketingAgreement(marketingAgreed);
         agreementRepository.save(agreement);
-        user.completeMarketingStep();
-        userJpaRepository.save(user);
     }
 
     public void completeOnboarding(User user) {

--- a/src/test/java/basakan/fryday/controller/user/UserControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/user/UserControllerTest.java
@@ -76,6 +76,7 @@ class UserControllerTest extends RestDocsSupport {
                 .accessToken("jwt-access-token")
                 .refreshToken("jwt-refresh-token")
                 .deviceId("device-id-123")
+                .isNewDevice(true)
                 .build();
 
         given(userAppService.socialLogin(any()))
@@ -90,6 +91,7 @@ class UserControllerTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.onboardingStatus").value("NEEDS_AGREEMENT"))
                 .andExpect(jsonPath("$.accessToken").exists())
                 .andExpect(jsonPath("$.refreshToken").exists())
+                .andExpect(jsonPath("$.isNewDevice").value(true))
                 .andDo(document("user-social-login",
                         requestFields(
                                 fieldWithPath("provider").type(JsonFieldType.STRING).description("소셜 로그인 제공자 (KAKAO, NAVER)"),
@@ -100,10 +102,11 @@ class UserControllerTest extends RestDocsSupport {
                                 fieldWithPath("fcmToken").type(JsonFieldType.STRING).description("FCM 푸시 토큰").optional()
                         ),
                         responseFields(
-                                fieldWithPath("onboardingStatus").type(JsonFieldType.STRING).description("온보딩 상태 (NEEDS_AGREEMENT, NEEDS_NICKNAME, NEEDS_ONBOARDING, NEEDS_MARKETING, COMPLETED)"),
+                                fieldWithPath("onboardingStatus").type(JsonFieldType.STRING).description("온보딩 상태 (NEEDS_AGREEMENT, NEEDS_NICKNAME, NEEDS_ONBOARDING, COMPLETED)"),
                                 fieldWithPath("accessToken").type(JsonFieldType.STRING).description("JWT Access Token"),
                                 fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("JWT Refresh Token"),
                                 fieldWithPath("deviceId").type(JsonFieldType.STRING).description("디바이스 ID"),
+                                fieldWithPath("isNewDevice").type(JsonFieldType.BOOLEAN).description("새 디바이스 여부 (true: 푸시 알림 권한 요청 필요)"),
                                 fieldWithPath("user.id").type(JsonFieldType.NUMBER).description("사용자 ID"),
                                 fieldWithPath("user.provider").type(JsonFieldType.STRING).description("소셜 로그인 제공자"),
                                 fieldWithPath("user.role").type(JsonFieldType.STRING).description("사용자 권한 (USER, ADMIN)"),
@@ -138,6 +141,7 @@ class UserControllerTest extends RestDocsSupport {
                 .accessToken("jwt-access-token")
                 .refreshToken("jwt-refresh-token")
                 .deviceId("device-id-123")
+                .isNewDevice(true)
                 .build();
 
         given(userAppService.socialLogin(any()))
@@ -152,6 +156,7 @@ class UserControllerTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.onboardingStatus").value("NEEDS_AGREEMENT"))
                 .andExpect(jsonPath("$.accessToken").exists())
                 .andExpect(jsonPath("$.refreshToken").exists())
+                .andExpect(jsonPath("$.isNewDevice").value(true))
                 .andDo(document("user-apple-login",
                         requestFields(
                                 fieldWithPath("idToken").type(JsonFieldType.STRING).description("Apple ID Token (JWT)"),
@@ -162,10 +167,11 @@ class UserControllerTest extends RestDocsSupport {
                                 fieldWithPath("fcmToken").type(JsonFieldType.STRING).description("FCM 푸시 토큰").optional()
                         ),
                         responseFields(
-                                fieldWithPath("onboardingStatus").type(JsonFieldType.STRING).description("온보딩 상태 (NEEDS_AGREEMENT, NEEDS_NICKNAME, NEEDS_ONBOARDING, NEEDS_MARKETING, COMPLETED)"),
+                                fieldWithPath("onboardingStatus").type(JsonFieldType.STRING).description("온보딩 상태 (NEEDS_AGREEMENT, NEEDS_NICKNAME, NEEDS_ONBOARDING, COMPLETED)"),
                                 fieldWithPath("accessToken").type(JsonFieldType.STRING).description("JWT Access Token"),
                                 fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("JWT Refresh Token"),
                                 fieldWithPath("deviceId").type(JsonFieldType.STRING).description("디바이스 ID"),
+                                fieldWithPath("isNewDevice").type(JsonFieldType.BOOLEAN).description("새 디바이스 여부 (true: 푸시 알림 권한 요청 필요)"),
                                 fieldWithPath("user.id").type(JsonFieldType.NUMBER).description("사용자 ID"),
                                 fieldWithPath("user.provider").type(JsonFieldType.STRING).description("소셜 로그인 제공자"),
                                 fieldWithPath("user.role").type(JsonFieldType.STRING).description("사용자 권한 (USER, ADMIN)"),
@@ -177,13 +183,13 @@ class UserControllerTest extends RestDocsSupport {
     }
 
     @Test
-    @DisplayName("개인정보 동의 완료 API")
+    @DisplayName("약관 동의 완료 API")
     @WithMockUser
     void agreeConsent() throws Exception {
         // given
-        ConsentRequest request = new ConsentRequest(true);
+        ConsentRequest request = new ConsentRequest(true, true, false);
 
-        doNothing().when(userAppService).agreeConsent(anyBoolean());
+        doNothing().when(userAppService).agreeConsent(anyBoolean(), anyBoolean(), anyBoolean());
 
         // when & then
         mockMvc.perform(post("/api/users/me/consent")
@@ -191,10 +197,12 @@ class UserControllerTest extends RestDocsSupport {
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("개인정보 수집 및 이용에 동의하였습니다."))
+                .andExpect(jsonPath("$.message").value("약관 동의가 완료되었습니다."))
                 .andDo(document("user-consent",
                         requestFields(
-                                fieldWithPath("privacyRequired").type(JsonFieldType.BOOLEAN).description("개인정보 수집 및 이용 동의 (필수)")
+                                fieldWithPath("termsRequired").type(JsonFieldType.BOOLEAN).description("이용약관 동의 (필수)"),
+                                fieldWithPath("privacyRequired").type(JsonFieldType.BOOLEAN).description("개인정보 수집 및 이용 동의 (필수)"),
+                                fieldWithPath("marketingOptional").type(JsonFieldType.BOOLEAN).description("마케팅 정보 수신 동의 (선택)")
                         ),
                         responseFields(
                                 fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")
@@ -203,11 +211,26 @@ class UserControllerTest extends RestDocsSupport {
     }
 
     @Test
-    @DisplayName("개인정보 동의 API - 필수 동의 미체크 시 실패")
+    @DisplayName("약관 동의 API - 개인정보 동의 미체크 시 실패")
     @WithMockUser
     void agreeConsent_FailWhenPrivacyNotAgreed() throws Exception {
         // given
-        ConsentRequest request = new ConsentRequest(false);
+        ConsentRequest request = new ConsentRequest(true, false, false);
+
+        // when & then
+        mockMvc.perform(post("/api/users/me/consent")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("약관 동의 API - 이용약관 미동의 시 실패")
+    @WithMockUser
+    void agreeConsent_FailWhenTermsNotAgreed() throws Exception {
+        // given
+        ConsentRequest request = new ConsentRequest(false, true, false);
 
         // when & then
         mockMvc.perform(post("/api/users/me/consent")
@@ -410,7 +433,7 @@ class UserControllerTest extends RestDocsSupport {
     }
 
     @Test
-    @DisplayName("마케팅 수신 동의 API")
+    @DisplayName("마케팅 수신 설정 변경 API")
     @WithMockUser
     void agreeMarketing() throws Exception {
         // given


### PR DESCRIPTION
## 📌 Related Issue
- close: #

## 🚀 Description                                                                                                                                                             
  - `NEEDS_MARKETING` 온보딩 단계 완전 제거 (5단계 → 4단계)                                                                                                                     
  - consent API에서 이용약관 + 개인정보 + 마케팅 동의를 한번에 처리                                                                                                             
  - 마케팅 동의 API(`PATCH /me/marketing`)는 온보딩 상태 전환 없이 설정 변경만 수행                                                                                             
  - 로그인 응답에 `isNewDevice` 필드 추가 (새 디바이스 시 푸시 알림 권한 요청 팝업용)                                                                                           
  - Agreement 엔티티에 `terms_agreed` 컬럼 추가                                                                                                                                 
                                                                                                                                                                                
  ## 📢 Notes                                                                                                                                                                                    
  - 온보딩 플로우: `NEEDS_AGREEMENT → NEEDS_NICKNAME → NEEDS_ONBOARDING → COMPLETED` 

