### PR TITLE
#105 fix: THIS_AND_FUTURE/ALL 수정 시 재생성 인스턴스 displayOrder 유지

### DIFF
--- a/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
@@ -37,6 +37,9 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     @Query("SELECT t FROM Todo t WHERE t.recurrenceId = :recurrenceId AND t.deletedAt IS NULL")
     List<Todo> findAllByRecurrenceId(@Param("recurrenceId") Long recurrenceId);
 
+    @Query("SELECT t FROM Todo t WHERE t.recurrenceId = :recurrenceId AND t.date >= :fromDate AND t.deletedAt IS NULL")
+    List<Todo> findAllByRecurrenceIdAndDateGte(@Param("recurrenceId") Long recurrenceId, @Param("fromDate") LocalDate fromDate);
+
     @Query("SELECT CASE WHEN COUNT(t) > 0 THEN TRUE ELSE FALSE END FROM Todo t WHERE t.recurrenceId = :recurrenceId AND t.date = :date")
     boolean existsByRecurrenceIdAndDate(@Param("recurrenceId") Long recurrenceId, @Param("date") LocalDate date);
 

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceInstanceService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceInstanceService.java
@@ -21,6 +21,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -99,11 +102,13 @@ public class RecurrenceInstanceService {
 
         Recurrence savedNewMaster = recurrenceRepository.save(newMaster);
 
-        // STEP 3: T 이후 기존 인스턴스 일괄 soft delete
+        // STEP 3: T 이후 기존 인스턴스 일괄 soft delete (delete 전 displayOrder 보존)
+        Map<LocalDate, Long> preservedOrders = todoRepository.findAllByRecurrenceIdAndDateGte(oldMaster.getId(), T)
+                .stream().collect(Collectors.toMap(Todo::getDate, Todo::getDisplayOrder));
         todoRepository.bulkSoftDeleteByRecurrenceIdAndDateGte(oldMaster.getId(), T, LocalDate.now());
 
         // STEP 4: M_new 기준으로 T부터 새 인스턴스 배치 생성
-        generateInstances(savedNewMaster, T, 365);
+        generateInstances(savedNewMaster, T, 365, preservedOrders);
     }
 
     /** spec 4.5: Master 직접 수정 — override 있는 인스턴스는 건드리지 않음 */
@@ -134,9 +139,11 @@ public class RecurrenceInstanceService {
             LocalDate generateFrom = newStartDate.isAfter(today) ? newStartDate : today;
             master.updateLastGeneratedDate(generateFrom);
 
-            // 오늘 이후 인스턴스 물리 삭제 (과거 완료 이력 보존)
+            // 오늘 이후 인스턴스 물리 삭제 (과거 완료 이력 보존, delete 전 displayOrder 보존)
+            Map<LocalDate, Long> preservedOrders = todoRepository.findAllByRecurrenceIdAndDateGte(master.getId(), today)
+                    .stream().collect(Collectors.toMap(Todo::getDate, Todo::getDisplayOrder));
             todoRepository.hardDeleteByRecurrenceIdAndDateGte(master.getId(), today);
-            generateInstances(master, generateFrom, 365);
+            generateInstances(master, generateFrom, 365, preservedOrders);
         } else {
             // 내용만 변경: Master 업데이트 + 비override 인스턴스 일괄 반영
             master.updateContent(payload.getTitle(), payload.getMemo(),
@@ -194,6 +201,11 @@ public class RecurrenceInstanceService {
      * 이미 존재하는 날짜(삭제 포함)는 SKIP.
      */
     public List<Todo> generateInstances(Recurrence master, LocalDate startDate, int limitDays) {
+        return generateInstances(master, startDate, limitDays, Map.of());
+    }
+
+    public List<Todo> generateInstances(Recurrence master, LocalDate startDate, int limitDays,
+                                        Map<LocalDate, Long> preservedOrders) {
         LocalDate endLimit = startDate.plusDays(limitDays);
         LocalDate toDate = (master.getEndType() == EndType.UNTIL && master.getEndDate() != null
                 && master.getEndDate().isBefore(endLimit))
@@ -208,8 +220,10 @@ public class RecurrenceInstanceService {
         return occurrenceDates.stream()
                 .filter(date -> !todoRepository.existsByRecurrenceIdAndDate(master.getId(), date))
                 .map(date -> {
-                    Long maxOrder = todoRepository.findMaxDisplayOrder(master.getUserId(), date);
-                    long displayOrder = (maxOrder == null) ? 1 : maxOrder + 1;
+                    long displayOrder = preservedOrders.containsKey(date)
+                            ? preservedOrders.get(date)
+                            : Optional.ofNullable(todoRepository.findMaxDisplayOrder(master.getUserId(), date))
+                                    .map(max -> max + 1).orElse(1L);
 
                     Todo todo = Todo.builder()
                             .description(master.getDescription())


### PR DESCRIPTION
## 📌 Related Issue
- close: #105 

## 🚀 Description

### 문제

반복 투두를 `THIS_AND_FUTURE` 또는 `ALL`(규칙 변경) scope로 수정하면 해당 날짜 이후 인스턴스가 삭제 후 재생성됩니다. 이 과정에서 기존 `displayOrder`가 소멸되고, 재생성 시 `findMaxDisplayOrder + 1`로 새로운 순서가 배정되어 투두 위치가 변경되는 문제가 있었습니다.

### 원인

   ```
   1. 기존 인스턴스 soft/hard delete → displayOrder 정보 소멸
   2. 새 인스턴스 생성 시 findMaxDisplayOrder로 재계산 → 기존과 다른 순서 배정
   ```

 ### 수정 내용

 delete 실행 전에 `Map<LocalDate, Long>` 형태로 날짜별 displayOrder를 캡처해두고, 재생성 시 해당 날짜가 존재하면 기존 값을 그대로 사용합니다. 규칙 변경으로 새로 추가된 날짜는 기존과 동일하게 `findMaxDisplayOrder + 1`로 처리합니다.

   ```java
   Map<LocalDate, Long> preservedOrders = todoRepository
       .findAllByRecurrenceIdAndDateGte(recurrenceId, fromDate)
       .stream().collect(Collectors.toMap(Todo::getDate, Todo::getDisplayOrder));

   // delete 후 generateInstances에 전달
   long displayOrder = preservedOrders.containsKey(date)
       ? preservedOrders.get(date)
       : Optional.ofNullable(todoRepository.findMaxDisplayOrder(...)).map(max -> max + 1).orElse(1L);
   ```

   ## 변경 파일

   - `TodoRepository` — `findAllByRecurrenceIdAndDateGte` 쿼리 추가
   - `RecurrenceInstanceService` — `generateInstances` 오버로드, `editThisAndFuture`·`editAll` displayOrder 캡처 로직 추가
## 📢 Notes



   