### PR TITLE
월간 리포트 조회 비동기 병렬 처리로 성능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,11 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testRuntimeOnly 'com.h2database:h2'
 
+	// Testcontainers
+	testImplementation 'org.testcontainers:testcontainers'
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.testcontainers:mysql'
+
 	// REST Docs
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
@@ -72,6 +77,9 @@ ext {
 test {
 	outputs.dir snippetsDir
 	useJUnitPlatform()
+	testLogging {
+		showStandardStreams = true
+	}
 }
 
 asciidoctor {

--- a/src/main/java/basakan/fryday/common/config/AsyncConfig.java
+++ b/src/main/java/basakan/fryday/common/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package basakan.fryday.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean("reportAsyncExecutor")
+    public Executor reportAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(15);
+        executor.setQueueCapacity(30);
+        executor.setThreadNamePrefix("report-async-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/basakan/fryday/service/report/MonthlyReportReadService.java
+++ b/src/main/java/basakan/fryday/service/report/MonthlyReportReadService.java
@@ -10,6 +10,7 @@ import basakan.fryday.repository.CategoryRepository;
 import basakan.fryday.repository.todo.TodoRepository;
 import basakan.fryday.service.report.dto.CategoryReportDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,12 +18,14 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
-@RequiredArgsConstructor
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class MonthlyReportReadService {
 
     private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
@@ -31,6 +34,7 @@ public class MonthlyReportReadService {
 
     private final CategoryRepository categoryRepository;
     private final TodoRepository todoRepository;
+    private final Executor reportAsyncExecutor;
 
     public MonthlyReportResponse getMonthlyReportResponse(Long userId, int year, int month) {
         LocalDate today = LocalDate.now(KOREA_ZONE);
@@ -42,21 +46,129 @@ public class MonthlyReportReadService {
             throw new BusinessException(ErrorCode.INVALID_REPORT_PERIOD);
         }
 
-        // 현재 월 → Todo 실시간 집계 (오늘까지만)
+        // 현재 월 → 오늘까지만 집계 (비동기)
         if (requestedYearMonth.equals(currentYearMonth)) {
-            return buildRealtimeReport(userId, year, month, today);
+            return buildRealtimeReportAsync(userId, year, month, today);
         }
 
-        // 과거 월 → 실시간 집계 (날짜 제한 없이 전체 월)
-        return buildPastMonthReport(userId, year, month);
+        // 과거 월 → 전체 월 집계 (비동기)
+        return buildPastMonthReportAsync(userId, year, month);
     }
 
+    private MonthlyReportResponse buildRealtimeReportAsync(Long userId, int year, int month, LocalDate today) {
+        CompletableFuture<List<CategoryReportDto>> categoryStatsFuture =
+            CompletableFuture.supplyAsync(
+                () -> todoRepository.findMonthlyReportByCategoryUntilDate(userId, year, month, today),
+                reportAsyncExecutor
+            );
+
+        CompletableFuture<Integer> attendanceDaysFuture =
+            CompletableFuture.supplyAsync(
+                () -> todoRepository.countAttendanceDaysUntilDate(userId, year, month, today),
+                reportAsyncExecutor
+            );
+
+        CompletableFuture<List<Category>> categoriesFuture =
+            CompletableFuture.supplyAsync(
+                () -> categoryRepository.findAllByUserIdAndDeletedAtIsNullOrderByDisplayOrderAsc(userId),
+                reportAsyncExecutor
+            );
+
+        CompletableFuture.allOf(categoryStatsFuture, attendanceDaysFuture, categoriesFuture).join();
+
+        return assembleResponse(
+            year, month,
+            categoryStatsFuture.join(),
+            attendanceDaysFuture.join(),
+            categoriesFuture.join()
+        );
+    }
+
+    /**
+     * 과거 월 리포트 - CompletableFuture 비동기 병렬 처리
+     * 3개의 독립적인 쿼리를 동시에 실행하여 성능 개선
+     */
+    public MonthlyReportResponse buildPastMonthReportAsync(Long userId, int year, int month) {
+        CompletableFuture<List<CategoryReportDto>> categoryStatsFuture =
+            CompletableFuture.supplyAsync(
+                () -> todoRepository.findMonthlyReportByCategory(userId, year, month),
+                reportAsyncExecutor
+            );
+
+        CompletableFuture<Integer> attendanceDaysFuture =
+            CompletableFuture.supplyAsync(
+                () -> todoRepository.countAttendanceDays(userId, year, month),
+                reportAsyncExecutor
+            );
+
+        CompletableFuture<List<Category>> categoriesFuture =
+            CompletableFuture.supplyAsync(
+                () -> categoryRepository.findAllByUserIdAndDeletedAtIsNullOrderByDisplayOrderAsc(userId),
+                reportAsyncExecutor
+            );
+
+        CompletableFuture.allOf(categoryStatsFuture, attendanceDaysFuture, categoriesFuture).join();
+
+        return assembleResponse(
+            year, month,
+            categoryStatsFuture.join(),
+            attendanceDaysFuture.join(),
+            categoriesFuture.join()
+        );
+    }
+
+    private MonthlyReportResponse assembleResponse(int year, int month,
+                                                    List<CategoryReportDto> categoryStats,
+                                                    int attendanceDays,
+                                                    List<Category> activeCategories) {
+        int totalTodos = categoryStats.stream()
+            .mapToInt(CategoryReportDto::getTotalTodos).sum();
+        int completedTodos = categoryStats.stream()
+            .mapToInt(CategoryReportDto::getCompletedTodos).sum();
+        int incompleteTodos = categoryStats.stream()
+            .mapToInt(CategoryReportDto::getIncompleteTodos).sum();
+        double achievementRate = calculateRate(completedTodos, totalTodos);
+
+        AttendanceIcon icon = AttendanceIcon.fromAttendanceDays(attendanceDays);
+
+        Map<Long, CategoryReportDto> statsMap = categoryStats.stream()
+            .collect(Collectors.toMap(CategoryReportDto::getCategoryId, Function.identity()));
+
+        List<CategoryReportResponse> categories = activeCategories.stream()
+            .map(category -> {
+                CategoryReportDto dto = statsMap.get(category.getId());
+                if (dto != null) {
+                    double successRate = calculateRate(dto.getCompletedTodos(), dto.getTotalTodos());
+                    double failureRate = calculateRate(dto.getIncompleteTodos(), dto.getTotalTodos());
+                    return CategoryReportResponse.from(dto, successRate, failureRate);
+                }
+                return CategoryReportResponse.empty(category);
+            })
+            .toList();
+
+        return MonthlyReportResponse.ofRealtime(
+            year, month, totalTodos, completedTodos, incompleteTodos,
+            attendanceDays, achievementRate, icon, categories);
+    }
+
+    private double calculateRate(int numerator, int denominator) {
+        if (denominator == 0) {
+            return 0.0;
+        }
+        return Math.round(numerator * ROUNDING_SCALE / denominator) / PERCENTAGE_SCALE;
+    }
+
+    // ============================================================================
+    // 기존 Sequential 버전 (주석 처리)
+    // ============================================================================
+
+    /*
     private MonthlyReportResponse buildRealtimeReport(Long userId, int year, int month, LocalDate today) {
         List<CategoryReportDto> categoryStats =
             todoRepository.findMonthlyReportByCategoryUntilDate(userId, year, month, today);
         int attendanceDays = todoRepository.countAttendanceDaysUntilDate(userId, year, month, today);
 
-        return assembleResponse(userId, year, month, categoryStats, attendanceDays);
+        return assembleResponseSequential(userId, year, month, categoryStats, attendanceDays);
     }
 
     private MonthlyReportResponse buildPastMonthReport(Long userId, int year, int month) {
@@ -64,12 +176,12 @@ public class MonthlyReportReadService {
             todoRepository.findMonthlyReportByCategory(userId, year, month);
         int attendanceDays = todoRepository.countAttendanceDays(userId, year, month);
 
-        return assembleResponse(userId, year, month, categoryStats, attendanceDays);
+        return assembleResponseSequential(userId, year, month, categoryStats, attendanceDays);
     }
 
-    private MonthlyReportResponse assembleResponse(Long userId, int year, int month,
-                                                    List<CategoryReportDto> categoryStats,
-                                                    int attendanceDays) {
+    private MonthlyReportResponse assembleResponseSequential(Long userId, int year, int month,
+                                                              List<CategoryReportDto> categoryStats,
+                                                              int attendanceDays) {
         int totalTodos = categoryStats.stream()
             .mapToInt(CategoryReportDto::getTotalTodos).sum();
         int completedTodos = categoryStats.stream()
@@ -102,11 +214,5 @@ public class MonthlyReportReadService {
             year, month, totalTodos, completedTodos, incompleteTodos,
             attendanceDays, achievementRate, icon, categories);
     }
-
-    private double calculateRate(int numerator, int denominator) {
-        if (denominator == 0) {
-            return 0.0;
-        }
-        return Math.round(numerator * ROUNDING_SCALE / denominator) / PERCENTAGE_SCALE;
-    }
+    */
 }

--- a/src/test/java/basakan/fryday/service/report/MonthlyReportReadServiceIntegrationTest.java
+++ b/src/test/java/basakan/fryday/service/report/MonthlyReportReadServiceIntegrationTest.java
@@ -1,0 +1,103 @@
+package basakan.fryday.service.report;
+
+import basakan.fryday.controller.report.response.MonthlyReportResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Testcontainers
+@ActiveProfiles("test")
+@Sql(scripts = "/sql/monthly-report-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+class MonthlyReportReadServiceIntegrationTest {
+
+    @Container
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("fryday_test")
+            .withUsername("test")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
+        registry.add("spring.jpa.properties.hibernate.dialect", () -> "org.hibernate.dialect.MySQLDialect");
+    }
+
+    @Autowired
+    private MonthlyReportReadService monthlyReportReadService;
+
+    @Test
+    @DisplayName("비동기 월간 리포트 조회 - 과거 월 데이터 정상 조회")
+    void getMonthlyReportResponse_asyncPastMonth_success() {
+        // given
+        Long userId = 1L;
+        int year = 2025;
+        int month = 1;
+
+        // when
+        MonthlyReportResponse response = monthlyReportReadService.getMonthlyReportResponse(userId, year, month);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getYear()).isEqualTo(2025);
+        assertThat(response.getMonth()).isEqualTo(1);
+        assertThat(response.getTotalTodos()).isEqualTo(10);
+        assertThat(response.getCompletedTodos()).isEqualTo(7);
+        assertThat(response.getIncompleteTodos()).isEqualTo(3);
+        assertThat(response.getAchievementRate()).isEqualTo(70.0);
+        assertThat(response.getCategories()).hasSize(3);
+
+        // 카테고리별 검증
+        var categories = response.getCategories();
+
+        // 운동: 3개 중 2개 완료
+        var exercise = categories.stream()
+                .filter(c -> c.getCategoryName().equals("운동"))
+                .findFirst().orElseThrow();
+        assertThat(exercise.getTotalTodos()).isEqualTo(3);
+        assertThat(exercise.getCompletedTodos()).isEqualTo(2);
+
+        // 공부: 3개 중 2개 완료
+        var study = categories.stream()
+                .filter(c -> c.getCategoryName().equals("공부"))
+                .findFirst().orElseThrow();
+        assertThat(study.getTotalTodos()).isEqualTo(3);
+        assertThat(study.getCompletedTodos()).isEqualTo(2);
+
+        // 독서: 4개 중 3개 완료
+        var reading = categories.stream()
+                .filter(c -> c.getCategoryName().equals("독서"))
+                .findFirst().orElseThrow();
+        assertThat(reading.getTotalTodos()).isEqualTo(4);
+        assertThat(reading.getCompletedTodos()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("비동기 처리로 3개 쿼리가 병렬 실행되어 결과 반환")
+    void getMonthlyReportResponse_asyncExecution_returnsCorrectData() {
+        // given
+        Long userId = 1L;
+
+        // when
+        MonthlyReportResponse response = monthlyReportReadService.getMonthlyReportResponse(userId, 2025, 1);
+
+        // then
+        assertThat(response.getAttendanceDays()).isGreaterThan(0);
+        assertThat(response.getAttendanceIcon()).isNotNull();
+        assertThat(response.getCategories()).isNotEmpty();
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -11,7 +11,24 @@ spring:
         show_sql: false
     open-in-view: false
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      username: ""
+      password: ""
+
 jwt:
   secret-key: test-secret-key-for-testing-purposes-at-least-32-characters-long-enough
   access-token-expiration: 3600000
   refresh-token-expiration: 1209600000
+
+oauth:
+  apple:
+    client-id: com.test.app
+    jwks-url: https://appleid.apple.com/auth/keys
+
+fcm:
+  enabled: false
+  credentials:
+    json: ""

--- a/src/test/resources/sql/monthly-report-test-data.sql
+++ b/src/test/resources/sql/monthly-report-test-data.sql
@@ -1,0 +1,27 @@
+-- 기존 데이터 삭제
+DELETE FROM todo;
+DELETE FROM category;
+DELETE FROM users;
+
+-- 테스트용 사용자
+INSERT INTO users (id, provider, provider_user_id, email, nickname, onboarding_status, account_status, role, created_at, updated_at)
+VALUES (1, 'KAKAO', 'test_user_001', 'test@example.com', 'TestUser', 'COMPLETED', 'ACTIVE', 'USER', NOW(), NOW());
+
+-- 카테고리 3개
+INSERT INTO category (id, name, color, user_id, display_order, created_at, updated_at) VALUES
+(1, '운동', 'OR', 1, 1, NOW(), NOW()),
+(2, '공부', 'CB', 1, 2, NOW(), NOW()),
+(3, '독서', 'LG', 1, 3, NOW(), NOW());
+
+-- Todo 10개 (2025년 1월, COMPLETED 7개, IN_PROGRESS 3개 = 70% 달성률)
+INSERT INTO todo (id, description, status, category_id, date, display_order, created_at, updated_at) VALUES
+(1, '운동 1', 'COMPLETED', 1, '2025-01-01', 1, NOW(), NOW()),
+(2, '운동 2', 'COMPLETED', 1, '2025-01-02', 1, NOW(), NOW()),
+(3, '운동 3', 'IN_PROGRESS', 1, '2025-01-03', 1, NOW(), NOW()),
+(4, '공부 1', 'COMPLETED', 2, '2025-01-01', 2, NOW(), NOW()),
+(5, '공부 2', 'COMPLETED', 2, '2025-01-02', 2, NOW(), NOW()),
+(6, '공부 3', 'IN_PROGRESS', 2, '2025-01-03', 2, NOW(), NOW()),
+(7, '독서 1', 'COMPLETED', 3, '2025-01-01', 3, NOW(), NOW()),
+(8, '독서 2', 'COMPLETED', 3, '2025-01-02', 3, NOW(), NOW()),
+(9, '독서 3', 'COMPLETED', 3, '2025-01-03', 3, NOW(), NOW()),
+(10, '독서 4', 'IN_PROGRESS', 3, '2025-01-04', 3, NOW(), NOW());


### PR DESCRIPTION
## 📌 Related Issue
- close: #

## 🚀 Description
- 월간 리포트 조회 시 3개의 독립적인 DB 쿼리를 `CompletableFuture`로 병렬 실행하여 성능 개선
  - 카테고리별 통계 조회
  - 출석일 수 조회
  - 활성 카테고리 목록 조회
- `AsyncConfig` 추가하여 `reportAsyncExecutor` 스레드풀 설정 (core: 5, max: 15)
- Testcontainers 기반 MySQL 통합 테스트 추가

## 📢 Notes
- 기존 순차 실행 코드는 주석 처리로 보존
- Testcontainers 의존성 추가 (`build.gradle`)