### PR TITLE
#86 투두 내일하기/오늘하기 - 완료 시 복사 기능 추가

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -513,30 +513,45 @@ include::{snippets}/todo-recurrence-delete-all/response-fields.adoc[]
 === 투두 내일 하기
 `PATCH /api/todos/{todoId}/tomorrow`
 
-투두 일자를 내일로 변경합니다.
+투두 일자를 내일로 변경합니다. 미완료 투두는 **이동**되며, 완료된 투두는 **복사**됩니다 (원본 유지, 새 미완료 투두 생성).
 
 ==== 경로 파라미터
-include::{snippets}/todo-postpone-tomorrow/path-parameters.adoc[]
+include::{snippets}/todo-postpone-tomorrow-move/path-parameters.adoc[]
 ==== HTTP 요청 예시
-include::{snippets}/todo-postpone-tomorrow/http-request.adoc[]
-==== HTTP 응답 예시
-include::{snippets}/todo-postpone-tomorrow/http-response.adoc[]
-==== 응답 필드
-include::{snippets}/todo-postpone-tomorrow/response-fields.adoc[]
+include::{snippets}/todo-postpone-tomorrow-move/http-request.adoc[]
+==== HTTP 응답 예시 (미완료 - 이동)
+include::{snippets}/todo-postpone-tomorrow-move/http-response.adoc[]
+==== 응답 필드 (미완료 - 이동)
+include::{snippets}/todo-postpone-tomorrow-move/response-fields.adoc[]
+
+==== HTTP 응답 예시 (완료 - 복사)
+include::{snippets}/todo-postpone-tomorrow-copy/http-response.adoc[]
+==== 응답 필드 (완료 - 복사)
+include::{snippets}/todo-postpone-tomorrow-copy/response-fields.adoc[]
+
+==== HTTP 응답 예시 (실패 - 오늘 날짜가 아님)
+include::{snippets}/todo-postpone-tomorrow-fail/http-response.adoc[]
+==== 응답 필드 (실패)
+include::{snippets}/todo-postpone-tomorrow-fail/response-fields.adoc[]
 
 === 투두 오늘 하기
 `PATCH /api/todos/{todoId}/today`
 
-투두를 오늘 날짜로 변경합니다.
+투두를 오늘 날짜로 변경합니다. 미완료 투두는 **이동**되며, 완료된 투두는 **복사**됩니다 (원본 유지, 새 미완료 투두 생성).
 
 ==== 경로 파라미터
-include::{snippets}/todo-move-today/path-parameters.adoc[]
+include::{snippets}/todo-move-today-move/path-parameters.adoc[]
 ==== HTTP 요청 예시
-include::{snippets}/todo-move-today/http-request.adoc[]
-==== HTTP 응답 예시
-include::{snippets}/todo-move-today/http-response.adoc[]
-==== 응답 필드
-include::{snippets}/todo-move-today/response-fields.adoc[]
+include::{snippets}/todo-move-today-move/http-request.adoc[]
+==== HTTP 응답 예시 (미완료 - 이동)
+include::{snippets}/todo-move-today-move/http-response.adoc[]
+==== 응답 필드 (미완료 - 이동)
+include::{snippets}/todo-move-today-move/response-fields.adoc[]
+
+==== HTTP 응답 예시 (완료 - 복사)
+include::{snippets}/todo-move-today-copy/http-response.adoc[]
+==== 응답 필드 (완료 - 복사)
+include::{snippets}/todo-move-today-copy/response-fields.adoc[]
 
 === 투두 날짜 변경
 `PATCH /api/todos/{todoId}/date`

--- a/src/main/java/basakan/fryday/service/todo/TodoService.java
+++ b/src/main/java/basakan/fryday/service/todo/TodoService.java
@@ -142,23 +142,7 @@ public class TodoService {
             throw new BusinessException(ErrorCode.TODO_NOT_TODAY);
         }
 
-        LocalDate tomorrow = LocalDate.now().plusDays(1);
-        LocalDate originalDate = todo.getDate();
-
-        // 반복 투두인 경우: 원래 날짜에 재생성 방지, 기존 투두 삭제 없이 옮기기만
-        if (todo.getRecurrenceId() != null) {
-            preventRecurrenceOccurrenceRecreation(todo.getRecurrenceId(), originalDate, userId);
-            Recurrence recurrence = recurrenceRepository.findById(todo.getRecurrenceId())
-                    .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
-            if (recurrence.getUserId() != userId) {
-                throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
-            }
-            ensureMovedExceptionIfInSchedule(todo.getRecurrenceId(), tomorrow, recurrence);
-        }
-
-        todo.updateDate(tomorrow);
-
-        return TodoResponse.from(todo);
+        return moveOrCopyTodoToDate(todo, LocalDate.now().plusDays(1), userId);
     }
 
     @Transactional
@@ -170,10 +154,17 @@ public class TodoService {
             throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
         }
 
-        LocalDate today = LocalDate.now();
+        return moveOrCopyTodoToDate(todo, LocalDate.now(), userId);
+    }
+
+    private TodoResponse moveOrCopyTodoToDate(Todo todo, LocalDate targetDate, Long userId) {
+        if (todo.isCompleted()) {
+            Todo copiedTodo = copyTodoToDate(todo, targetDate);
+            return TodoResponse.from(copiedTodo);
+        }
+
         LocalDate originalDate = todo.getDate();
 
-        // 반복 투두인 경우: 원래 날짜에 재생성 방지, 기존 투두 삭제 없이 옮기기만
         if (todo.getRecurrenceId() != null) {
             preventRecurrenceOccurrenceRecreation(todo.getRecurrenceId(), originalDate, userId);
             Recurrence recurrence = recurrenceRepository.findById(todo.getRecurrenceId())
@@ -181,12 +172,28 @@ public class TodoService {
             if (recurrence.getUserId() != userId) {
                 throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
             }
-            ensureMovedExceptionIfInSchedule(todo.getRecurrenceId(), today, recurrence);
+            ensureMovedExceptionIfInSchedule(todo.getRecurrenceId(), targetDate, recurrence);
         }
 
-        todo.updateDate(today);
-
+        todo.updateDate(targetDate);
         return TodoResponse.from(todo);
+    }
+
+    private Todo copyTodoToDate(Todo source, LocalDate targetDate) {
+        Long userId = source.getCategory().getUserId();
+        Long maxOrder = todoRepository.findMaxDisplayOrder(userId, targetDate);
+        long nextOrder = (maxOrder == null) ? 1 : maxOrder + 1;
+
+        Todo copiedTodo = Todo.builder()
+                .description(source.getDescription())
+                .category(source.getCategory())
+                .date(targetDate)
+                .displayOrder(nextOrder)
+                .recurrenceId(null)
+                .memo(source.getMemo())
+                .build();
+
+        return todoRepository.save(copiedTodo);
     }
 
     @Transactional

--- a/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
@@ -352,9 +352,9 @@ class TodoControllerTest extends RestDocsSupport {
     }
 
     @Test
-    @DisplayName("투두 내일 하기 (날짜 미루기)")
-    void postponeToTomorrow() throws Exception {
-        // given
+    @DisplayName("투두 내일 하기 - 미완료 시 이동 (날짜만 변경)")
+    void postponeToTomorrow_미완료_이동() throws Exception {
+        // given - 미완료 투두: 이동으로 처리 (기존 ID 유지)
         Long todoId = 1L;
         LocalDate tomorrow = LocalDate.now().plusDays(1);
 
@@ -376,7 +376,9 @@ class TodoControllerTest extends RestDocsSupport {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andDo(document("todo-postpone-tomorrow",
+                .andExpect(jsonPath("$.data.id").value(todoId))
+                .andExpect(jsonPath("$.data.date").value(tomorrow.toString()))
+                .andDo(document("todo-postpone-tomorrow-move",
                         pathParameters(
                                 parameterWithName("todoId").description("미룰 투두 ID")
                         ),
@@ -384,13 +386,64 @@ class TodoControllerTest extends RestDocsSupport {
                                 fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
                                 fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
 
-                                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("투두 ID"),
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("투두 ID (이동 시 기존 ID 유지)"),
                                 fieldWithPath("data.description").type(JsonFieldType.STRING).description("할 일 내용"),
-                                fieldWithPath("data.status").type(JsonFieldType.STRING).description("상태"),
+                                fieldWithPath("data.status").type(JsonFieldType.STRING).description("상태 (IN_PROGRESS, COMPLETED)"),
                                 fieldWithPath("data.categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
                                 fieldWithPath("data.memo").type(JsonFieldType.STRING).description("메모").optional(),
 
                                 fieldWithPath("data.date").type(JsonFieldType.STRING).description("변경 후 날짜 (내일)"),
+
+                                fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("투두 내일 하기 - 완료 시 복사 (새 투두 생성)")
+    void postponeToTomorrow_완료_복사() throws Exception {
+        // given - 완료 투두: 복사로 처리 (새 ID 반환)
+        Long originalTodoId = 1L;
+        Long copiedTodoId = 2L;
+        LocalDate tomorrow = LocalDate.now().plusDays(1);
+
+        Category mockCategory = Category.builder().name("요리").color(CategoryColor.BR).userId(1L).build();
+        ReflectionTestUtils.setField(mockCategory, "id", 1L);
+
+        Todo copiedTodo = Todo.builder()
+                .description("양파 썰기")
+                .category(mockCategory)
+                .date(tomorrow)
+                .memo("메모")
+                .build();
+        ReflectionTestUtils.setField(copiedTodo, "id", copiedTodoId);
+
+        given(todoService.postponeToTomorrow(anyLong(), anyLong()))
+                .willReturn(TodoResponse.from(copiedTodo));
+
+        // when & then
+        mockMvc.perform(patch("/api/todos/{todoId}/tomorrow", originalTodoId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(copiedTodoId))
+                .andExpect(jsonPath("$.data.date").value(tomorrow.toString()))
+                .andExpect(jsonPath("$.data.status").value("IN_PROGRESS"))
+                .andDo(document("todo-postpone-tomorrow-copy",
+                        pathParameters(
+                                parameterWithName("todoId").description("미룰 투두 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("복사된 새 투두 ID"),
+                                fieldWithPath("data.description").type(JsonFieldType.STRING).description("할 일 내용"),
+                                fieldWithPath("data.status").type(JsonFieldType.STRING).description("상태 (복사 시 항상 IN_PROGRESS)"),
+                                fieldWithPath("data.categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
+                                fieldWithPath("data.memo").type(JsonFieldType.STRING).description("메모").optional(),
+
+                                fieldWithPath("data.date").type(JsonFieldType.STRING).description("복사된 날짜 (내일)"),
 
                                 fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
                         )
@@ -403,7 +456,6 @@ class TodoControllerTest extends RestDocsSupport {
         // given
         Long todoId = 1L;
 
-        // Mocking: Service가 예외를 던지도록 설정
         given(todoService.postponeToTomorrow(anyLong(), anyLong()))
                 .willThrow(new BusinessException(ErrorCode.TODO_NOT_TODAY));
 
@@ -412,17 +464,26 @@ class TodoControllerTest extends RestDocsSupport {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("오늘 날짜의 투두만 내일로 미룰 수 있습니다."));
+                .andExpect(jsonPath("$.message").value("오늘 날짜의 투두만 내일로 미룰 수 있습니다."))
+                .andDo(document("todo-postpone-tomorrow-fail",
+                        pathParameters(
+                                parameterWithName("todoId").description("미룰 투두 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부 (false)"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메시지"),
+                                fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
+                        )
+                ));
     }
 
     @Test
-    @DisplayName("투두 오늘 하기 (날짜 당기기)")
-    void moveToToday() throws Exception {
-        // given
+    @DisplayName("투두 오늘 하기 - 미완료 시 이동")
+    void moveToToday_미완료_이동() throws Exception {
+        // given - 미완료 투두: 이동 (기존 ID 유지)
         Long todoId = 1L;
         LocalDate today = LocalDate.now();
 
-        // Mocking: 날짜가 오늘로 변경된 투두 응답
         Category mockCategory = Category.builder().name("요리").color(CategoryColor.BR).userId(1L).build();
         ReflectionTestUtils.setField(mockCategory, "id", 1L);
 
@@ -441,7 +502,9 @@ class TodoControllerTest extends RestDocsSupport {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andDo(document("todo-move-today",
+                .andExpect(jsonPath("$.data.id").value(todoId))
+                .andExpect(jsonPath("$.data.date").value(today.toString()))
+                .andDo(document("todo-move-today-move",
                         pathParameters(
                                 parameterWithName("todoId").description("가져올 투두 ID")
                         ),
@@ -449,13 +512,63 @@ class TodoControllerTest extends RestDocsSupport {
                                 fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
                                 fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
 
-                                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("투두 ID"),
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("투두 ID (이동 시 기존 ID 유지)"),
                                 fieldWithPath("data.description").type(JsonFieldType.STRING).description("할 일 내용"),
                                 fieldWithPath("data.status").type(JsonFieldType.STRING).description("상태"),
                                 fieldWithPath("data.categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
                                 fieldWithPath("data.memo").type(JsonFieldType.STRING).description("메모").optional(),
 
                                 fieldWithPath("data.date").type(JsonFieldType.STRING).description("변경 후 날짜 (오늘)"),
+
+                                fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("투두 오늘 하기 - 완료 시 복사 (새 투두 생성)")
+    void moveToToday_완료_복사() throws Exception {
+        // given - 완료 투두: 복사 (새 ID 반환)
+        Long originalTodoId = 1L;
+        Long copiedTodoId = 3L;
+        LocalDate today = LocalDate.now();
+
+        Category mockCategory = Category.builder().name("요리").color(CategoryColor.BR).userId(1L).build();
+        ReflectionTestUtils.setField(mockCategory, "id", 1L);
+
+        Todo copiedTodo = Todo.builder()
+                .description("양파 썰기")
+                .category(mockCategory)
+                .date(today)
+                .build();
+        ReflectionTestUtils.setField(copiedTodo, "id", copiedTodoId);
+
+        given(todoService.moveToToday(anyLong(), anyLong()))
+                .willReturn(TodoResponse.from(copiedTodo));
+
+        // when & then
+        mockMvc.perform(patch("/api/todos/{todoId}/today", originalTodoId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(copiedTodoId))
+                .andExpect(jsonPath("$.data.date").value(today.toString()))
+                .andExpect(jsonPath("$.data.status").value("IN_PROGRESS"))
+                .andDo(document("todo-move-today-copy",
+                        pathParameters(
+                                parameterWithName("todoId").description("가져올 투두 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("복사된 새 투두 ID"),
+                                fieldWithPath("data.description").type(JsonFieldType.STRING).description("할 일 내용"),
+                                fieldWithPath("data.status").type(JsonFieldType.STRING).description("상태 (복사 시 항상 IN_PROGRESS)"),
+                                fieldWithPath("data.categoryId").type(JsonFieldType.NUMBER).description("카테고리 ID"),
+                                fieldWithPath("data.memo").type(JsonFieldType.STRING).description("메모").optional(),
+
+                                fieldWithPath("data.date").type(JsonFieldType.STRING).description("복사된 날짜 (오늘)"),
 
                                 fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
                         )

--- a/src/test/java/basakan/fryday/service/todo/TodoServiceTest.java
+++ b/src/test/java/basakan/fryday/service/todo/TodoServiceTest.java
@@ -1,0 +1,411 @@
+package basakan.fryday.service.todo;
+
+import basakan.fryday.common.ErrorCode;
+import basakan.fryday.common.exception.BusinessException;
+import basakan.fryday.domain.category.Category;
+import basakan.fryday.domain.category.CategoryColor;
+import basakan.fryday.domain.todo.Recurrence;
+import basakan.fryday.domain.todo.RecurrenceType;
+import basakan.fryday.domain.todo.Todo;
+import basakan.fryday.repository.CategoryRepository;
+import basakan.fryday.repository.todo.RecurrenceExceptionRepository;
+import basakan.fryday.repository.todo.RecurrenceRepository;
+import basakan.fryday.repository.todo.TodoAlarmRepository;
+import basakan.fryday.repository.todo.TodoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class TodoServiceTest {
+
+    @Mock
+    private TodoRepository todoRepository;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private TodoAlarmRepository todoAlarmRepository;
+
+    @Mock
+    private RecurrenceRepository recurrenceRepository;
+
+    @Mock
+    private RecurrenceExceptionRepository recurrenceExceptionRepository;
+
+    @Mock
+    private RecurrenceOccurrenceMaterializeService materializeService;
+
+    @Mock
+    private RecurrenceOccurrenceCalculator occurrenceCalculator;
+
+    @InjectMocks
+    private TodoService todoService;
+
+    private static final Long USER_ID = 1L;
+    private static final Long TODO_ID = 100L;
+    private static final Long CATEGORY_ID = 1L;
+
+    private Category category;
+    private Todo inProgressTodo;
+    private Todo completedTodo;
+    private LocalDate today;
+    private LocalDate tomorrow;
+
+    @BeforeEach
+    void setUp() {
+        today = LocalDate.now();
+        tomorrow = today.plusDays(1);
+
+        category = Category.builder().name("운동").color(CategoryColor.BR).userId(USER_ID).build();
+        ReflectionTestUtils.setField(category, "id", CATEGORY_ID);
+
+        inProgressTodo = Todo.builder()
+                .description("스쿼트 100개")
+                .category(category)
+                .date(today)
+                .displayOrder(1L)
+                .build();
+        ReflectionTestUtils.setField(inProgressTodo, "id", TODO_ID);
+
+        completedTodo = Todo.builder()
+                .description("런닝 30분")
+                .category(category)
+                .date(today)
+                .displayOrder(2L)
+                .memo("완료 메모")
+                .build();
+        ReflectionTestUtils.setField(completedTodo, "id", TODO_ID + 1);
+        completedTodo.toggleCompletion();
+    }
+
+    @Nested
+    @DisplayName("postponeToTomorrow")
+    class PostponeToTomorrow {
+
+        @Test
+        @DisplayName("미완료 투두 - 이동 (날짜만 변경)")
+        void 미완료_투두_이동() {
+            // given
+            given(todoRepository.findById(TODO_ID)).willReturn(Optional.of(inProgressTodo));
+
+            // when
+            var result = todoService.postponeToTomorrow(TODO_ID, USER_ID);
+
+            // then
+            assertThat(result.getId()).isEqualTo(TODO_ID);
+            assertThat(result.getDate()).isEqualTo(tomorrow);
+            assertThat(result.getStatus()).isEqualTo(Todo.Status.IN_PROGRESS.name());
+            assertThat(inProgressTodo.getDate()).isEqualTo(tomorrow);
+            then(todoRepository).should().findById(TODO_ID);
+        }
+
+        @Test
+        @DisplayName("완료 투두 - 복사 (새 투두 생성)")
+        void 완료_투두_복사() {
+            // given
+            Todo copiedTodo = Todo.builder()
+                    .description(completedTodo.getDescription())
+                    .category(category)
+                    .date(tomorrow)
+                    .displayOrder(1L)
+                    .memo(completedTodo.getMemo())
+                    .build();
+            ReflectionTestUtils.setField(copiedTodo, "id", 999L);
+
+            given(todoRepository.findById(completedTodo.getId())).willReturn(Optional.of(completedTodo));
+            given(todoRepository.findMaxDisplayOrder(USER_ID, tomorrow)).willReturn(null);
+            given(todoRepository.save(any(Todo.class))).willReturn(copiedTodo);
+
+            // when
+            var result = todoService.postponeToTomorrow(completedTodo.getId(), USER_ID);
+
+            // then - 복사된 새 투두 반환
+            assertThat(result.getId()).isEqualTo(999L);
+            assertThat(result.getDate()).isEqualTo(tomorrow);
+            assertThat(result.getDescription()).isEqualTo("런닝 30분");
+            assertThat(result.getStatus()).isEqualTo(Todo.Status.IN_PROGRESS.name()); // 복사본은 미완료
+            assertThat(result.getMemo()).isEqualTo("완료 메모");
+            // 원본은 그대로 유지 (완료 상태, 원래 날짜)
+            assertThat(completedTodo.getDate()).isEqualTo(today);
+            assertThat(completedTodo.isCompleted()).isTrue();
+            then(todoRepository).should().save(any(Todo.class));
+        }
+
+        @Test
+        @DisplayName("실패 - 오늘 날짜가 아닌 투두")
+        void 실패_오늘_날짜가_아님() {
+            // given - 어제 날짜의 투두
+            Todo yesterdayTodo = Todo.builder()
+                    .description("어제 투두")
+                    .category(category)
+                    .date(today.minusDays(1))
+                    .displayOrder(1L)
+                    .build();
+            ReflectionTestUtils.setField(yesterdayTodo, "id", TODO_ID);
+            given(todoRepository.findById(TODO_ID)).willReturn(Optional.of(yesterdayTodo));
+
+            // when & then
+            assertThatThrownBy(() -> todoService.postponeToTomorrow(TODO_ID, USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.TODO_NOT_TODAY);
+        }
+
+        @Test
+        @DisplayName("미완료 반복 투두 - 이동")
+        void 미완료_반복투두_이동() {
+            // given
+            Long recurrenceId = 10L;
+            Todo recurringTodo = Todo.builder()
+                    .description("반복 운동")
+                    .category(category)
+                    .date(today)
+                    .displayOrder(1L)
+                    .recurrenceId(recurrenceId)
+                    .build();
+            ReflectionTestUtils.setField(recurringTodo, "id", TODO_ID);
+
+            Recurrence recurrence = Recurrence.builder()
+                    .userId(USER_ID)
+                    .categoryId(CATEGORY_ID)
+                    .description("반복 운동")
+                    .type(RecurrenceType.DAILY)
+                    .startDate(today)
+                    .lastGeneratedDate(today)
+                    .build();
+
+            given(todoRepository.findById(TODO_ID)).willReturn(Optional.of(recurringTodo));
+            given(recurrenceRepository.findById(recurrenceId)).willReturn(Optional.of(recurrence));
+            given(recurrenceExceptionRepository.findByRecurrenceIdAndOccurrenceDate(recurrenceId, today))
+                    .willReturn(Optional.empty());
+            given(recurrenceExceptionRepository.findByRecurrenceId(recurrenceId)).willReturn(List.of());
+            given(occurrenceCalculator.calculateOccurrences(any(), eq(tomorrow), eq(tomorrow), any()))
+                    .willReturn(List.of(tomorrow));
+
+            // when
+            var result = todoService.postponeToTomorrow(TODO_ID, USER_ID);
+
+            // then
+            assertThat(result.getId()).isEqualTo(TODO_ID);
+            assertThat(result.getDate()).isEqualTo(tomorrow);
+            assertThat(recurringTodo.getDate()).isEqualTo(tomorrow);
+        }
+
+        @Test
+        @DisplayName("완료 반복 투두 - 복사 (recurrenceId 없이 새 투두)")
+        void 완료_반복투두_복사() {
+            // given
+            Long recurrenceId = 10L;
+            Todo completedRecurring = Todo.builder()
+                    .description("완료된 반복")
+                    .category(category)
+                    .date(today)
+                    .displayOrder(1L)
+                    .recurrenceId(recurrenceId)
+                    .build();
+            ReflectionTestUtils.setField(completedRecurring, "id", TODO_ID);
+            completedRecurring.toggleCompletion();
+
+            Todo copiedTodo = Todo.builder()
+                    .description(completedRecurring.getDescription())
+                    .category(category)
+                    .date(tomorrow)
+                    .displayOrder(1L)
+                    .build();
+            ReflectionTestUtils.setField(copiedTodo, "id", 888L);
+
+            given(todoRepository.findById(TODO_ID)).willReturn(Optional.of(completedRecurring));
+            given(todoRepository.findMaxDisplayOrder(USER_ID, tomorrow)).willReturn(null);
+            given(todoRepository.save(any(Todo.class))).willReturn(copiedTodo);
+
+            // when
+            var result = todoService.postponeToTomorrow(TODO_ID, USER_ID);
+
+            // then - 복사본은 recurrenceId 없음
+            assertThat(result.getId()).isEqualTo(888L);
+            assertThat(result.getDate()).isEqualTo(tomorrow);
+            assertThat(result.getStatus()).isEqualTo(Todo.Status.IN_PROGRESS.name());
+            then(todoRepository).should().save(any(Todo.class));
+        }
+
+        @Test
+        @DisplayName("실패 - 투두 없음")
+        void 실패_투두_없음() {
+            given(todoRepository.findById(TODO_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> todoService.postponeToTomorrow(TODO_ID, USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.TODO_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("moveToToday")
+    class MoveToToday {
+
+        @Test
+        @DisplayName("미완료 투두 - 이동")
+        void 미완료_투두_이동() {
+            // given - 내일 날짜 투두
+            Todo futureTodo = Todo.builder()
+                    .description("내일 할 일")
+                    .category(category)
+                    .date(tomorrow)
+                    .displayOrder(1L)
+                    .build();
+            ReflectionTestUtils.setField(futureTodo, "id", TODO_ID);
+            given(todoRepository.findById(TODO_ID)).willReturn(Optional.of(futureTodo));
+
+            // when
+            var result = todoService.moveToToday(TODO_ID, USER_ID);
+
+            // then
+            assertThat(result.getId()).isEqualTo(TODO_ID);
+            assertThat(result.getDate()).isEqualTo(today);
+            assertThat(futureTodo.getDate()).isEqualTo(today);
+        }
+
+        @Test
+        @DisplayName("완료 투두 - 복사")
+        void 완료_투두_복사() {
+            // given - 어제 완료한 투두
+            Todo yesterdayCompleted = Todo.builder()
+                    .description("어제 완료")
+                    .category(category)
+                    .date(today.minusDays(1))
+                    .displayOrder(1L)
+                    .memo("메모")
+                    .build();
+            ReflectionTestUtils.setField(yesterdayCompleted, "id", TODO_ID);
+            yesterdayCompleted.toggleCompletion();
+
+            Todo copiedTodo = Todo.builder()
+                    .description(yesterdayCompleted.getDescription())
+                    .category(category)
+                    .date(today)
+                    .displayOrder(1L)
+                    .memo(yesterdayCompleted.getMemo())
+                    .build();
+            ReflectionTestUtils.setField(copiedTodo, "id", 777L);
+
+            given(todoRepository.findById(TODO_ID)).willReturn(Optional.of(yesterdayCompleted));
+            given(todoRepository.findMaxDisplayOrder(USER_ID, today)).willReturn(5L);
+            given(todoRepository.save(any(Todo.class))).willReturn(copiedTodo);
+
+            // when
+            var result = todoService.moveToToday(TODO_ID, USER_ID);
+
+            // then
+            assertThat(result.getId()).isEqualTo(777L);
+            assertThat(result.getDate()).isEqualTo(today);
+            assertThat(result.getDescription()).isEqualTo("어제 완료");
+            assertThat(result.getStatus()).isEqualTo(Todo.Status.IN_PROGRESS.name());
+            assertThat(yesterdayCompleted.getDate()).isEqualTo(today.minusDays(1));
+            assertThat(yesterdayCompleted.isCompleted()).isTrue();
+            then(todoRepository).should().save(any(Todo.class));
+        }
+
+        @Test
+        @DisplayName("미완료 반복 투두 - 이동")
+        void 미완료_반복투두_이동() {
+            // given
+            Long recurrenceId = 10L;
+            Todo recurringTodo = Todo.builder()
+                    .description("반복 투두")
+                    .category(category)
+                    .date(tomorrow)
+                    .displayOrder(1L)
+                    .recurrenceId(recurrenceId)
+                    .build();
+            ReflectionTestUtils.setField(recurringTodo, "id", TODO_ID);
+
+            Recurrence recurrence = Recurrence.builder()
+                    .userId(USER_ID)
+                    .categoryId(CATEGORY_ID)
+                    .description("반복 투두")
+                    .type(RecurrenceType.DAILY)
+                    .startDate(today)
+                    .lastGeneratedDate(tomorrow)
+                    .build();
+
+            given(todoRepository.findById(TODO_ID)).willReturn(Optional.of(recurringTodo));
+            given(recurrenceRepository.findById(recurrenceId)).willReturn(Optional.of(recurrence));
+            given(recurrenceExceptionRepository.findByRecurrenceIdAndOccurrenceDate(recurrenceId, tomorrow))
+                    .willReturn(Optional.empty());
+            given(recurrenceExceptionRepository.findByRecurrenceId(recurrenceId)).willReturn(List.of());
+            given(occurrenceCalculator.calculateOccurrences(any(), eq(today), eq(today), any()))
+                    .willReturn(List.of(today));
+
+            // when
+            var result = todoService.moveToToday(TODO_ID, USER_ID);
+
+            // then
+            assertThat(result.getId()).isEqualTo(TODO_ID);
+            assertThat(result.getDate()).isEqualTo(today);
+        }
+
+        @Test
+        @DisplayName("완료 반복 투두 - 복사")
+        void 완료_반복투두_복사() {
+            // given
+            Long recurrenceId = 10L;
+            Todo completedRecurring = Todo.builder()
+                    .description("완료된 반복")
+                    .category(category)
+                    .date(today.minusDays(2))
+                    .displayOrder(1L)
+                    .recurrenceId(recurrenceId)
+                    .build();
+            ReflectionTestUtils.setField(completedRecurring, "id", TODO_ID);
+            completedRecurring.toggleCompletion();
+
+            Todo copiedTodo = Todo.builder()
+                    .description(completedRecurring.getDescription())
+                    .category(category)
+                    .date(today)
+                    .displayOrder(1L)
+                    .build();
+            ReflectionTestUtils.setField(copiedTodo, "id", 666L);
+
+            given(todoRepository.findById(TODO_ID)).willReturn(Optional.of(completedRecurring));
+            given(todoRepository.findMaxDisplayOrder(USER_ID, today)).willReturn(null);
+            given(todoRepository.save(any(Todo.class))).willReturn(copiedTodo);
+
+            // when
+            var result = todoService.moveToToday(TODO_ID, USER_ID);
+
+            // then
+            assertThat(result.getId()).isEqualTo(666L);
+            assertThat(result.getDate()).isEqualTo(today);
+            assertThat(result.getStatus()).isEqualTo(Todo.Status.IN_PROGRESS.name());
+        }
+
+        @Test
+        @DisplayName("실패 - 투두 없음")
+        void 실패_투두_없음() {
+            given(todoRepository.findById(TODO_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> todoService.moveToToday(TODO_ID, USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.TODO_NOT_FOUND);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Related Issue
- close: #86 

## 🚀 Description
### 요약
완료된 투두에 대해 내일하기/오늘하기 호출 시 **이동** 대신 **복사**되도록 변경했습니다. 미완료 투두는 기존처럼 이동합니다. 
### 기능
- **postponeToTomorrow (내일하기)**: 미완료 → 이동, 완료 → 복사
- **moveToToday (오늘하기)**: 미완료 → 이동, 완료 → 복사
### 리팩토링
- `postponeToTomorrow` / `moveToToday` 공통 로직을 `moveOrCopyTodoToDate` 메서드로 추출

## 📢 Notes
### 테스트
- TodoServiceTest: postponeToTomorrow, moveToToday 케이스별 단위 테스트 추가
- TodoControllerTest: REST Docs 테스트 수정 (이동/복사/실패 시나리오 문서화)

## 동작 정리
| 투두 상태 | postponeToTomorrow | moveToToday |
|-----------|-------------------|-------------|
| 미완료 | 이동 | 이동 |
| 완료 | 복사 | 복사 |