### PR TITLE
#94 반복 규칙 수정 후 기준 날짜 투두 미표시 및 DELETED 예외 정합성 수정

### DIFF
--- a/src/main/java/basakan/fryday/repository/todo/RecurrenceExceptionRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/RecurrenceExceptionRepository.java
@@ -18,6 +18,14 @@ public interface RecurrenceExceptionRepository extends JpaRepository<RecurrenceE
     List<RecurrenceException> findByRecurrenceId(@Param("recurrenceId") Long recurrenceId);
 
     @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM RecurrenceException re WHERE re.recurrenceId = :recurrenceId "
+            + "AND re.occurrenceDate = :occurrenceDate AND re.type = :type")
+    void deleteByRecurrenceIdAndOccurrenceDateAndType(
+            @Param("recurrenceId") Long recurrenceId,
+            @Param("occurrenceDate") LocalDate occurrenceDate,
+            @Param("type") RecurrenceException.ExceptionType type);
+
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM RecurrenceException re WHERE re.recurrenceId IN " +
             "(SELECT r.id FROM Recurrence r WHERE r.userId = :userId)")
     void deleteAllByUserId(@Param("userId") Long userId);

--- a/src/main/java/basakan/fryday/repository/todo/RecurrenceExceptionRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/RecurrenceExceptionRepository.java
@@ -17,7 +17,7 @@ public interface RecurrenceExceptionRepository extends JpaRepository<RecurrenceE
     @Query("SELECT re FROM RecurrenceException re WHERE re.recurrenceId = :recurrenceId")
     List<RecurrenceException> findByRecurrenceId(@Param("recurrenceId") Long recurrenceId);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = false)
     @Query("DELETE FROM RecurrenceException re WHERE re.recurrenceId = :recurrenceId "
             + "AND re.occurrenceDate = :occurrenceDate AND re.type = :type")
     void deleteByRecurrenceIdAndOccurrenceDateAndType(

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
@@ -61,13 +61,6 @@ public class RecurrenceService {
             throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
         }
 
-        RecurrenceException exception = RecurrenceException.builder()
-                .recurrenceId(savedRecurrence.getId())
-                .occurrenceDate(originalTodo.getDate())
-                .type(RecurrenceException.ExceptionType.DELETED)
-                .build();
-        recurrenceExceptionRepository.save(exception);
-
         Todo todo = todoRepository.findById(request.getTodoId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
         return TodoResponse.from(todo);

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceService.java
@@ -182,6 +182,7 @@ public class RecurrenceService {
         List<Todo> todos = todoRepository.findAllByRecurrenceId(recurrenceId);
         for (Todo todo : todos) {
             if (!detachedTodoIds.contains(todo.getId())) {
+                recurrenceExceptionRepository.deleteByRecurrenceIdAndOccurrenceDateAndType(recurrenceId, todo.getDate(), RecurrenceException.ExceptionType.DELETED);
                 todo.delete();
             }
         }

--- a/src/test/java/basakan/fryday/service/todo/RecurrenceServiceIntegrationTest.java
+++ b/src/test/java/basakan/fryday/service/todo/RecurrenceServiceIntegrationTest.java
@@ -1,0 +1,189 @@
+package basakan.fryday.service.todo;
+
+import basakan.fryday.common.ErrorCode;
+import basakan.fryday.common.config.JpaConfig;
+import basakan.fryday.common.exception.BusinessException;
+import basakan.fryday.controller.todo.request.RecurrenceCreateRequest;
+import basakan.fryday.controller.todo.request.RecurrenceUpdateRequest;
+import basakan.fryday.domain.category.Category;
+import basakan.fryday.domain.category.CategoryColor;
+import basakan.fryday.domain.todo.RecurrenceException;
+import basakan.fryday.domain.todo.RecurrenceType;
+import basakan.fryday.domain.todo.Todo;
+import basakan.fryday.domain.user.AuthProvider;
+import basakan.fryday.domain.user.User;
+import basakan.fryday.repository.CategoryRepository;
+import basakan.fryday.repository.auth.UserJpaRepository;
+import basakan.fryday.repository.todo.RecurrenceExceptionRepository;
+import basakan.fryday.repository.todo.TodoRepository;
+import basakan.fryday.service.user.UserReadService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(
+        properties = {
+                "spring.datasource.url=jdbc:h2:mem:recurrence_service_it;MODE=MySQL;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE;DB_CLOSE_DELAY=-1",
+                "spring.datasource.driver-class-name=org.h2.Driver",
+                "spring.datasource.username=sa",
+                "spring.datasource.password=",
+                "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+                "spring.jpa.hibernate.ddl-auto=create-drop",
+                "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,"
+                        + "org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration"
+        }
+)
+@Import({
+        JpaConfig.class,
+        RecurrenceService.class,
+        TodoService.class,
+        RecurrenceOccurrenceMaterializeService.class,
+        RecurrenceOccurrenceCalculator.class,
+        UserReadService.class
+})
+@DisplayName("RecurrenceService 통합")
+class RecurrenceServiceIntegrationTest {
+
+    private static final LocalDate ANCHOR = LocalDate.of(2026, 4, 1);
+    private static final LocalDate SECOND_DAY = LocalDate.of(2026, 4, 2);
+    private static final LocalDate RANGE_END = LocalDate.of(2026, 4, 5);
+
+    @Autowired
+    private RecurrenceService recurrenceService;
+    @Autowired
+    private TodoService todoService;
+    @Autowired
+    private RecurrenceOccurrenceMaterializeService materializeService;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
+    @Autowired
+    private TodoRepository todoRepository;
+    @Autowired
+    private RecurrenceExceptionRepository recurrenceExceptionRepository;
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("규칙 수정 후 앵커 날짜에 materialize 하면 투두가 다시 생긴다")
+    void anchorDate_materializesAgain_afterRecurrenceUpdate() {
+        User user = userJpaRepository.save(User.createNewUser(AuthProvider.APPLE, "dev-sub", "t@t.com"));
+        Long userId = user.getId();
+
+        Category category = categoryRepository.save(
+                Category.builder().name("업무").color(CategoryColor.BR).userId(userId).displayOrder(1L).build()
+        );
+
+        Todo anchorTodo = todoRepository.save(
+                Todo.builder().description("반복 A").category(category).date(ANCHOR).displayOrder(1L).build()
+        );
+
+        RecurrenceCreateRequest createRequest = new RecurrenceCreateRequest();
+        ReflectionTestUtils.setField(createRequest, "todoId", anchorTodo.getId());
+        ReflectionTestUtils.setField(createRequest, "type", RecurrenceType.DAILY);
+        ReflectionTestUtils.setField(createRequest, "startDate", ANCHOR);
+        ReflectionTestUtils.setField(createRequest, "endDate", RANGE_END);
+        ReflectionTestUtils.setField(createRequest, "notificationTime", null);
+
+        recurrenceService.createRecurrence(userId, createRequest);
+
+        Todo updatedAnchor = todoRepository.findById(anchorTodo.getId()).orElseThrow();
+        Long recurrenceId = updatedAnchor.getRecurrenceId();
+        assertThat(recurrenceId).isNotNull();
+
+        RecurrenceUpdateRequest updateRequest = new RecurrenceUpdateRequest();
+        ReflectionTestUtils.setField(updateRequest, "type", RecurrenceType.DAILY);
+        ReflectionTestUtils.setField(updateRequest, "startDate", ANCHOR);
+        ReflectionTestUtils.setField(updateRequest, "endDate", LocalDate.of(2026, 4, 10));
+        ReflectionTestUtils.setField(updateRequest, "notificationTime", null);
+
+        recurrenceService.updateRecurrence(recurrenceId, updateRequest, userId);
+
+        assertThat(todoRepository.findAllByUserIdAndDate(userId, ANCHOR)).isEmpty();
+
+        Todo materialized = materializeService.materializeOccurrenceIfNotExists(userId, recurrenceId, ANCHOR);
+
+        assertThat(materialized.getDate()).isEqualTo(ANCHOR);
+        assertThat(materialized.getRecurrenceId()).isEqualTo(recurrenceId);
+        assertThat(todoRepository.findAllByUserIdAndDate(userId, ANCHOR)).hasSize(1);
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("사용자가 삭제한 회차는 규칙 수정 후에도 DELETED 예외가 유지되어 재생성되지 않는다")
+    void userDeletedOccurrence_keepsDeletedException_afterRecurrenceUpdate() {
+        User user = userJpaRepository.save(User.createNewUser(AuthProvider.APPLE, "dev-sub-2", "t2@t.com"));
+        Long userId = user.getId();
+
+        Category category = categoryRepository.save(
+                Category.builder().name("업무").color(CategoryColor.BR).userId(userId).displayOrder(1L).build()
+        );
+
+        Todo anchorTodo = todoRepository.save(
+                Todo.builder().description("반복 B").category(category).date(ANCHOR).displayOrder(1L).build()
+        );
+
+        RecurrenceCreateRequest createRequest = new RecurrenceCreateRequest();
+        ReflectionTestUtils.setField(createRequest, "todoId", anchorTodo.getId());
+        ReflectionTestUtils.setField(createRequest, "type", RecurrenceType.DAILY);
+        ReflectionTestUtils.setField(createRequest, "startDate", ANCHOR);
+        ReflectionTestUtils.setField(createRequest, "endDate", RANGE_END);
+        ReflectionTestUtils.setField(createRequest, "notificationTime", null);
+
+        recurrenceService.createRecurrence(userId, createRequest);
+
+        Todo refreshedAnchor = todoRepository.findById(anchorTodo.getId()).orElseThrow();
+        Long recurrenceId = refreshedAnchor.getRecurrenceId();
+
+        materializeService.materializeOccurrenceIfNotExists(userId, recurrenceId, SECOND_DAY);
+        Todo secondDayTodo = todoRepository.findAllByUserIdAndDate(userId, SECOND_DAY).stream()
+                .filter(t -> recurrenceId.equals(t.getRecurrenceId()))
+                .findFirst()
+                .orElseThrow();
+
+        todoService.deleteTodo(secondDayTodo.getId(), userId);
+
+        assertThat(recurrenceExceptionRepository.findByRecurrenceIdAndOccurrenceDate(recurrenceId, SECOND_DAY))
+                .isPresent();
+        assertThat(recurrenceExceptionRepository.findByRecurrenceIdAndOccurrenceDate(recurrenceId, SECOND_DAY).orElseThrow().getType())
+                .isEqualTo(RecurrenceException.ExceptionType.DELETED);
+        assertThat(todoRepository.findAllByUserIdAndDate(userId, SECOND_DAY)).isEmpty();
+
+        RecurrenceUpdateRequest updateRequest = new RecurrenceUpdateRequest();
+        ReflectionTestUtils.setField(updateRequest, "type", RecurrenceType.DAILY);
+        ReflectionTestUtils.setField(updateRequest, "startDate", ANCHOR);
+        ReflectionTestUtils.setField(updateRequest, "endDate", LocalDate.of(2026, 4, 12));
+        ReflectionTestUtils.setField(updateRequest, "notificationTime", null);
+
+        recurrenceService.updateRecurrence(recurrenceId, updateRequest, userId);
+
+        assertThat(recurrenceExceptionRepository.findByRecurrenceIdAndOccurrenceDate(recurrenceId, SECOND_DAY))
+                .isPresent();
+        assertThat(recurrenceExceptionRepository.findByRecurrenceIdAndOccurrenceDate(recurrenceId, SECOND_DAY).orElseThrow().getType())
+                .isEqualTo(RecurrenceException.ExceptionType.DELETED);
+
+        assertThatThrownBy(() -> materializeService.materializeOccurrenceIfNotExists(userId, recurrenceId, SECOND_DAY))
+                .isInstanceOf(BusinessException.class)
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+
+        assertThat(todoRepository.findAllByUserIdAndDate(userId, SECOND_DAY)).isEmpty();
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -2,7 +2,14 @@ spring:
   application:
     name: fryday-test
 
+  datasource:
+    url: jdbc:h2:mem:fryday_test;MODE=MySQL;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
   jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: create-drop
     properties:


### PR DESCRIPTION
## 📌 Related Issue
- close: #94 

## 🚀 Description

### 문제
반복 투두에 매일 + 기간(예: 4/1~4/5)을 설정한 뒤 종료일만 바꾸고, 반복 시작일을 조회하면 해당 투두가 보이지 않는 현상이 있었습니다.

**원인 요약**
1. 최초 반복 생성 시 기준 투두 날짜에 `RecurrenceException`(DELETED)를 두어 중복 materialize를 막았는데, **반복 규칙 수정(`updateRecurrence`)** 시 시리즈에 묶인 투두는 소프트 삭제되어도 **해당 DELETED 행이 남으면** 그 날짜는 계속 “예외 날짜”로 처리되어 재생성이 막혔습니다.
2. 구현 과정에서 예외 삭제용 `@Modifying(clearAutomatically = true)` 직후 **영속성 컨텍스트가 비워져** 같은 루프의 `todo.delete()`가 반영되지 않을 수 있었습니다. 통합 테스트로 확인 후 해당 삭제 쿼리는 **`clearAutomatically = false`** 로 조정했습니다.

또한 사용자가 **특정 회차만 삭제**한 경우에는 `DELETED` 예외가 유지되어야 재생성이 막히는데, 규칙 수정 시 **활성 투두가 없는 날짜**(이미 사용자가 삭제한 회차)는 `findAllByRecurrenceId`에 잡히지 않으므로 **그날의 DELETED는 건드리지 않도록** 했습니다.

### 검토한 대안
- **규칙 수정 시 예외 전부 삭제**: 단순하지만 사용자가 삭제한 회차용 `DELETED`까지 지울 수 있어 제외
- **materialize에서 DELETED를 조건부로 무시**: “실제 활성 투두가 없을 때만 무시” 등으로도 가능하지만, 예외 타입 의미를 코드 전반에서 재정의해야 해 범위가 커짐
- **기준 투두만 별도 플래그/저장 방식으로 분리**: 깔끔하지만 스키마, 마이그레이션 범위가 컸음.

### 채택한 방식
1. **`createRecurrence`에서 기준 날짜용 DELETED 예외를 저장하지 않음** — 기준 날짜에는 이미 물리 투두가 있고, materialize에서 동일 `recurrenceId`로 중복을 막을 수 있음.
2. **`updateRecurrence`에서 활성 투두를 소프트 삭제할 때만** `(recurrenceId, occurrenceDate, DELETED)` 예외를 JPQL로 삭제 — 규칙을 수정할 때만 “기준용으로 남았을 수 있는 DELETED”를 정리하고, 이미 목록에 없는(사용자가 삭제한) 회차는 루프에 안 들어와 예외가 유지됨.
3. **통합 테스트(`RecurrenceServiceIntegrationTest`)** (H2)
   - 규칙 수정 후 기준 날짜에 materialize 시 투두가 다시 생기는지
   - 사용자 삭제 회차는 규칙 수정 후에도 DELETED가 남고 재생성되지 않는지
를 H2 기반으로 검증

## 📢 Notes
