### PR TITLE
Admin 전체 푸시 알림 발송 API 구현

### DIFF
--- a/src/main/java/basakan/fryday/common/ErrorCode.java
+++ b/src/main/java/basakan/fryday/common/ErrorCode.java
@@ -50,7 +50,10 @@ public enum ErrorCode {
     DEVICE_EXPIRED(HttpStatus.UNAUTHORIZED, "디바이스 세션이 만료되었습니다."),
 
     // Report
-    INVALID_REPORT_PERIOD(HttpStatus.BAD_REQUEST, "조회할 수 없는 기간입니다.");
+    INVALID_REPORT_PERIOD(HttpStatus.BAD_REQUEST, "조회할 수 없는 기간입니다."),
+
+    // Admin
+    ADMIN_KEY_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 Admin Key입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/basakan/fryday/common/config/AdminWebConfig.java
+++ b/src/main/java/basakan/fryday/common/config/AdminWebConfig.java
@@ -1,0 +1,20 @@
+package basakan.fryday.common.config;
+
+import basakan.fryday.common.security.AdminKeyInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class AdminWebConfig implements WebMvcConfigurer {
+
+    @Value("${admin.api-key:#{null}}")
+    private String adminApiKey;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new AdminKeyInterceptor(adminApiKey))
+                .addPathPatterns("/api/admin/**");
+    }
+}

--- a/src/main/java/basakan/fryday/common/config/SecurityConfig.java
+++ b/src/main/java/basakan/fryday/common/config/SecurityConfig.java
@@ -70,6 +70,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/users/apple/login").permitAll()
                         .requestMatchers("/api/users/token/refresh").permitAll()
                         .requestMatchers("/api/users/nickname/check").permitAll()
+                        .requestMatchers("/api/admin/**").permitAll()
                         .requestMatchers("/actuator/**").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/basakan/fryday/common/security/AdminKeyInterceptor.java
+++ b/src/main/java/basakan/fryday/common/security/AdminKeyInterceptor.java
@@ -1,0 +1,32 @@
+package basakan.fryday.common.security;
+
+import basakan.fryday.common.ErrorCode;
+import basakan.fryday.common.exception.BusinessException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class AdminKeyInterceptor implements HandlerInterceptor {
+
+    private static final String ADMIN_KEY_HEADER = "X-Admin-Key";
+
+    private final String adminApiKey;
+
+    public AdminKeyInterceptor(String adminApiKey) {
+        this.adminApiKey = adminApiKey;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        if (adminApiKey == null || adminApiKey.isBlank()) {
+            throw new BusinessException(ErrorCode.ADMIN_KEY_INVALID);
+        }
+
+        String requestKey = request.getHeader(ADMIN_KEY_HEADER);
+        if (!adminApiKey.equals(requestKey)) {
+            throw new BusinessException(ErrorCode.ADMIN_KEY_INVALID);
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/basakan/fryday/controller/admin/AdminPushController.java
+++ b/src/main/java/basakan/fryday/controller/admin/AdminPushController.java
@@ -1,0 +1,28 @@
+package basakan.fryday.controller.admin;
+
+import basakan.fryday.common.response.ApiResponse;
+import basakan.fryday.controller.admin.request.BroadcastPushRequest;
+import basakan.fryday.controller.admin.response.BroadcastPushResponse;
+import basakan.fryday.service.admin.AdminPushService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class AdminPushController {
+
+    private final AdminPushService adminPushService;
+
+    @PostMapping("/push")
+    public ApiResponse<BroadcastPushResponse> broadcastPush(
+            @Valid @RequestBody BroadcastPushRequest request
+    ) {
+        int sentCount = adminPushService.broadcastPush(request.getTitle(), request.getBody());
+        return ApiResponse.success(new BroadcastPushResponse(sentCount));
+    }
+}

--- a/src/main/java/basakan/fryday/controller/admin/request/BroadcastPushRequest.java
+++ b/src/main/java/basakan/fryday/controller/admin/request/BroadcastPushRequest.java
@@ -1,0 +1,24 @@
+package basakan.fryday.controller.admin.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class BroadcastPushRequest {
+
+    @NotBlank(message = "알림 제목은 필수입니다.")
+    @Size(max = 50, message = "알림 제목은 최대 50자까지 가능합니다.")
+    private String title;
+
+    @NotBlank(message = "알림 내용은 필수입니다.")
+    @Size(max = 200, message = "알림 내용은 최대 200자까지 가능합니다.")
+    private String body;
+
+    public BroadcastPushRequest(String title, String body) {
+        this.title = title;
+        this.body = body;
+    }
+}

--- a/src/main/java/basakan/fryday/controller/admin/response/BroadcastPushResponse.java
+++ b/src/main/java/basakan/fryday/controller/admin/response/BroadcastPushResponse.java
@@ -1,0 +1,13 @@
+package basakan.fryday.controller.admin.response;
+
+import lombok.Getter;
+
+@Getter
+public class BroadcastPushResponse {
+
+    private final int sentCount;
+
+    public BroadcastPushResponse(int sentCount) {
+        this.sentCount = sentCount;
+    }
+}

--- a/src/main/java/basakan/fryday/repository/auth/UserDeviceRepository.java
+++ b/src/main/java/basakan/fryday/repository/auth/UserDeviceRepository.java
@@ -30,4 +30,6 @@ public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
     List<UserDevice> findAllByUserIdAndIsActiveTrueAndPushNotificationAgreedTrue(Long userId);
 
     void deleteAllByUserId(Long userId);
+
+    List<UserDevice> findAllByIsActiveTrueAndPushNotificationAgreedTrueAndFcmTokenIsNotNull();
 }

--- a/src/main/java/basakan/fryday/service/admin/AdminPushService.java
+++ b/src/main/java/basakan/fryday/service/admin/AdminPushService.java
@@ -1,0 +1,44 @@
+package basakan.fryday.service.admin;
+
+import basakan.fryday.common.service.push.PushService;
+import basakan.fryday.domain.user.UserDevice;
+import basakan.fryday.repository.auth.UserDeviceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminPushService {
+
+    private final UserDeviceRepository userDeviceRepository;
+    private final PushService pushService;
+
+    @Transactional(readOnly = true)
+    public int broadcastPush(String title, String body) {
+        List<UserDevice> devices = userDeviceRepository
+                .findAllByIsActiveTrueAndPushNotificationAgreedTrueAndFcmTokenIsNotNull();
+
+        if (devices.isEmpty()) {
+            log.info("전체 푸시 발송 대상 디바이스가 없습니다.");
+            return 0;
+        }
+
+        int successCount = 0;
+        for (UserDevice device : devices) {
+            try {
+                pushService.sendToToken(device.getFcmToken(), title, body);
+                successCount++;
+            } catch (Exception e) {
+                log.warn("전체 푸시 발송 실패: fcmToken={}, error={}", device.getFcmToken(), e.getMessage());
+            }
+        }
+
+        log.info("전체 푸시 발송 완료: 총 {}대 중 {}대 성공", devices.size(), successCount);
+        return successCount;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,3 +34,6 @@ docs:
   security:
     username: ${DOCS_USER:1111}
     password: ${DOCS_PASSWORD:1111}
+
+admin:
+  api-key: ${ADMIN_API_KEY:#{null}}

--- a/src/test/java/basakan/fryday/common/security/AdminKeyInterceptorTest.java
+++ b/src/test/java/basakan/fryday/common/security/AdminKeyInterceptorTest.java
@@ -1,0 +1,75 @@
+package basakan.fryday.common.security;
+
+import basakan.fryday.common.ErrorCode;
+import basakan.fryday.common.exception.BusinessException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AdminKeyInterceptorTest {
+
+    @Test
+    @DisplayName("유효한 Admin Key면 통과한다")
+    void validAdminKey() {
+        AdminKeyInterceptor interceptor = new AdminKeyInterceptor("my-secret-key");
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        when(request.getHeader("X-Admin-Key")).thenReturn("my-secret-key");
+
+        boolean result = interceptor.preHandle(request, response, new Object());
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("Admin Key가 없으면 BusinessException 발생")
+    void missingAdminKey() {
+        AdminKeyInterceptor interceptor = new AdminKeyInterceptor("my-secret-key");
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        when(request.getHeader("X-Admin-Key")).thenReturn(null);
+
+        assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ADMIN_KEY_INVALID);
+    }
+
+    @Test
+    @DisplayName("Admin Key가 틀리면 BusinessException 발생")
+    void invalidAdminKey() {
+        AdminKeyInterceptor interceptor = new AdminKeyInterceptor("my-secret-key");
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        when(request.getHeader("X-Admin-Key")).thenReturn("wrong-key");
+
+        assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ADMIN_KEY_INVALID);
+    }
+
+    @Test
+    @DisplayName("Admin Key가 설정되지 않으면 모든 요청 거부")
+    void adminKeyNotConfigured() {
+        AdminKeyInterceptor interceptor = new AdminKeyInterceptor(null);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        when(request.getHeader("X-Admin-Key")).thenReturn("any-key");
+
+        assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ADMIN_KEY_INVALID);
+    }
+}

--- a/src/test/java/basakan/fryday/controller/admin/AdminPushControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/admin/AdminPushControllerTest.java
@@ -1,0 +1,95 @@
+package basakan.fryday.controller.admin;
+
+import basakan.fryday.RestDocsSupport;
+import basakan.fryday.common.config.AdminWebConfig;
+import basakan.fryday.common.config.SecurityConfig;
+import basakan.fryday.common.security.JwtAuthenticationFilter;
+import basakan.fryday.common.security.JwtTokenProvider;
+import basakan.fryday.controller.admin.request.BroadcastPushRequest;
+import basakan.fryday.service.admin.AdminPushService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = AdminPushController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+                        classes = {SecurityConfig.class, AdminWebConfig.class})
+        }
+)
+class AdminPushControllerTest extends RestDocsSupport {
+
+    @MockitoBean
+    private AdminPushService adminPushService;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @DisplayName("전체 푸시 발송 API - 성공")
+    void broadcastPush() throws Exception {
+        // given
+        BroadcastPushRequest request = new BroadcastPushRequest("공지사항", "서버 점검 안내입니다");
+        given(adminPushService.broadcastPush("공지사항", "서버 점검 안내입니다")).willReturn(15);
+
+        // when & then
+        mockMvc.perform(post("/api/admin/push")
+                        .header("X-Admin-Key", "test-admin-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.sentCount").value(15))
+                .andDo(document("admin-broadcast-push",
+                        requestHeaders(
+                                headerWithName("X-Admin-Key").description("Admin 인증 키")
+                        ),
+                        requestFields(
+                                fieldWithPath("title").description("알림 제목 (최대 50자)"),
+                                fieldWithPath("body").description("알림 내용 (최대 200자)")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.sentCount").description("발송 성공 디바이스 수"),
+                                fieldWithPath("timestamp").description("응답 시각")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("전체 푸시 발송 API - 제목 누락 시 400")
+    void broadcastPushWithoutTitle() throws Exception {
+        // given
+        BroadcastPushRequest request = new BroadcastPushRequest("", "내용");
+
+        // when & then
+        mockMvc.perform(post("/api/admin/push")
+                        .header("X-Admin-Key", "test-admin-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/basakan/fryday/service/admin/AdminPushServiceTest.java
+++ b/src/test/java/basakan/fryday/service/admin/AdminPushServiceTest.java
@@ -1,0 +1,100 @@
+package basakan.fryday.service.admin;
+
+import basakan.fryday.common.service.push.PushService;
+import basakan.fryday.domain.user.UserDevice;
+import basakan.fryday.repository.auth.UserDeviceRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.ArgumentMatchers.anyString;
+
+@ExtendWith(MockitoExtension.class)
+class AdminPushServiceTest {
+
+    @InjectMocks
+    private AdminPushService adminPushService;
+
+    @Mock
+    private UserDeviceRepository userDeviceRepository;
+
+    @Mock
+    private PushService pushService;
+
+    @Test
+    @DisplayName("푸시 동의한 모든 활성 디바이스에 알림을 발송한다")
+    void broadcastToAllActiveDevices() {
+        // given
+        UserDevice device1 = createDevice("token-1");
+        UserDevice device2 = createDevice("token-2");
+        given(userDeviceRepository.findAllByIsActiveTrueAndPushNotificationAgreedTrueAndFcmTokenIsNotNull())
+                .willReturn(List.of(device1, device2));
+
+        // when
+        int count = adminPushService.broadcastPush("공지", "서버 점검입니다");
+
+        // then
+        then(pushService).should(times(1)).sendToToken("token-1", "공지", "서버 점검입니다");
+        then(pushService).should(times(1)).sendToToken("token-2", "공지", "서버 점검입니다");
+        assertThat(count).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("대상 디바이스가 없으면 0을 반환한다")
+    void noDevices() {
+        // given
+        given(userDeviceRepository.findAllByIsActiveTrueAndPushNotificationAgreedTrueAndFcmTokenIsNotNull())
+                .willReturn(List.of());
+
+        // when
+        int count = adminPushService.broadcastPush("공지", "내용");
+
+        // then
+        then(pushService).should(never()).sendToToken(anyString(), anyString(), anyString());
+        assertThat(count).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("일부 디바이스 발송 실패해도 나머지는 계속 발송한다")
+    void partialFailureContinues() {
+        // given
+        UserDevice device1 = createDevice("token-1");
+        UserDevice device2 = createDevice("token-2");
+        UserDevice device3 = createDevice("token-3");
+        given(userDeviceRepository.findAllByIsActiveTrueAndPushNotificationAgreedTrueAndFcmTokenIsNotNull())
+                .willReturn(List.of(device1, device2, device3));
+        org.mockito.Mockito.lenient().doThrow(new RuntimeException("FCM error"))
+                .when(pushService).sendToToken("token-2", "공지", "내용");
+
+        // when
+        int count = adminPushService.broadcastPush("공지", "내용");
+
+        // then
+        then(pushService).should().sendToToken("token-1", "공지", "내용");
+        then(pushService).should().sendToToken("token-2", "공지", "내용");
+        then(pushService).should().sendToToken("token-3", "공지", "내용");
+        assertThat(count).isEqualTo(2);
+    }
+
+    private UserDevice createDevice(String fcmToken) {
+        UserDevice device = UserDevice.builder()
+                .userId(1L)
+                .deviceId("device-" + fcmToken)
+                .fcmToken(fcmToken)
+                .deviceType("iOS")
+                .deviceName("Test Device")
+                .build();
+        device.updatePushNotificationAgreement(true);
+        return device;
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -44,3 +44,6 @@ docs:
   security:
     username: test
     password: test
+
+admin:
+  api-key: test-admin-key


### PR DESCRIPTION
## 📌 Related Issue
- close: #

## 🚀 Description

### 개요
`X-Admin-Key` 헤더 인증 기반의 Admin 전용 전체 푸시 알림 발송 API를 구현합니다.

### 주요 변경사항

**1. Admin 인증 (X-Admin-Key 헤더)**
- `AdminKeyInterceptor`: 요청 헤더의 `X-Admin-Key` 값을 환경변수(`ADMIN_API_KEY`)와 비교
- `AdminWebConfig`: `/api/admin/**` 경로에 인터셉터 등록
- `SecurityConfig`: `/api/admin/**` 경로 JWT 인증 skip (permitAll)

**2. 전체 푸시 발송**
- `AdminPushService`: 푸시 동의 + 활성 + FCM 토큰 보유 디바이스 전체 조회 후 발송
- 개별 디바이스 발송 실패 시에도 나머지 계속 발송 (부분 실패 허용)
- 발송 성공 디바이스 수 반환

**3. API 엔드포인트**
```
POST /api/admin/push
Header: X-Admin-Key: {ADMIN_API_KEY}
Body: { "title": "알림 제목", "body": "알림 내용" }
```

### 아키텍처

```mermaid
sequenceDiagram
    participant Client
    participant SecurityFilter
    participant AdminKeyInterceptor
    participant AdminPushController
    participant AdminPushService
    participant FcmPushService
    participant FCM

    Client->>SecurityFilter: POST /api/admin/push
    SecurityFilter->>SecurityFilter: permitAll (JWT skip)
    SecurityFilter->>AdminKeyInterceptor: X-Admin-Key 검증
    alt Key 불일치 또는 미설정
        AdminKeyInterceptor-->>Client: 401 ADMIN_KEY_INVALID
    end
    AdminKeyInterceptor->>AdminPushController: 통과
    AdminPushController->>AdminPushService: broadcastPush(title, body)
    AdminPushService->>AdminPushService: 활성 디바이스 전체 조회
    loop 각 디바이스
        AdminPushService->>FcmPushService: sendToToken(fcmToken, title, body)
        FcmPushService->>FCM: 발송
        alt 실패
            AdminPushService->>AdminPushService: 로그 남기고 계속
        end
    end
    AdminPushService-->>AdminPushController: 성공 수 반환
    AdminPushController-->>Client: 200 { sentCount: N }
```

### 변경 파일
| 파일 | 변경 |
|------|------|
| `ErrorCode.java` | `ADMIN_KEY_INVALID` 추가 |
| `application.yml` (main/test) | `admin.api-key` 속성 추가 |
| `AdminKeyInterceptor.java` | 신규 - 헤더 검증 |
| `AdminWebConfig.java` | 신규 - 인터셉터 등록 |
| `SecurityConfig.java` | `/api/admin/**` permitAll 추가 |
| `BroadcastPushRequest.java` | 신규 - 요청 DTO |
| `BroadcastPushResponse.java` | 신규 - 응답 DTO |
| `UserDeviceRepository.java` | 전체 활성 디바이스 조회 메서드 추가 |
| `AdminPushService.java` | 신규 - 전체 발송 서비스 |
| `AdminPushController.java` | 신규 - 컨트롤러 |

### 테스트
- `AdminKeyInterceptorTest`: 4 tests (유효/누락/불일치/미설정)
- `AdminPushServiceTest`: 3 tests (전체발송/대상없음/부분실패)
- `AdminPushControllerTest`: 2 tests (성공/validation 실패) + REST Docs

## 📢 Notes
- 서버 배포 시 `ADMIN_API_KEY` 환경변수 설정 필수 (미설정 시 모든 Admin 요청 거부)
- dev 서버 테스트 완료