### PR TITLE
공지사항 조회 API 구현

### DIFF
--- a/src/main/java/basakan/fryday/controller/notice/NoticeController.java
+++ b/src/main/java/basakan/fryday/controller/notice/NoticeController.java
@@ -1,0 +1,25 @@
+package basakan.fryday.controller.notice;
+
+import basakan.fryday.controller.notice.response.NoticeResponse;
+import basakan.fryday.service.NoticeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notices")
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @GetMapping
+    public ResponseEntity<List<NoticeResponse>> getNotices() {
+        List<NoticeResponse> responses = noticeService.getNotices();
+        return ResponseEntity.ok(responses);
+    }
+}

--- a/src/main/java/basakan/fryday/controller/notice/response/NoticeResponse.java
+++ b/src/main/java/basakan/fryday/controller/notice/response/NoticeResponse.java
@@ -1,0 +1,24 @@
+package basakan.fryday.controller.notice.response;
+
+import basakan.fryday.domain.notice.Notice;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class NoticeResponse {
+
+    private Long id;
+    private String content;
+    private LocalDate noticeDate;
+
+    public static NoticeResponse from(Notice notice) {
+        return NoticeResponse.builder()
+                .id(notice.getId())
+                .content(notice.getContent())
+                .noticeDate(notice.getNoticeDate())
+                .build();
+    }
+}

--- a/src/main/java/basakan/fryday/domain/notice/Notice.java
+++ b/src/main/java/basakan/fryday/domain/notice/Notice.java
@@ -1,0 +1,31 @@
+package basakan.fryday.domain.notice;
+
+import basakan.fryday.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Table(name = "notice")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notice extends BaseEntity {
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false)
+    private LocalDate noticeDate;
+
+    @Builder
+    public Notice(String content, LocalDate noticeDate) {
+        this.content = content;
+        this.noticeDate = noticeDate;
+    }
+}

--- a/src/main/java/basakan/fryday/repository/notice/NoticeRepository.java
+++ b/src/main/java/basakan/fryday/repository/notice/NoticeRepository.java
@@ -1,0 +1,11 @@
+package basakan.fryday.repository.notice;
+
+import basakan.fryday.domain.notice.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+    List<Notice> findAllByOrderByNoticeDateDesc();
+}

--- a/src/main/java/basakan/fryday/service/NoticeService.java
+++ b/src/main/java/basakan/fryday/service/NoticeService.java
@@ -1,0 +1,25 @@
+package basakan.fryday.service;
+
+import basakan.fryday.controller.notice.response.NoticeResponse;
+import basakan.fryday.repository.notice.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    public List<NoticeResponse> getNotices() {
+        return noticeRepository.findAllByOrderByNoticeDateDesc()
+                .stream()
+                .map(NoticeResponse::from)
+                .toList();
+    }
+}


### PR DESCRIPTION
 ## 공지사항 API 명세서                                                                                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                           
### 공지사항 목록 조회

  | 항목 | 내용 |
  |------|------|
  | **URL** | `/api/notices` |
  | **Method** | `GET` |
  | **인증** | 필수 |

  #### Request Header

  | 헤더 | 필수 | 설명 |
  |------|------|------|
  | `Authorization` | O | `Bearer {accessToken}` |


  #### Response

  | 필드 | 타입 | 설명 |
  |------|------|------|
  | `id` | Long | 공지사항 ID |
  | `content` | String | 공지 내용 |
  | `noticeDate` | LocalDate | 공지 날짜 |

  #### Response 예시

  ```json
  [
    {
      "id": 1,
      "content": "서비스 점검 안내입니다.",
      "noticeDate": "2026-02-20"
    },
    {
      "id": 2,
      "content": "신규 기능이 추가되었습니다.",
      "noticeDate": "2026-02-18"
    }
  ]
