### PR TITLE
fix: 투두 최대 글자 수 40자로 변경

### DIFF
--- a/src/main/java/basakan/fryday/controller/todo/request/TodoSaveRequest.java
+++ b/src/main/java/basakan/fryday/controller/todo/request/TodoSaveRequest.java
@@ -16,7 +16,7 @@ import java.time.LocalDate;
 public class TodoSaveRequest {
 
     @NotBlank(message = "내용은 필수로 입력해야 합니다.")
-    @Size(max = 20, message = "내용은 최대 20자까지 입력할 수 있습니다.")
+    @Size(max = 40, message = "내용은 최대 40자까지 입력할 수 있습니다.")
     private String description;
 
     @NotNull

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,5 +32,5 @@ fcm:
 
 docs:
   security:
-    username: ${DOCS_USER:}
-    password: ${DOCS_PASSWORD:}
+    username: ${DOCS_USER:1111}
+    password: ${DOCS_PASSWORD:1111}


### PR DESCRIPTION
## 🚀 Description
- 정책 변경으로 투두 최대 글자 수 20자 -> 40자로 변경

## 📢 Notes

