### PR TITLE
#109 fix: IDOR 취약점 해결 및 환경별 JWT Secret 분리

### DIFF
--- a/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
@@ -22,9 +22,9 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     List<Todo> findAllByUserIdAndDate(@Param("userId") Long userId, @Param("date") LocalDate date);
 
     @Query("SELECT t FROM Todo t " +
-            "WHERE t.category.id = :categoryId AND t.date = :date AND t.deletedAt IS NULL " +
+            "WHERE t.category.id = :categoryId AND t.category.userId = :userId AND t.date = :date AND t.deletedAt IS NULL " +
             "ORDER BY t.displayOrder ASC")
-    List<Todo> findAllByCategoryIdAndDate(@Param("categoryId") Long categoryId, @Param("date") LocalDate date);
+    List<Todo> findAllByCategoryIdAndDate(@Param("categoryId") Long categoryId, @Param("userId") Long userId, @Param("date") LocalDate date);
 
     @Query("SELECT DISTINCT c.userId FROM Todo t JOIN t.category c " +
             "WHERE t.date = :date AND t.status = :status AND t.deletedAt IS NULL")

--- a/src/main/java/basakan/fryday/service/todo/TodoService.java
+++ b/src/main/java/basakan/fryday/service/todo/TodoService.java
@@ -261,7 +261,7 @@ public class TodoService {
         if (categoryId == null) {
             todos = todoRepository.findAllByUserIdAndDate(userId, date);
         } else {
-            todos = todoRepository.findAllByCategoryIdAndDate(categoryId, date);
+            todos = todoRepository.findAllByCategoryIdAndDate(categoryId, userId, date);
         }
 
         List<TodoListResponse> allResponses = todos.stream()

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -24,6 +24,9 @@ management:
     tags:
       application: fryday-dev
 
+jwt:
+  secret-key: ${JWT_SECRET_KEY_DEV}
+
 logging:
   file:
     name: /home/ubuntu/logs/dev/application.log

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -29,6 +29,9 @@ management:
     tags:
       application: fryday-prod
 
+jwt:
+  secret-key: ${JWT_SECRET_KEY_PROD}
+
 logging:
   file:
     name: /home/ubuntu/logs/prod/application.log

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,6 @@ spring:
       thread-name-prefix: fryday-scheduler-
 
 jwt:
-  secret-key: ${JWT_SECRET_KEY:your-default-jwt-secret-key}
   access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:3600000}
   refresh-token-expiration: ${JWT_REFRESH_TOKEN_EXPIRATION:1296000000}
 


### PR DESCRIPTION
## 📌 Related Issue
- close: #109 

## 🚀 Description
### Summary
  - `GET /api/todos?categoryId=` 호출 시 `categoryId`만으로 조회해 타 유저 데이터가 노출될 수 있는 IDOR 취약점 수정
  - dev/prod 공용 JWT secret으로 인해 dev 토큰이 prod에서 유효하게 검증되는 문제 수정

  ### 변경 사항

  **IDOR 방어**
  - `findAllByCategoryIdAndDate` 쿼리에 `AND t.category.userId = :userId` 조건 추가
  - `categoryId`를 넘기더라도 본인 소유 카테고리만 조회되도록 보장

  **JWT secret 환경별 분리**
  - `application.yml`의 공통 `JWT_SECRET_KEY` 제거
  - `application-dev.yml` → `JWT_SECRET_KEY_DEV` 참조
  - `application-prod.yml` → `JWT_SECRET_KEY_PROD` 참조
  - 서버 env 파일에 두 값을 다르게 설정하면 dev 토큰이 prod에서 검증 실패

  ### 배포 시 조치 사항
  - 서버 env 파일에 `JWT_SECRET_KEY_DEV` 새로 추가 (prod 키는 기존 `JWT_SECRET_KEY` 값 유지)
  - dev/prod 각각 재시작 필요

## 📢 Notes

