### PR TITLE
#107 feat: 반복 해제 기능 강화

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -663,6 +663,54 @@ include::{snippets}/instance-delete-all/http-response.adoc[]
 include::{snippets}/instance-delete-this/response-fields.adoc[]
 
 
+=== 반복 인스턴스 반복 해제
+`PATCH /api/todos/instances/{instanceId}/cancel-recurrence`
+
+반복 투두의 특정 인스턴스를 반복에서 해제합니다. 삭제가 아닌 **일반 투두로 전환**하는 기능입니다. `scope` 값에 따라 해제 범위가 달라집니다.
+
+NOTE: `instanceId`는 `GET /api/todos` 응답의 `data[].id` 필드입니다.
+
+==== scope별 동작
+
+[cols="1,2,3"]
+|===
+|scope |UI 문구 예시 |동작
+
+|`THIS`
+|이번 일정만 반복 해제
+|선택한 인스턴스만 일반 투두로 전환됩니다. 반복 규칙과 다른 날짜 인스턴스는 유지됩니다.
+
+|`THIS_AND_FUTURE`
+|이번 이후 전체 반복 해제
+|선택한 날짜의 인스턴스는 일반 투두로 전환되고, 그 이후 인스턴스는 삭제됩니다. 반복 규칙은 선택한 날짜 하루 전에 종료됩니다.
+
+|`ALL`
+|전체 반복 해제
+|선택한 인스턴스만 일반 투두로 전환되고, 나머지 모든 인스턴스는 삭제됩니다. 반복 규칙 자체도 삭제됩니다.
+|===
+
+==== 경로 파라미터
+include::{snippets}/instance-cancel-recurrence-this/path-parameters.adoc[]
+
+==== 요청 필드
+include::{snippets}/instance-cancel-recurrence-this/request-fields.adoc[]
+
+==== HTTP 요청/응답 예시 — THIS (이번만 반복 해제)
+include::{snippets}/instance-cancel-recurrence-this/http-request.adoc[]
+include::{snippets}/instance-cancel-recurrence-this/http-response.adoc[]
+
+==== HTTP 요청/응답 예시 — THIS_AND_FUTURE (이후 전체 반복 해제)
+include::{snippets}/instance-cancel-recurrence-this-and-future/http-request.adoc[]
+include::{snippets}/instance-cancel-recurrence-this-and-future/http-response.adoc[]
+
+==== HTTP 요청/응답 예시 — ALL (전체 반복 해제)
+include::{snippets}/instance-cancel-recurrence-all/http-request.adoc[]
+include::{snippets}/instance-cancel-recurrence-all/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/instance-cancel-recurrence-this/response-fields.adoc[]
+
+
 === 투두 내일 하기
 `PATCH /api/todos/{todoId}/tomorrow`
 

--- a/src/main/java/basakan/fryday/controller/todo/RecurrenceInstanceController.java
+++ b/src/main/java/basakan/fryday/controller/todo/RecurrenceInstanceController.java
@@ -1,6 +1,7 @@
 package basakan.fryday.controller.todo;
 
 import basakan.fryday.common.response.ApiResponse;
+import basakan.fryday.controller.todo.request.CancelRecurrenceRequest;
 import basakan.fryday.controller.todo.request.InstanceDeleteRequest;
 import basakan.fryday.controller.todo.request.InstanceEditRequest;
 import basakan.fryday.service.todo.RecurrenceInstanceService;
@@ -34,5 +35,15 @@ public class RecurrenceInstanceController {
     ) {
         recurrenceInstanceService.delete(instanceId, request.getScope(), userId);
         return ApiResponse.success(null);
+    }
+
+    @PatchMapping("/{instanceId}/cancel-recurrence")
+    public ApiResponse<Void> cancelRecurrence(
+            @PathVariable long instanceId,
+            @RequestBody @Valid CancelRecurrenceRequest request,
+            @AuthenticationPrincipal Long userId
+    ) {
+        recurrenceInstanceService.cancelRecurrence(instanceId, request.getScope(), userId);
+        return ApiResponse.success(null, "반복이 해제되었습니다.");
     }
 }

--- a/src/main/java/basakan/fryday/controller/todo/request/CancelRecurrenceRequest.java
+++ b/src/main/java/basakan/fryday/controller/todo/request/CancelRecurrenceRequest.java
@@ -1,5 +1,6 @@
 package basakan.fryday.controller.todo.request;
 
+import basakan.fryday.domain.todo.RecurrenceScope;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,10 +9,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CancelRecurrenceRequest {
 
-    public enum CancelScope {
-        THIS, THIS_AND_FUTURE, ALL
-    }
-
     @NotNull
-    private CancelScope scope;
+    private RecurrenceScope scope;
 }

--- a/src/main/java/basakan/fryday/controller/todo/request/CancelRecurrenceRequest.java
+++ b/src/main/java/basakan/fryday/controller/todo/request/CancelRecurrenceRequest.java
@@ -1,0 +1,17 @@
+package basakan.fryday.controller.todo.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CancelRecurrenceRequest {
+
+    public enum CancelScope {
+        THIS, THIS_AND_FUTURE, ALL
+    }
+
+    @NotNull
+    private CancelScope scope;
+}

--- a/src/main/java/basakan/fryday/controller/todo/request/InstanceDeleteRequest.java
+++ b/src/main/java/basakan/fryday/controller/todo/request/InstanceDeleteRequest.java
@@ -1,5 +1,6 @@
 package basakan.fryday.controller.todo.request;
 
+import basakan.fryday.domain.todo.RecurrenceScope;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,11 +10,5 @@ import lombok.NoArgsConstructor;
 public class InstanceDeleteRequest {
 
     @NotNull
-    private DeleteScope scope;
-
-    public enum DeleteScope {
-        THIS,
-        THIS_AND_FUTURE,
-        ALL
-    }
+    private RecurrenceScope scope;
 }

--- a/src/main/java/basakan/fryday/controller/todo/request/InstanceEditRequest.java
+++ b/src/main/java/basakan/fryday/controller/todo/request/InstanceEditRequest.java
@@ -1,5 +1,6 @@
 package basakan.fryday.controller.todo.request;
 
+import basakan.fryday.domain.todo.RecurrenceScope;
 import basakan.fryday.domain.todo.RecurrenceType;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -15,17 +16,11 @@ import java.util.List;
 public class InstanceEditRequest {
 
     @NotNull
-    private EditScope scope;
+    private RecurrenceScope scope;
 
     @NotNull
     @Valid
     private Payload payload;
-
-    public enum EditScope {
-        THIS,
-        THIS_AND_FUTURE,
-        ALL
-    }
 
     @Getter
     @NoArgsConstructor

--- a/src/main/java/basakan/fryday/domain/todo/RecurrenceScope.java
+++ b/src/main/java/basakan/fryday/domain/todo/RecurrenceScope.java
@@ -1,0 +1,5 @@
+package basakan.fryday.domain.todo;
+
+public enum RecurrenceScope {
+    THIS, THIS_AND_FUTURE, ALL
+}

--- a/src/main/java/basakan/fryday/domain/todo/Todo.java
+++ b/src/main/java/basakan/fryday/domain/todo/Todo.java
@@ -127,4 +127,18 @@ public class Todo extends BaseEntity {
         this.isOverridden = true;
     }
 
+    /** override 값을 base 필드에 이관하고 반복 연결을 끊어 독립 Todo로 전환 */
+    public void detachFromRecurrence() {
+        if (this.overrideTitle != null) this.description = this.overrideTitle;
+        if (this.overrideMemo != null) this.memo = this.overrideMemo;
+
+        this.overrideTitle = null;
+        this.overrideMemo = null;
+        this.overrideIsAlarm = null;
+        this.overrideAlarmTime = null;
+        this.isOverridden = false;
+
+        this.recurrenceId = null;
+    }
+
 }

--- a/src/main/java/basakan/fryday/domain/todo/TodoAlarm.java
+++ b/src/main/java/basakan/fryday/domain/todo/TodoAlarm.java
@@ -83,4 +83,8 @@ public class TodoAlarm extends BaseEntity {
     public boolean canRetry() {
         return this.status == AlarmStatus.PENDING && this.failCount < MAX_RETRY_COUNT;
     }
+
+    public void reassignTo(Todo newTodo) {
+        this.todo = newTodo;
+    }
 }

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceInstanceService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceInstanceService.java
@@ -204,10 +204,35 @@ public class RecurrenceInstanceService {
 
     // ── Cancel ─────────────────────────────────────────────────────────────────
 
-    /** 해당 인스턴스만 일반 Todo로 전환, 나머지 반복 유지 */
+    /**
+     * 해당 인스턴스만 일반 Todo로 전환, 나머지 반복 유지.
+     */
     private void cancelThis(long instanceId, long userId) {
         Todo instance = findActiveInstance(instanceId, userId);
-        instance.detachFromRecurrence();
+
+        String finalDescription = instance.getOverrideTitle() != null
+                ? instance.getOverrideTitle() : instance.getDescription();
+        String finalMemo = instance.getOverrideMemo() != null
+                ? instance.getOverrideMemo() : instance.getMemo();
+        boolean wasCompleted = instance.isCompleted();
+
+        instance.delete();
+
+        Todo standalone = Todo.builder()
+                .description(finalDescription)
+                .category(instance.getCategory())
+                .date(instance.getDate())
+                .displayOrder(instance.getDisplayOrder())
+                .memo(finalMemo)
+                .build();
+        Todo saved = todoRepository.save(standalone);
+
+        if (wasCompleted) {
+            saved.toggleCompletion();
+        }
+
+        todoAlarmRepository.findByTodoId(instanceId)
+                .ifPresent(alarm -> alarm.reassignTo(saved));
     }
 
     /** Master 종료(endDate=T-1) + T+1 이후 soft delete + 선택 인스턴스(T) 일반 Todo 전환 */

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceInstanceService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceInstanceService.java
@@ -2,10 +2,8 @@ package basakan.fryday.service.todo;
 
 import basakan.fryday.common.ErrorCode;
 import basakan.fryday.common.exception.BusinessException;
-import basakan.fryday.controller.todo.request.CancelRecurrenceRequest.CancelScope;
-import basakan.fryday.controller.todo.request.InstanceDeleteRequest.DeleteScope;
-import basakan.fryday.controller.todo.request.InstanceEditRequest.EditScope;
 import basakan.fryday.controller.todo.request.InstanceEditRequest.Payload;
+import basakan.fryday.domain.todo.RecurrenceScope;
 import basakan.fryday.domain.category.Category;
 import basakan.fryday.domain.todo.EndType;
 import basakan.fryday.domain.todo.Recurrence;
@@ -37,7 +35,7 @@ public class RecurrenceInstanceService {
     private final RecurrenceOccurrenceCalculator occurrenceCalculator;
 
     @Transactional
-    public void edit(long instanceId, EditScope scope, Payload payload, long userId) {
+    public void edit(long instanceId, RecurrenceScope scope, Payload payload, long userId) {
         switch (scope) {
             case THIS -> editThis(instanceId, payload, userId);
             case THIS_AND_FUTURE -> editThisAndFuture(instanceId, payload, userId);
@@ -46,7 +44,7 @@ public class RecurrenceInstanceService {
     }
 
     @Transactional
-    public void delete(long instanceId, DeleteScope scope, long userId) {
+    public void delete(long instanceId, RecurrenceScope scope, long userId) {
         switch (scope) {
             case THIS -> deleteThis(instanceId, userId);
             case THIS_AND_FUTURE -> deleteThisAndFuture(instanceId, userId);
@@ -55,7 +53,7 @@ public class RecurrenceInstanceService {
     }
 
     @Transactional
-    public void cancelRecurrence(long instanceId, CancelScope scope, long userId) {
+    public void cancelRecurrence(long instanceId, RecurrenceScope scope, long userId) {
         switch (scope) {
             case THIS -> cancelThis(instanceId, userId);
             case THIS_AND_FUTURE -> cancelThisAndFuture(instanceId, userId);

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceInstanceService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceInstanceService.java
@@ -246,8 +246,12 @@ public class RecurrenceInstanceService {
         }
 
         master.terminateAt(T);
+        // clearAutomatically = true로 영속성 컨텍스트가 초기화되므로 이후 재조회
         todoRepository.bulkSoftDeleteByRecurrenceIdAndDateGte(master.getId(), T.plusDays(1), LocalDate.now());
-        instance.detachFromRecurrence();
+
+        todoRepository.findById(instanceId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND))
+                .detachFromRecurrence();
     }
 
     /** 선택 인스턴스 일반 Todo 전환 + 나머지 전체 soft delete + Master 물리 삭제 */

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceInstanceService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceInstanceService.java
@@ -2,6 +2,7 @@ package basakan.fryday.service.todo;
 
 import basakan.fryday.common.ErrorCode;
 import basakan.fryday.common.exception.BusinessException;
+import basakan.fryday.controller.todo.request.CancelRecurrenceRequest.CancelScope;
 import basakan.fryday.controller.todo.request.InstanceDeleteRequest.DeleteScope;
 import basakan.fryday.controller.todo.request.InstanceEditRequest.EditScope;
 import basakan.fryday.controller.todo.request.InstanceEditRequest.Payload;
@@ -50,6 +51,15 @@ public class RecurrenceInstanceService {
             case THIS -> deleteThis(instanceId, userId);
             case THIS_AND_FUTURE -> deleteThisAndFuture(instanceId, userId);
             case ALL -> deleteAll(instanceId, userId);
+        }
+    }
+
+    @Transactional
+    public void cancelRecurrence(long instanceId, CancelScope scope, long userId) {
+        switch (scope) {
+            case THIS -> cancelThis(instanceId, userId);
+            case THIS_AND_FUTURE -> cancelThisAndFuture(instanceId, userId);
+            case ALL -> cancelAll(instanceId, userId);
         }
     }
 
@@ -192,6 +202,53 @@ public class RecurrenceInstanceService {
 
         master.markDeleted();
         todoRepository.bulkSoftDeleteByRecurrenceId(master.getId(), LocalDate.now());
+    }
+
+    // ── Cancel ─────────────────────────────────────────────────────────────────
+
+    /** 해당 인스턴스만 일반 Todo로 전환, 나머지 반복 유지 */
+    private void cancelThis(long instanceId, long userId) {
+        Todo instance = findActiveInstance(instanceId, userId);
+        instance.detachFromRecurrence();
+    }
+
+    /** Master 종료(endDate=T-1) + T+1 이후 soft delete + 선택 인스턴스(T) 일반 Todo 전환 */
+    private void cancelThisAndFuture(long instanceId, long userId) {
+        Todo instance = findActiveInstance(instanceId, userId);
+        LocalDate T = instance.getDate();
+
+        Recurrence master = findMaster(instance);
+        if (master.getUserId() != userId) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
+
+        master.terminateAt(T);
+        todoRepository.bulkSoftDeleteByRecurrenceIdAndDateGte(master.getId(), T.plusDays(1), LocalDate.now());
+        instance.detachFromRecurrence();
+    }
+
+    /** 선택 인스턴스 일반 Todo 전환 + 나머지 전체 soft delete + Master 물리 삭제 */
+    private void cancelAll(long instanceId, long userId) {
+        Todo instance = findActiveInstance(instanceId, userId);
+        Long recurrenceId = instance.getRecurrenceId();
+
+        Recurrence recurrence = recurrenceRepository.findById(recurrenceId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        if (recurrence.getUserId() != userId) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
+
+        List<Todo> todos = todoRepository.findAllByRecurrenceId(recurrenceId);
+        for (Todo todo : todos) {
+            if (todo.getId().equals(instance.getId())) {
+                todo.detachFromRecurrence();
+            } else {
+                todo.delete();
+            }
+        }
+
+        recurrenceRepository.delete(recurrence);
     }
 
     // ── generateInstances ──────────────────────────────────────────────────────

--- a/src/test/java/basakan/fryday/controller/todo/RecurrenceInstanceControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/todo/RecurrenceInstanceControllerTest.java
@@ -4,6 +4,7 @@ import basakan.fryday.RestDocsSupport;
 import basakan.fryday.common.config.SecurityConfig;
 import basakan.fryday.common.security.JwtAuthenticationFilter;
 import basakan.fryday.common.security.JwtTokenProvider;
+import basakan.fryday.controller.todo.request.CancelRecurrenceRequest;
 import basakan.fryday.controller.todo.request.InstanceDeleteRequest;
 import basakan.fryday.controller.todo.request.InstanceEditRequest;
 import basakan.fryday.service.todo.RecurrenceInstanceService;
@@ -310,5 +311,109 @@ class RecurrenceInstanceControllerTest extends RestDocsSupport {
                                 fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
                         )
                 ));
+    }
+
+    @Test
+    @DisplayName("반복 해제 - 이번만 (THIS)")
+    void cancelRecurrence_this() throws Exception {
+        long instanceId = 1L;
+        willDoNothing().given(recurrenceInstanceService)
+                .cancelRecurrence(anyLong(), any(CancelRecurrenceRequest.CancelScope.class), anyLong());
+
+        Map<String, Object> request = Map.of("scope", "THIS");
+
+        mockMvc.perform(patch("/api/todos/instances/{instanceId}/cancel-recurrence", instanceId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("instance-cancel-recurrence-this",
+                        pathParameters(
+                                parameterWithName("instanceId").description("반복 해제할 인스턴스(투두) ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("scope").type(JsonFieldType.STRING)
+                                        .description("해제 범위: THIS(이번만) / THIS_AND_FUTURE(이번 이후 전체) / ALL(전체)")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("반복 해제 - 이번 이후 전체 (THIS_AND_FUTURE)")
+    void cancelRecurrence_thisAndFuture() throws Exception {
+        long instanceId = 1L;
+        willDoNothing().given(recurrenceInstanceService)
+                .cancelRecurrence(anyLong(), any(CancelRecurrenceRequest.CancelScope.class), anyLong());
+
+        Map<String, Object> request = Map.of("scope", "THIS_AND_FUTURE");
+
+        mockMvc.perform(patch("/api/todos/instances/{instanceId}/cancel-recurrence", instanceId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("instance-cancel-recurrence-this-and-future",
+                        pathParameters(
+                                parameterWithName("instanceId").description("반복 해제할 인스턴스(투두) ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("scope").type(JsonFieldType.STRING)
+                                        .description("해제 범위: THIS_AND_FUTURE — 이 날짜부터 이후 인스턴스 삭제, 선택 Todo는 일반 Todo로 전환")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("반복 해제 - 전체 (ALL)")
+    void cancelRecurrence_all() throws Exception {
+        long instanceId = 1L;
+        willDoNothing().given(recurrenceInstanceService)
+                .cancelRecurrence(anyLong(), any(CancelRecurrenceRequest.CancelScope.class), anyLong());
+
+        Map<String, Object> request = Map.of("scope", "ALL");
+
+        mockMvc.perform(patch("/api/todos/instances/{instanceId}/cancel-recurrence", instanceId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("instance-cancel-recurrence-all",
+                        pathParameters(
+                                parameterWithName("instanceId").description("반복 해제할 인스턴스(투두) ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("scope").type(JsonFieldType.STRING)
+                                        .description("해제 범위: ALL — 선택 Todo는 일반 Todo로 전환, 나머지 전체 삭제 및 반복 규칙 삭제")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("반복 해제 실패 - scope 누락")
+    void cancelRecurrence_scopeMissing() throws Exception {
+        long instanceId = 1L;
+
+        Map<String, Object> request = Map.of();
+
+        mockMvc.perform(patch("/api/todos/instances/{instanceId}/cancel-recurrence", instanceId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/basakan/fryday/controller/todo/RecurrenceInstanceControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/todo/RecurrenceInstanceControllerTest.java
@@ -7,6 +7,7 @@ import basakan.fryday.common.security.JwtTokenProvider;
 import basakan.fryday.controller.todo.request.CancelRecurrenceRequest;
 import basakan.fryday.controller.todo.request.InstanceDeleteRequest;
 import basakan.fryday.controller.todo.request.InstanceEditRequest;
+import basakan.fryday.domain.todo.RecurrenceScope;
 import basakan.fryday.service.todo.RecurrenceInstanceService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -318,7 +319,7 @@ class RecurrenceInstanceControllerTest extends RestDocsSupport {
     void cancelRecurrence_this() throws Exception {
         long instanceId = 1L;
         willDoNothing().given(recurrenceInstanceService)
-                .cancelRecurrence(anyLong(), any(CancelRecurrenceRequest.CancelScope.class), anyLong());
+                .cancelRecurrence(anyLong(), any(RecurrenceScope.class), anyLong());
 
         Map<String, Object> request = Map.of("scope", "THIS");
 
@@ -348,7 +349,7 @@ class RecurrenceInstanceControllerTest extends RestDocsSupport {
     void cancelRecurrence_thisAndFuture() throws Exception {
         long instanceId = 1L;
         willDoNothing().given(recurrenceInstanceService)
-                .cancelRecurrence(anyLong(), any(CancelRecurrenceRequest.CancelScope.class), anyLong());
+                .cancelRecurrence(anyLong(), any(RecurrenceScope.class), anyLong());
 
         Map<String, Object> request = Map.of("scope", "THIS_AND_FUTURE");
 
@@ -378,7 +379,7 @@ class RecurrenceInstanceControllerTest extends RestDocsSupport {
     void cancelRecurrence_all() throws Exception {
         long instanceId = 1L;
         willDoNothing().given(recurrenceInstanceService)
-                .cancelRecurrence(anyLong(), any(CancelRecurrenceRequest.CancelScope.class), anyLong());
+                .cancelRecurrence(anyLong(), any(RecurrenceScope.class), anyLong());
 
         Map<String, Object> request = Map.of("scope", "ALL");
 

--- a/src/test/java/basakan/fryday/service/todo/RecurrenceInstanceServiceTest.java
+++ b/src/test/java/basakan/fryday/service/todo/RecurrenceInstanceServiceTest.java
@@ -2,7 +2,7 @@ package basakan.fryday.service.todo;
 
 import basakan.fryday.common.ErrorCode;
 import basakan.fryday.common.exception.BusinessException;
-import basakan.fryday.controller.todo.request.CancelRecurrenceRequest.CancelScope;
+import basakan.fryday.domain.todo.RecurrenceScope;
 import basakan.fryday.domain.category.Category;
 import basakan.fryday.domain.category.CategoryColor;
 import basakan.fryday.domain.todo.EndType;
@@ -95,7 +95,7 @@ class RecurrenceInstanceServiceTest {
         void recurrenceId_null로_변경() {
             given(todoRepository.findById(INSTANCE_ID)).willReturn(Optional.of(instance));
 
-            service.cancelRecurrence(INSTANCE_ID, CancelScope.THIS, USER_ID);
+            service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.THIS, USER_ID);
 
             assertThat(instance.getRecurrenceId()).isNull();
         }
@@ -106,7 +106,7 @@ class RecurrenceInstanceServiceTest {
             instance.applyOverride("오버라이드 제목", "오버라이드 메모", null, null);
             given(todoRepository.findById(INSTANCE_ID)).willReturn(Optional.of(instance));
 
-            service.cancelRecurrence(INSTANCE_ID, CancelScope.THIS, USER_ID);
+            service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.THIS, USER_ID);
 
             assertThat(instance.getDescription()).isEqualTo("오버라이드 제목");
             assertThat(instance.getMemo()).isEqualTo("오버라이드 메모");
@@ -118,7 +118,7 @@ class RecurrenceInstanceServiceTest {
             instance.applyOverride("오버라이드 제목", "오버라이드 메모", true, null);
             given(todoRepository.findById(INSTANCE_ID)).willReturn(Optional.of(instance));
 
-            service.cancelRecurrence(INSTANCE_ID, CancelScope.THIS, USER_ID);
+            service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.THIS, USER_ID);
 
             assertThat(instance.getOverrideTitle()).isNull();
             assertThat(instance.getOverrideMemo()).isNull();
@@ -135,7 +135,7 @@ class RecurrenceInstanceServiceTest {
             ReflectionTestUtils.setField(nonRecurring, "id", INSTANCE_ID);
             given(todoRepository.findById(INSTANCE_ID)).willReturn(Optional.of(nonRecurring));
 
-            assertThatThrownBy(() -> service.cancelRecurrence(INSTANCE_ID, CancelScope.THIS, USER_ID))
+            assertThatThrownBy(() -> service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.THIS, USER_ID))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_RECURRING_TODO);
         }
@@ -158,7 +158,7 @@ class RecurrenceInstanceServiceTest {
         void master_endDate_T_마이너스_1() {
             LocalDate T = instance.getDate(); // 2026-05-10
 
-            service.cancelRecurrence(INSTANCE_ID, CancelScope.THIS_AND_FUTURE, USER_ID);
+            service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.THIS_AND_FUTURE, USER_ID);
 
             assertThat(master.getEndDate()).isEqualTo(T.minusDays(1)); // 2026-05-09
             assertThat(master.getEndType()).isEqualTo(EndType.UNTIL);
@@ -169,7 +169,7 @@ class RecurrenceInstanceServiceTest {
         void T_이후_인스턴스_soft_delete() {
             LocalDate T = instance.getDate();
 
-            service.cancelRecurrence(INSTANCE_ID, CancelScope.THIS_AND_FUTURE, USER_ID);
+            service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.THIS_AND_FUTURE, USER_ID);
 
             then(todoRepository).should()
                     .bulkSoftDeleteByRecurrenceIdAndDateGte(eq(RECURRENCE_ID), eq(T.plusDays(1)), any());
@@ -178,7 +178,7 @@ class RecurrenceInstanceServiceTest {
         @Test
         @DisplayName("선택 Todo(T일)는 일반 Todo로 전환된다")
         void 선택_Todo_일반_전환() {
-            service.cancelRecurrence(INSTANCE_ID, CancelScope.THIS_AND_FUTURE, USER_ID);
+            service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.THIS_AND_FUTURE, USER_ID);
 
             assertThat(instance.getRecurrenceId()).isNull();
         }
@@ -188,7 +188,7 @@ class RecurrenceInstanceServiceTest {
         void T_이전_인스턴스_유지() {
             LocalDate T = instance.getDate();
 
-            service.cancelRecurrence(INSTANCE_ID, CancelScope.THIS_AND_FUTURE, USER_ID);
+            service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.THIS_AND_FUTURE, USER_ID);
 
             // T+1 이후만 삭제 → T-1 이전은 삭제되지 않음을 인자로 검증
             then(todoRepository).should()
@@ -201,7 +201,7 @@ class RecurrenceInstanceServiceTest {
             LocalDate T = instance.getDate();
             ReflectionTestUtils.setField(master, "startDate", T);
 
-            service.cancelRecurrence(INSTANCE_ID, CancelScope.THIS_AND_FUTURE, USER_ID);
+            service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.THIS_AND_FUTURE, USER_ID);
 
             // endDate = T-1 < startDate = T 이지만 예외 없이 실행됨
             assertThat(master.getEndDate()).isEqualTo(T.minusDays(1));
@@ -240,7 +240,7 @@ class RecurrenceInstanceServiceTest {
         @Test
         @DisplayName("선택 Todo의 recurrenceId가 null로 변경된다")
         void 선택_Todo_recurrenceId_null() {
-            service.cancelRecurrence(INSTANCE_ID, CancelScope.ALL, USER_ID);
+            service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.ALL, USER_ID);
 
             assertThat(instance.getRecurrenceId()).isNull();
         }
@@ -248,7 +248,7 @@ class RecurrenceInstanceServiceTest {
         @Test
         @DisplayName("선택 Todo는 soft delete되지 않는다")
         void 선택_Todo_soft_delete_안됨() {
-            service.cancelRecurrence(INSTANCE_ID, CancelScope.ALL, USER_ID);
+            service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.ALL, USER_ID);
 
             assertThat(instance.isDeleted()).isFalse();
         }
@@ -256,7 +256,7 @@ class RecurrenceInstanceServiceTest {
         @Test
         @DisplayName("나머지 모든 인스턴스가 soft delete된다")
         void 나머지_인스턴스_soft_delete() {
-            service.cancelRecurrence(INSTANCE_ID, CancelScope.ALL, USER_ID);
+            service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.ALL, USER_ID);
 
             assertThat(other1.isDeleted()).isTrue();
             assertThat(other2.isDeleted()).isTrue();
@@ -265,7 +265,7 @@ class RecurrenceInstanceServiceTest {
         @Test
         @DisplayName("Master(Recurrence)가 삭제된다")
         void Master_삭제() {
-            service.cancelRecurrence(INSTANCE_ID, CancelScope.ALL, USER_ID);
+            service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.ALL, USER_ID);
 
             then(recurrenceRepository).should().delete(master);
         }

--- a/src/test/java/basakan/fryday/service/todo/RecurrenceInstanceServiceTest.java
+++ b/src/test/java/basakan/fryday/service/todo/RecurrenceInstanceServiceTest.java
@@ -239,11 +239,23 @@ class RecurrenceInstanceServiceTest {
         }
 
         @Test
-        @DisplayName("선택 Todo(T일)는 일반 Todo로 전환된다")
+        @DisplayName("선택 Todo(T일)는 벌크 삭제 후 재조회한 인스턴스에 detach가 적용된다")
         void 선택_Todo_일반_전환() {
+            // clearAutomatically = true 이후 재조회를 시뮬레이션하기 위해
+            // 두 번째 findById 호출에서 별도 객체 반환
+            Todo reloaded = Todo.builder()
+                    .description("마스터 제목").category(category)
+                    .date(LocalDate.of(2026, 5, 10)).displayOrder(1L)
+                    .recurrenceId(RECURRENCE_ID).build();
+            ReflectionTestUtils.setField(reloaded, "id", INSTANCE_ID);
+            given(todoRepository.findById(INSTANCE_ID))
+                    .willReturn(Optional.of(instance))   // findActiveInstance
+                    .willReturn(Optional.of(reloaded));  // 벌크 삭제 후 재조회
+
             service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.THIS_AND_FUTURE, USER_ID);
 
-            assertThat(instance.getRecurrenceId()).isNull();
+            assertThat(reloaded.getRecurrenceId()).isNull();  // 재조회한 인스턴스에 detach 적용
+            assertThat(instance.getRecurrenceId()).isEqualTo(RECURRENCE_ID);  // 원본은 변경 없음
         }
 
         @Test

--- a/src/test/java/basakan/fryday/service/todo/RecurrenceInstanceServiceTest.java
+++ b/src/test/java/basakan/fryday/service/todo/RecurrenceInstanceServiceTest.java
@@ -1,0 +1,273 @@
+package basakan.fryday.service.todo;
+
+import basakan.fryday.common.ErrorCode;
+import basakan.fryday.common.exception.BusinessException;
+import basakan.fryday.controller.todo.request.CancelRecurrenceRequest.CancelScope;
+import basakan.fryday.domain.category.Category;
+import basakan.fryday.domain.category.CategoryColor;
+import basakan.fryday.domain.todo.EndType;
+import basakan.fryday.domain.todo.Recurrence;
+import basakan.fryday.domain.todo.RecurrenceType;
+import basakan.fryday.domain.todo.Todo;
+import basakan.fryday.repository.CategoryRepository;
+import basakan.fryday.repository.todo.RecurrenceRepository;
+import basakan.fryday.repository.todo.TodoAlarmRepository;
+import basakan.fryday.repository.todo.TodoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RecurrenceInstanceService - cancelRecurrence")
+class RecurrenceInstanceServiceTest {
+
+    @Mock private TodoRepository todoRepository;
+    @Mock private RecurrenceRepository recurrenceRepository;
+    @Mock private CategoryRepository categoryRepository;
+    @Mock private TodoAlarmRepository todoAlarmRepository;
+    @Mock private RecurrenceOccurrenceCalculator occurrenceCalculator;
+
+    @InjectMocks
+    private RecurrenceInstanceService service;
+
+    private static final long USER_ID = 1L;
+    private static final long OTHER_USER_ID = 2L;
+    private static final long RECURRENCE_ID = 10L;
+    private static final long INSTANCE_ID = 100L;
+
+    private Category category;
+    private Recurrence master;
+    private Todo instance;
+
+    @BeforeEach
+    void setUp() {
+        category = Category.builder()
+                .name("업무").color(CategoryColor.BR).userId(USER_ID).build();
+        ReflectionTestUtils.setField(category, "id", 1L);
+
+        master = Recurrence.builder()
+                .userId(USER_ID)
+                .categoryId(1L)
+                .description("마스터 제목")
+                .type(RecurrenceType.DAILY)
+                .startDate(LocalDate.of(2026, 1, 1))
+                .endDate(LocalDate.of(2026, 12, 31))
+                .endType(EndType.UNTIL)
+                .lastGeneratedDate(LocalDate.of(2026, 1, 1))
+                .build();
+        ReflectionTestUtils.setField(master, "id", RECURRENCE_ID);
+
+        instance = Todo.builder()
+                .description("마스터 제목")
+                .category(category)
+                .date(LocalDate.of(2026, 5, 10))
+                .displayOrder(1L)
+                .recurrenceId(RECURRENCE_ID)
+                .build();
+        ReflectionTestUtils.setField(instance, "id", INSTANCE_ID);
+    }
+
+    // ── cancelThis ────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("cancelThis")
+    class CancelThis {
+
+        @Test
+        @DisplayName("선택 Todo의 recurrenceId가 null로 변경된다")
+        void recurrenceId_null로_변경() {
+            given(todoRepository.findById(INSTANCE_ID)).willReturn(Optional.of(instance));
+
+            service.cancelRecurrence(INSTANCE_ID, CancelScope.THIS, USER_ID);
+
+            assertThat(instance.getRecurrenceId()).isNull();
+        }
+
+        @Test
+        @DisplayName("override 값이 있으면 base 필드에 이관된다")
+        void override_base_필드_이관() {
+            instance.applyOverride("오버라이드 제목", "오버라이드 메모", null, null);
+            given(todoRepository.findById(INSTANCE_ID)).willReturn(Optional.of(instance));
+
+            service.cancelRecurrence(INSTANCE_ID, CancelScope.THIS, USER_ID);
+
+            assertThat(instance.getDescription()).isEqualTo("오버라이드 제목");
+            assertThat(instance.getMemo()).isEqualTo("오버라이드 메모");
+        }
+
+        @Test
+        @DisplayName("override 필드가 null로 정리된다")
+        void override_필드_null_정리() {
+            instance.applyOverride("오버라이드 제목", "오버라이드 메모", true, null);
+            given(todoRepository.findById(INSTANCE_ID)).willReturn(Optional.of(instance));
+
+            service.cancelRecurrence(INSTANCE_ID, CancelScope.THIS, USER_ID);
+
+            assertThat(instance.getOverrideTitle()).isNull();
+            assertThat(instance.getOverrideMemo()).isNull();
+            assertThat(instance.getOverrideIsAlarm()).isNull();
+            assertThat(instance.isOverridden()).isFalse();
+        }
+
+        @Test
+        @DisplayName("반복 투두가 아니면 NOT_RECURRING_TODO 예외")
+        void 비반복_투두_예외() {
+            Todo nonRecurring = Todo.builder()
+                    .description("일반 투두").category(category)
+                    .date(LocalDate.now()).displayOrder(1L).build();
+            ReflectionTestUtils.setField(nonRecurring, "id", INSTANCE_ID);
+            given(todoRepository.findById(INSTANCE_ID)).willReturn(Optional.of(nonRecurring));
+
+            assertThatThrownBy(() -> service.cancelRecurrence(INSTANCE_ID, CancelScope.THIS, USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_RECURRING_TODO);
+        }
+    }
+
+    // ── cancelThisAndFuture ───────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("cancelThisAndFuture")
+    class CancelThisAndFuture {
+
+        @BeforeEach
+        void setUpMocks() {
+            given(todoRepository.findById(INSTANCE_ID)).willReturn(Optional.of(instance));
+            given(recurrenceRepository.findById(RECURRENCE_ID)).willReturn(Optional.of(master));
+        }
+
+        @Test
+        @DisplayName("Master의 endDate가 T-1일로 수정된다")
+        void master_endDate_T_마이너스_1() {
+            LocalDate T = instance.getDate(); // 2026-05-10
+
+            service.cancelRecurrence(INSTANCE_ID, CancelScope.THIS_AND_FUTURE, USER_ID);
+
+            assertThat(master.getEndDate()).isEqualTo(T.minusDays(1)); // 2026-05-09
+            assertThat(master.getEndType()).isEqualTo(EndType.UNTIL);
+        }
+
+        @Test
+        @DisplayName("T+1일 이후 인스턴스가 soft delete된다")
+        void T_이후_인스턴스_soft_delete() {
+            LocalDate T = instance.getDate();
+
+            service.cancelRecurrence(INSTANCE_ID, CancelScope.THIS_AND_FUTURE, USER_ID);
+
+            then(todoRepository).should()
+                    .bulkSoftDeleteByRecurrenceIdAndDateGte(eq(RECURRENCE_ID), eq(T.plusDays(1)), any());
+        }
+
+        @Test
+        @DisplayName("선택 Todo(T일)는 일반 Todo로 전환된다")
+        void 선택_Todo_일반_전환() {
+            service.cancelRecurrence(INSTANCE_ID, CancelScope.THIS_AND_FUTURE, USER_ID);
+
+            assertThat(instance.getRecurrenceId()).isNull();
+        }
+
+        @Test
+        @DisplayName("T-1일 이전 인스턴스는 유지된다 (bulkSoftDelete 호출 범위가 T+1부터)")
+        void T_이전_인스턴스_유지() {
+            LocalDate T = instance.getDate();
+
+            service.cancelRecurrence(INSTANCE_ID, CancelScope.THIS_AND_FUTURE, USER_ID);
+
+            // T+1 이후만 삭제 → T-1 이전은 삭제되지 않음을 인자로 검증
+            then(todoRepository).should()
+                    .bulkSoftDeleteByRecurrenceIdAndDateGte(eq(RECURRENCE_ID), eq(T.plusDays(1)), any());
+        }
+
+        @Test
+        @DisplayName("master.startDate == T인 엣지케이스: terminateAt만 실행, 오류 없음")
+        void startDate_equals_T_엣지케이스() {
+            LocalDate T = instance.getDate();
+            ReflectionTestUtils.setField(master, "startDate", T);
+
+            service.cancelRecurrence(INSTANCE_ID, CancelScope.THIS_AND_FUTURE, USER_ID);
+
+            // endDate = T-1 < startDate = T 이지만 예외 없이 실행됨
+            assertThat(master.getEndDate()).isEqualTo(T.minusDays(1));
+        }
+    }
+
+    // ── cancelAll ─────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("cancelAll")
+    class CancelAll {
+
+        private Todo other1;
+        private Todo other2;
+
+        @BeforeEach
+        void setUpOthers() {
+            other1 = Todo.builder()
+                    .description("마스터 제목").category(category)
+                    .date(LocalDate.of(2026, 5, 11)).displayOrder(1L)
+                    .recurrenceId(RECURRENCE_ID).build();
+            ReflectionTestUtils.setField(other1, "id", 101L);
+
+            other2 = Todo.builder()
+                    .description("마스터 제목").category(category)
+                    .date(LocalDate.of(2026, 5, 12)).displayOrder(1L)
+                    .recurrenceId(RECURRENCE_ID).build();
+            ReflectionTestUtils.setField(other2, "id", 102L);
+
+            given(todoRepository.findById(INSTANCE_ID)).willReturn(Optional.of(instance));
+            given(recurrenceRepository.findById(RECURRENCE_ID)).willReturn(Optional.of(master));
+            given(todoRepository.findAllByRecurrenceId(RECURRENCE_ID))
+                    .willReturn(List.of(instance, other1, other2));
+        }
+
+        @Test
+        @DisplayName("선택 Todo의 recurrenceId가 null로 변경된다")
+        void 선택_Todo_recurrenceId_null() {
+            service.cancelRecurrence(INSTANCE_ID, CancelScope.ALL, USER_ID);
+
+            assertThat(instance.getRecurrenceId()).isNull();
+        }
+
+        @Test
+        @DisplayName("선택 Todo는 soft delete되지 않는다")
+        void 선택_Todo_soft_delete_안됨() {
+            service.cancelRecurrence(INSTANCE_ID, CancelScope.ALL, USER_ID);
+
+            assertThat(instance.isDeleted()).isFalse();
+        }
+
+        @Test
+        @DisplayName("나머지 모든 인스턴스가 soft delete된다")
+        void 나머지_인스턴스_soft_delete() {
+            service.cancelRecurrence(INSTANCE_ID, CancelScope.ALL, USER_ID);
+
+            assertThat(other1.isDeleted()).isTrue();
+            assertThat(other2.isDeleted()).isTrue();
+        }
+
+        @Test
+        @DisplayName("Master(Recurrence)가 삭제된다")
+        void Master_삭제() {
+            service.cancelRecurrence(INSTANCE_ID, CancelScope.ALL, USER_ID);
+
+            then(recurrenceRepository).should().delete(master);
+        }
+    }
+}

--- a/src/test/java/basakan/fryday/service/todo/RecurrenceInstanceServiceTest.java
+++ b/src/test/java/basakan/fryday/service/todo/RecurrenceInstanceServiceTest.java
@@ -9,6 +9,7 @@ import basakan.fryday.domain.todo.EndType;
 import basakan.fryday.domain.todo.Recurrence;
 import basakan.fryday.domain.todo.RecurrenceType;
 import basakan.fryday.domain.todo.Todo;
+import basakan.fryday.domain.todo.TodoAlarm;
 import basakan.fryday.repository.CategoryRepository;
 import basakan.fryday.repository.todo.RecurrenceRepository;
 import basakan.fryday.repository.todo.TodoAlarmRepository;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -33,6 +35,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("RecurrenceInstanceService - cancelRecurrence")
@@ -90,40 +94,99 @@ class RecurrenceInstanceServiceTest {
     @DisplayName("cancelThis")
     class CancelThis {
 
-        @Test
-        @DisplayName("선택 Todo의 recurrenceId가 null로 변경된다")
-        void recurrenceId_null로_변경() {
+        @BeforeEach
+        void setUpMock() {
             given(todoRepository.findById(INSTANCE_ID)).willReturn(Optional.of(instance));
-
-            service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.THIS, USER_ID);
-
-            assertThat(instance.getRecurrenceId()).isNull();
+            lenient().when(todoRepository.save(any(Todo.class))).thenAnswer(inv -> inv.getArgument(0));
         }
 
         @Test
-        @DisplayName("override 값이 있으면 base 필드에 이관된다")
-        void override_base_필드_이관() {
+        @DisplayName("원본 인스턴스는 recurrenceId를 유지한 채 soft delete된다 (materializer 재생성 방지)")
+        void 원본_인스턴스_soft_delete_recurrenceId_유지() {
+            service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.THIS, USER_ID);
+
+            assertThat(instance.isDeleted()).isTrue();
+            assertThat(instance.getRecurrenceId()).isEqualTo(RECURRENCE_ID);
+        }
+
+        @Test
+        @DisplayName("새 독립 Todo가 recurrenceId null로 저장된다")
+        void 새_독립_Todo_저장() {
+            ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
+
+            service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.THIS, USER_ID);
+
+            then(todoRepository).should().save(captor.capture());
+            assertThat(captor.getValue().getRecurrenceId()).isNull();
+        }
+
+        @Test
+        @DisplayName("override 값이 있으면 새 Todo의 description/memo에 반영된다")
+        void override_새_Todo에_반영() {
             instance.applyOverride("오버라이드 제목", "오버라이드 메모", null, null);
-            given(todoRepository.findById(INSTANCE_ID)).willReturn(Optional.of(instance));
+            ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
 
             service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.THIS, USER_ID);
 
-            assertThat(instance.getDescription()).isEqualTo("오버라이드 제목");
-            assertThat(instance.getMemo()).isEqualTo("오버라이드 메모");
+            then(todoRepository).should().save(captor.capture());
+            assertThat(captor.getValue().getDescription()).isEqualTo("오버라이드 제목");
+            assertThat(captor.getValue().getMemo()).isEqualTo("오버라이드 메모");
         }
 
         @Test
-        @DisplayName("override 필드가 null로 정리된다")
-        void override_필드_null_정리() {
-            instance.applyOverride("오버라이드 제목", "오버라이드 메모", true, null);
-            given(todoRepository.findById(INSTANCE_ID)).willReturn(Optional.of(instance));
+        @DisplayName("override 없으면 base memo가 새 Todo에 그대로 이관된다")
+        void base_memo_이관() {
+            Todo instanceWithMemo = Todo.builder()
+                    .description("마스터 제목")
+                    .category(category)
+                    .date(LocalDate.of(2026, 5, 10))
+                    .displayOrder(1L)
+                    .recurrenceId(RECURRENCE_ID)
+                    .memo("기본 메모")
+                    .build();
+            ReflectionTestUtils.setField(instanceWithMemo, "id", INSTANCE_ID);
+            given(todoRepository.findById(INSTANCE_ID)).willReturn(Optional.of(instanceWithMemo));
+            ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
 
             service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.THIS, USER_ID);
 
-            assertThat(instance.getOverrideTitle()).isNull();
-            assertThat(instance.getOverrideMemo()).isNull();
-            assertThat(instance.getOverrideIsAlarm()).isNull();
-            assertThat(instance.isOverridden()).isFalse();
+            then(todoRepository).should().save(captor.capture());
+            assertThat(captor.getValue().getMemo()).isEqualTo("기본 메모");
+        }
+
+        @Test
+        @DisplayName("완료 상태가 새 Todo에 유지된다")
+        void 완료_상태_유지() {
+            instance.toggleCompletion();
+            ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
+
+            service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.THIS, USER_ID);
+
+            then(todoRepository).should().save(captor.capture());
+            assertThat(captor.getValue().isCompleted()).isTrue();
+        }
+
+        @Test
+        @DisplayName("알람이 있으면 새 독립 Todo로 이관된다")
+        void 알람_이관() {
+            TodoAlarm alarm = mock(TodoAlarm.class);
+            given(todoAlarmRepository.findByTodoId(INSTANCE_ID)).willReturn(Optional.of(alarm));
+            ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
+
+            service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.THIS, USER_ID);
+
+            then(todoRepository).should().save(captor.capture());
+            then(alarm).should().reassignTo(captor.getValue());
+        }
+
+        @Test
+        @DisplayName("알람이 없으면 이관 없이 정상 완료된다")
+        void 알람_없으면_정상_완료() {
+            given(todoAlarmRepository.findByTodoId(INSTANCE_ID)).willReturn(Optional.empty());
+
+            service.cancelRecurrence(INSTANCE_ID, RecurrenceScope.THIS, USER_ID);
+
+            then(todoAlarmRepository).shouldHaveNoMoreInteractions();
         }
 
         @Test


### PR DESCRIPTION
## 📌 Related Issue
- close: #107 

## 🚀 Description

## 개요

  반복 투두를 **삭제하지 않고 일반 투두로 전환**하는 반복 해제 기능을 구현합니다.

  기존 `DELETE /api/todos/{todoId}/recurrence`는 ALL 범위만 지원했지만, 이번 API는 THIS / THIS_AND_FUTURE / ALL 세 가지 범위를 지원합니다.

  ## 변경 사항

  ### 신규 엔드포인트
  PATCH /api/todos/instances/{instanceId}/cancel-recurrence

  | scope | 사용자 관점 동작 |
  |---|---|
  | `THIS` | 선택한 날짜의 투두만 반복에서 분리되어 일반 투두로 유지됩니다. 이전/이후 날짜의 반복 투두는 그대로 유지됩니다. |
  | `THIS_AND_FUTURE` | 선택한 날짜의 투두는 일반 투두로 전환되고, 그 이후 날짜의 반복 투두는 모두 삭제됩니다. 이전 날짜의 반복 투두는 그대로 유지됩니다. |
  | `ALL` | 선택한 날짜의 투두만 일반 투두로 전환되고, 나머지 모든 날짜의 반복 투두와 반복 규칙이 삭제됩니다. |

  ### 주요 구현

  - **`Todo.detachFromRecurrence()`** — override 값을 base 필드에 이관 후 반복 연결 해제. THIS_AND_FUTURE / ALL 공통 로직을 엔티티 메서드로 캡슐화
  - **`cancelThis` 구현 방식** — `recurrenceId`를 null로 바꾸는 대신 원본을 soft delete하고 새 독립 Todo를 생성. 묘비가 `existsByRecurrenceIdAndDate` 체크에 걸려 materializer의 인스턴스 재생성을 차단
  - **`TodoAlarm` 이관** — 반복 해제 시 기존 알람을 삭제하지 않고 새 독립 Todo로 재연결(`reassignTo`)
  - **`RecurrenceScope`** — 기존 `EditScope` / `DeleteScope` / `CancelScope`가 동일한 값을 중복 정의하고 있어 공용 enum으로 통합

  ### 버그 수정

  | 버그 | 원인 | 수정 |
  |---|---|---|
  | `cancelThis` 후 재조회 시 투두 2개 노출 | `detachFromRecurrence()`로 `recurrenceId = null`이 되면 materializer가 해당 날짜를 빈 것으로 보고 인스턴스 재생성 | 원본 soft delete로 재생성 차단 |
  | `cancelThisAndFuture` 후 선택 Todo `recurrenceId` 미변경 | `bulkSoftDeleteByRecurrenceIdAndDateGte`의 `clearAutomatically = true`로 영속성 컨텍스트가 초기화돼 이후 `detachFromRecurrence()` 변경이 DB에 미반영 | 벌크 삭제 후 `findById`로 재조회하여 detach 적용 |

## 📢 Notes
