### PR TITLE
DB 점검 시 SERVICE_UNAVAILABLE 에러 코드 응답 처리

### DIFF
--- a/src/main/java/basakan/fryday/common/ErrorCode.java
+++ b/src/main/java/basakan/fryday/common/ErrorCode.java
@@ -53,7 +53,10 @@ public enum ErrorCode {
     INVALID_REPORT_PERIOD(HttpStatus.BAD_REQUEST, "조회할 수 없는 기간입니다."),
 
     // Admin
-    ADMIN_KEY_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 Admin Key입니다.");
+    ADMIN_KEY_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 Admin Key입니다."),
+
+    // System
+    SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "서버 점검 중입니다. 잠시 후 다시 시도해주세요.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/basakan/fryday/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/basakan/fryday/common/exception/GlobalExceptionHandler.java
@@ -20,6 +20,9 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.transaction.CannotCreateTransactionException;
+
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -246,7 +249,18 @@ public class GlobalExceptionHandler {
         return "요청 본문을 읽을 수 없습니다. JSON 형식이 올바른지 확인해주세요.";
     }
 
-    // 12. 그 외 모든 예외 처리
+    // 12. DB 연결 실패 (503 Service Unavailable)
+    @ExceptionHandler({DataAccessResourceFailureException.class, CannotCreateTransactionException.class})
+    protected ResponseEntity<ApiResponse<Void>> handleDatabaseConnectionException(Exception e, HttpServletRequest request) {
+        log.error("DB 연결 실패 [{} {}]: {}", request.getMethod(), request.getRequestURI(), e.getMessage());
+        ErrorCode errorCode = ErrorCode.SERVICE_UNAVAILABLE;
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode.getMessage(), errorCode.name()));
+    }
+
+    // 13. 그 외 모든 예외 처리
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ApiResponse<Void>> handleException(Exception e, HttpServletRequest request) {
         log.error("ERROR [{} {}] 예외타입: {} 메시지: {}", request.getMethod(), request.getRequestURI(),

--- a/src/main/java/basakan/fryday/common/response/ApiResponse.java
+++ b/src/main/java/basakan/fryday/common/response/ApiResponse.java
@@ -14,6 +14,9 @@ public class ApiResponse<T> {
     private final String message;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final String errorCode;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private final T data;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -22,9 +25,10 @@ public class ApiResponse<T> {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private final LocalDateTime timestamp;
 
-    private ApiResponse(boolean success, String message, T data, List<FieldErrorResponse> errors) {
+    private ApiResponse(boolean success, String message, String errorCode, T data, List<FieldErrorResponse> errors) {
         this.success = success;
         this.message = message;
+        this.errorCode = errorCode;
         this.data = data;
         this.errors = errors;
         this.timestamp = LocalDateTime.now();
@@ -32,20 +36,25 @@ public class ApiResponse<T> {
 
     // 성공 응답 (데이터)
     public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(true, "정상 처리되었습니다.", data, null);
+        return new ApiResponse<>(true, "정상 처리되었습니다.", null, data, null);
     }
 
     // 성공 응답 (커스텀 메시지 + 데이터)
     public static <T> ApiResponse<T> success(T data, String message) {
-        return new ApiResponse<>(true, message, data, null);
+        return new ApiResponse<>(true, message, null, data, null);
     }
 
     // 실패 응답 (간단한 메시지)
     public static <T> ApiResponse<T> fail(String message) {
-        return new ApiResponse<>(false, message, null, null);
+        return new ApiResponse<>(false, message, null, null, null);
     }
 
     public static <T> ApiResponse<T> fail(String message, List<FieldErrorResponse> errors) {
-        return new ApiResponse<>(false, message, null, errors);
+        return new ApiResponse<>(false, message, null, null, errors);
+    }
+
+    // 실패 응답 (에러 코드 포함)
+    public static <T> ApiResponse<T> fail(String message, String errorCode) {
+        return new ApiResponse<>(false, message, errorCode, null, null);
     }
 }

--- a/src/test/java/basakan/fryday/common/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/basakan/fryday/common/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,52 @@
+package basakan.fryday.common.exception;
+
+import basakan.fryday.common.ErrorCode;
+import basakan.fryday.common.response.ApiResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.transaction.CannotCreateTransactionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    @DisplayName("DataAccessResourceFailureException 발생 시 503 + SERVICE_UNAVAILABLE 에러 코드 반환")
+    void handleDataAccessResourceFailureException() {
+        DataAccessResourceFailureException exception = new DataAccessResourceFailureException("DB 연결 실패");
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/todos");
+
+        ResponseEntity<ApiResponse<Void>> response = handler.handleDatabaseConnectionException(exception, request);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(503);
+        assertThat(response.getBody().getMessage()).isEqualTo(ErrorCode.SERVICE_UNAVAILABLE.getMessage());
+        assertThat(response.getBody().getErrorCode()).isEqualTo("SERVICE_UNAVAILABLE");
+        assertThat(response.getBody().isSuccess()).isFalse();
+    }
+
+    @Test
+    @DisplayName("CannotCreateTransactionException 발생 시 503 + SERVICE_UNAVAILABLE 에러 코드 반환")
+    void handleCannotCreateTransactionException() {
+        CannotCreateTransactionException exception = new CannotCreateTransactionException("트랜잭션 생성 실패");
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/todos");
+
+        ResponseEntity<ApiResponse<Void>> response = handler.handleDatabaseConnectionException(exception, request);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(503);
+        assertThat(response.getBody().getErrorCode()).isEqualTo("SERVICE_UNAVAILABLE");
+    }
+
+    @Test
+    @DisplayName("성공 응답에는 errorCode가 null이다")
+    void successResponseHasNoErrorCode() {
+        ApiResponse<String> response = ApiResponse.success("data");
+
+        assertThat(response.getErrorCode()).isNull();
+        assertThat(response.isSuccess()).isTrue();
+    }
+}


### PR DESCRIPTION
## 📌 Related Issue
- close: #

## 🚀 Description

### 개요
DB 연결 실패(점검 등) 시 프론트에서 구분 가능한 에러 코드를 응답에 포함하여 점검 모달을 띄울 수 있도록 한다.

### 주요 변경사항

**1. ApiResponse에 errorCode 필드 추가**
- `@JsonInclude(NON_NULL)` 적용 — 실패 시에만 응답에 포함
- 성공 응답은 기존과 완전히 동일 (프론트 영향 없음)
- `fail(message, errorCode)` 오버로드 추가

**2. DB 연결 실패 예외 핸들러 추가**
- `DataAccessResourceFailureException`, `CannotCreateTransactionException` 캐치
- HTTP 503 + `errorCode: "SERVICE_UNAVAILABLE"` 응답

**3. 응답 예시**
```json
{
  "success": false,
  "message": "서버 점검 중입니다. 잠시 후 다시 시도해주세요.",
  "errorCode": "SERVICE_UNAVAILABLE",
  "timestamp": "2026-05-08T14:00:00"
}
```

### 아키텍처

```mermaid
flowchart TD
    A[API 요청] --> B{DB 연결 상태}
    B -->|정상| C[비즈니스 로직 처리]
    C --> D[200 성공 응답]
    B -->|연결 실패| E[DataAccessResourceFailureException]
    E --> F[GlobalExceptionHandler]
    F --> G["503 + errorCode: SERVICE_UNAVAILABLE"]
    G --> H[프론트: 점검 모달 표시]
```

### 변경 파일
| 파일 | 변경 |
|------|------|
| `ErrorCode.java` | `SERVICE_UNAVAILABLE` 추가 |
| `ApiResponse.java` | `errorCode` 필드 + `fail()` 오버로드 추가 |
| `GlobalExceptionHandler.java` | DB 예외 핸들러 추가 |

### 테스트
- `GlobalExceptionHandlerTest`: 3 tests
  - `DataAccessResourceFailureException` → 503 + SERVICE_UNAVAILABLE
  - `CannotCreateTransactionException` → 503 + SERVICE_UNAVAILABLE
  - 성공 응답에는 errorCode null 확인

## 📢 Notes
- 성공 응답은 기존과 동일 — errorCode 필드가 아예 내려가지 않음
- 프론트 연동: `errorCode === "SERVICE_UNAVAILABLE"` 또는 HTTP 502/503 또는 Network Error 시 점검 모달 표시