### PR TITLE
FCM 알림 중복 발송 방지 및 발송 안정성 개선

### DIFF
--- a/src/main/java/basakan/fryday/common/service/push/FcmPushService.java
+++ b/src/main/java/basakan/fryday/common/service/push/FcmPushService.java
@@ -3,6 +3,7 @@ package basakan.fryday.common.service.push;
 import basakan.fryday.domain.user.User;
 import basakan.fryday.domain.user.UserDevice;
 import basakan.fryday.repository.auth.UserDeviceRepository;
+import basakan.fryday.service.fcm.UserDeviceWriteService;
 import com.google.firebase.messaging.AndroidConfig;
 import com.google.firebase.messaging.AndroidNotification;
 import com.google.firebase.messaging.ApnsConfig;
@@ -16,10 +17,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -27,6 +29,7 @@ import java.util.List;
 public class FcmPushService implements PushService {
 
     private final UserDeviceRepository userDeviceRepository;
+    private final UserDeviceWriteService userDeviceWriteService;
 
     @Value("${fcm.enabled:false}")
     private boolean fcmEnabled;
@@ -46,9 +49,11 @@ public class FcmPushService implements PushService {
             return;
         }
 
+        Set<String> sentTokens = new HashSet<>();
         for (UserDevice device : devices) {
-            if (device.getFcmToken() != null && !device.getFcmToken().isEmpty()) {
-                sendToTokenInternal(device.getId(), device.getFcmToken(), device.getDeviceId(), title, body);
+            String token = device.getFcmToken();
+            if (token != null && !token.isBlank() && sentTokens.add(token)) {
+                sendToTokenInternal(device.getId(), token, device.getDeviceId(), title, body);
             }
         }
     }
@@ -60,8 +65,8 @@ public class FcmPushService implements PushService {
             return;
         }
 
-        if (fcmToken == null || fcmToken.isEmpty()) {
-            log.warn("FCM token is null or empty. Cannot send notification.");
+        if (fcmToken == null || fcmToken.isBlank()) {
+            log.warn("FCM token is null or blank. Cannot send notification.");
             return;
         }
 
@@ -76,15 +81,17 @@ public class FcmPushService implements PushService {
         }
     }
 
-    private void sendToTokenInternal(Long deviceId, String fcmToken, String deviceIdStr, String title, String body) {
+    private void sendToTokenInternal(Long deviceId, String fcmToken, String physicalDeviceId, String title, String body) {
         try {
             Message message = buildMessage(fcmToken, title, body);
 
             String response = FirebaseMessaging.getInstance().send(message);
-            log.info("Push notification sent successfully: response={}, deviceId={}", response, deviceIdStr);
+            log.info("Push notification sent successfully: response={}, deviceId={}", response, physicalDeviceId);
 
         } catch (FirebaseMessagingException e) {
             handleFcmException(e, fcmToken, deviceId);
+        } catch (RuntimeException e) {
+            log.error("Unexpected error sending push notification: deviceId={}, error={}", physicalDeviceId, e.getMessage(), e);
         }
     }
 
@@ -110,57 +117,56 @@ public class FcmPushService implements PushService {
     }
 
     private void handleFcmException(FirebaseMessagingException e, String fcmToken, Long deviceId) {
+        String maskedToken = maskToken(fcmToken);
         MessagingErrorCode errorCode = e.getMessagingErrorCode();
 
         if (errorCode == null) {
-            log.error("FCM error without error code: token={}, message={}", fcmToken, e.getMessage(), e);
-            throw new RuntimeException("FCM push failed: " + e.getMessage(), e);
+            log.error("FCM error without error code: token={}, message={}", maskedToken, e.getMessage(), e);
+            return;
         }
 
         switch (errorCode) {
             case UNREGISTERED:
-                log.warn("FCM token unregistered, deactivating device: token={}", fcmToken);
+                log.warn("FCM token unregistered, deactivating device: token={}", maskedToken);
                 if (deviceId != null) {
-                    deactivateDevice(deviceId);
+                    userDeviceWriteService.deactivateDeviceById(deviceId);
                 }
                 break;
 
             case INVALID_ARGUMENT:
-                log.warn("FCM invalid token format, deactivating device: token={}", fcmToken);
+                log.warn("FCM invalid token format, deactivating device: token={}", maskedToken);
                 if (deviceId != null) {
-                    deactivateDevice(deviceId);
+                    userDeviceWriteService.deactivateDeviceById(deviceId);
                 }
                 break;
 
             case SENDER_ID_MISMATCH:
-                log.error("FCM sender ID mismatch - check Firebase configuration: token={}", fcmToken);
+                log.error("FCM sender ID mismatch - check Firebase configuration: token={}", maskedToken);
                 break;
 
             case QUOTA_EXCEEDED:
-                log.warn("FCM quota exceeded, will retry later: token={}", fcmToken);
-                throw new RuntimeException("FCM quota exceeded", e);
+                log.warn("FCM quota exceeded, will retry later: token={}", maskedToken);
+                break;
 
             case UNAVAILABLE:
             case INTERNAL:
-                log.warn("FCM temporary error ({}), will retry later: token={}", errorCode, fcmToken);
-                throw new RuntimeException("FCM temporary error: " + errorCode, e);
+                log.warn("FCM temporary error ({}), will retry later: token={}", errorCode, maskedToken);
+                break;
 
             case THIRD_PARTY_AUTH_ERROR:
-                log.error("FCM third party auth error (APNs): token={}", fcmToken);
+                log.error("FCM third party auth error (APNs): token={}", maskedToken);
                 break;
 
             default:
-                log.error("FCM unknown error: code={}, token={}, message={}", errorCode, fcmToken, e.getMessage(), e);
-                throw new RuntimeException("FCM push failed: " + errorCode, e);
+                log.error("FCM unknown error: code={}, token={}, message={}", errorCode, maskedToken, e.getMessage(), e);
+                break;
         }
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void deactivateDevice(Long deviceId) {
-        userDeviceRepository.findById(deviceId)
-                .ifPresent(device -> {
-                    device.deactivate();
-                    log.info("Device deactivated: deviceId={}", deviceId);
-                });
+    private static String maskToken(String token) {
+        if (token == null || token.length() < 8) {
+            return "[short-token]";
+        }
+        return "..." + token.substring(token.length() - 8);
     }
 }

--- a/src/main/java/basakan/fryday/repository/auth/UserDeviceRepository.java
+++ b/src/main/java/basakan/fryday/repository/auth/UserDeviceRepository.java
@@ -3,6 +3,9 @@ package basakan.fryday.repository.auth;
 import basakan.fryday.domain.user.UserDevice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -32,4 +35,6 @@ public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
     void deleteAllByUserId(Long userId);
 
     List<UserDevice> findAllByIsActiveTrueAndPushNotificationAgreedTrueAndFcmTokenIsNotNull();
+
+    Slice<UserDevice> findAllByIsActiveTrueAndPushNotificationAgreedTrueAndFcmTokenIsNotNull(Pageable pageable);
 }

--- a/src/main/java/basakan/fryday/service/admin/AdminPushService.java
+++ b/src/main/java/basakan/fryday/service/admin/AdminPushService.java
@@ -5,40 +5,54 @@ import basakan.fryday.domain.user.UserDevice;
 import basakan.fryday.repository.auth.UserDeviceRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AdminPushService {
 
+    private static final int BATCH_SIZE = 500;
+
     private final UserDeviceRepository userDeviceRepository;
     private final PushService pushService;
 
     @Transactional(readOnly = true)
     public int broadcastPush(String title, String body) {
-        List<UserDevice> devices = userDeviceRepository
-                .findAllByIsActiveTrueAndPushNotificationAgreedTrueAndFcmTokenIsNotNull();
-
-        if (devices.isEmpty()) {
-            log.info("전체 푸시 발송 대상 디바이스가 없습니다.");
-            return 0;
-        }
-
+        Set<String> sentTokens = new HashSet<>();
         int successCount = 0;
-        for (UserDevice device : devices) {
-            try {
-                pushService.sendToToken(device.getFcmToken(), title, body);
-                successCount++;
-            } catch (Exception e) {
-                log.warn("전체 푸시 발송 실패: fcmToken={}, error={}", device.getFcmToken(), e.getMessage());
+
+        Slice<UserDevice> slice = userDeviceRepository
+                .findAllByIsActiveTrueAndPushNotificationAgreedTrueAndFcmTokenIsNotNull(PageRequest.of(0, BATCH_SIZE));
+
+        while (!slice.isEmpty()) {
+            for (UserDevice device : slice.getContent()) {
+                String token = device.getFcmToken();
+                if (token == null || token.isBlank() || !sentTokens.add(token)) {
+                    continue;
+                }
+                try {
+                    pushService.sendToToken(token, title, body);
+                    successCount++;
+                } catch (Exception e) {
+                    log.warn("전체 푸시 발송 실패: error={}", e.getMessage());
+                }
             }
+
+            if (!slice.hasNext()) {
+                break;
+            }
+            slice = userDeviceRepository
+                    .findAllByIsActiveTrueAndPushNotificationAgreedTrueAndFcmTokenIsNotNull(slice.nextPageable());
         }
 
-        log.info("전체 푸시 발송 완료: 총 {}대 중 {}대 성공", devices.size(), successCount);
+        log.info("전체 푸시 발송 완료: 고유 토큰 {}개 중 {}개 성공", sentTokens.size(), successCount);
         return successCount;
     }
 }

--- a/src/main/java/basakan/fryday/service/fcm/UserDeviceWriteService.java
+++ b/src/main/java/basakan/fryday/service/fcm/UserDeviceWriteService.java
@@ -5,9 +5,13 @@ import basakan.fryday.common.exception.BusinessException;
 import basakan.fryday.domain.user.UserDevice;
 import basakan.fryday.repository.auth.UserDeviceRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -43,6 +47,15 @@ public class UserDeviceWriteService {
 
     public void deactivateDevice(UserDevice userDevice) {
         userDevice.deactivate();
+    }
+
+    @Transactional(propagation = REQUIRES_NEW)
+    public void deactivateDeviceById(Long deviceId) {
+        userDeviceRepository.findById(deviceId)
+                .ifPresent(device -> {
+                    device.deactivate();
+                    log.info("Device deactivated: deviceId={}", deviceId);
+                });
     }
 
     public void deactivateAllByUserId(Long userId) {

--- a/src/test/java/basakan/fryday/common/service/push/FcmPushServiceTest.java
+++ b/src/test/java/basakan/fryday/common/service/push/FcmPushServiceTest.java
@@ -1,0 +1,91 @@
+package basakan.fryday.common.service.push;
+
+import basakan.fryday.domain.user.UserDevice;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FcmPushServiceTest {
+
+    @Test
+    @DisplayName("동일한 FCM 토큰을 가진 디바이스가 여러 개여도 고유 토큰만 추출된다")
+    void extractUniqueTokens_duplicateTokens() {
+        // given
+        UserDevice device1 = createDevice(1L, "same-token");
+        UserDevice device2 = createDevice(2L, "same-token");
+        List<UserDevice> devices = List.of(device1, device2);
+
+        // when - sendToUser 내부에서 사용할 중복 제거 로직
+        Set<String> sentTokens = new HashSet<>();
+        for (UserDevice device : devices) {
+            if (device.getFcmToken() != null && !device.getFcmToken().isEmpty()) {
+                sentTokens.add(device.getFcmToken());
+            }
+        }
+
+        // then
+        assertThat(sentTokens).hasSize(1);
+        assertThat(sentTokens).containsExactly("same-token");
+    }
+
+    @Test
+    @DisplayName("서로 다른 FCM 토큰을 가진 디바이스는 모두 추출된다")
+    void extractUniqueTokens_differentTokens() {
+        // given
+        UserDevice device1 = createDevice(1L, "token-a");
+        UserDevice device2 = createDevice(2L, "token-b");
+        List<UserDevice> devices = List.of(device1, device2);
+
+        // when
+        Set<String> sentTokens = new HashSet<>();
+        for (UserDevice device : devices) {
+            if (device.getFcmToken() != null && !device.getFcmToken().isEmpty()) {
+                sentTokens.add(device.getFcmToken());
+            }
+        }
+
+        // then
+        assertThat(sentTokens).hasSize(2);
+        assertThat(sentTokens).containsExactlyInAnyOrder("token-a", "token-b");
+    }
+
+    @Test
+    @DisplayName("null, 빈 문자열, 공백 토큰은 제외된다")
+    void extractUniqueTokens_nullAndEmptyAndBlankFiltered() {
+        // given
+        UserDevice device1 = createDevice(1L, "valid-token");
+        UserDevice device2 = createDevice(2L, null);
+        UserDevice device3 = createDevice(3L, "");
+        UserDevice device4 = createDevice(4L, "valid-token");
+        UserDevice device5 = createDevice(5L, "   ");
+        List<UserDevice> devices = List.of(device1, device2, device3, device4, device5);
+
+        // when
+        Set<String> sentTokens = new HashSet<>();
+        for (UserDevice device : devices) {
+            String token = device.getFcmToken();
+            if (token != null && !token.isBlank()) {
+                sentTokens.add(token);
+            }
+        }
+
+        // then
+        assertThat(sentTokens).hasSize(1);
+        assertThat(sentTokens).containsExactly("valid-token");
+    }
+
+    private UserDevice createDevice(Long id, String fcmToken) {
+        return UserDevice.builder()
+                .userId(1L)
+                .deviceId("device-" + id)
+                .fcmToken(fcmToken)
+                .deviceType("iOS")
+                .deviceName("Test Device")
+                .build();
+    }
+}

--- a/src/test/java/basakan/fryday/service/admin/AdminPushServiceTest.java
+++ b/src/test/java/basakan/fryday/service/admin/AdminPushServiceTest.java
@@ -9,15 +9,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
-import static org.mockito.ArgumentMatchers.anyString;
 
 @ExtendWith(MockitoExtension.class)
 class AdminPushServiceTest {
@@ -37,8 +41,8 @@ class AdminPushServiceTest {
         // given
         UserDevice device1 = createDevice("token-1");
         UserDevice device2 = createDevice("token-2");
-        given(userDeviceRepository.findAllByIsActiveTrueAndPushNotificationAgreedTrueAndFcmTokenIsNotNull())
-                .willReturn(List.of(device1, device2));
+        given(userDeviceRepository.findAllByIsActiveTrueAndPushNotificationAgreedTrueAndFcmTokenIsNotNull(any(Pageable.class)))
+                .willReturn(new SliceImpl<>(List.of(device1, device2), PageRequest.of(0, 500), false));
 
         // when
         int count = adminPushService.broadcastPush("공지", "서버 점검입니다");
@@ -53,8 +57,8 @@ class AdminPushServiceTest {
     @DisplayName("대상 디바이스가 없으면 0을 반환한다")
     void noDevices() {
         // given
-        given(userDeviceRepository.findAllByIsActiveTrueAndPushNotificationAgreedTrueAndFcmTokenIsNotNull())
-                .willReturn(List.of());
+        given(userDeviceRepository.findAllByIsActiveTrueAndPushNotificationAgreedTrueAndFcmTokenIsNotNull(any(Pageable.class)))
+                .willReturn(new SliceImpl<>(List.of(), PageRequest.of(0, 500), false));
 
         // when
         int count = adminPushService.broadcastPush("공지", "내용");
@@ -71,8 +75,8 @@ class AdminPushServiceTest {
         UserDevice device1 = createDevice("token-1");
         UserDevice device2 = createDevice("token-2");
         UserDevice device3 = createDevice("token-3");
-        given(userDeviceRepository.findAllByIsActiveTrueAndPushNotificationAgreedTrueAndFcmTokenIsNotNull())
-                .willReturn(List.of(device1, device2, device3));
+        given(userDeviceRepository.findAllByIsActiveTrueAndPushNotificationAgreedTrueAndFcmTokenIsNotNull(any(Pageable.class)))
+                .willReturn(new SliceImpl<>(List.of(device1, device2, device3), PageRequest.of(0, 500), false));
         org.mockito.Mockito.lenient().doThrow(new RuntimeException("FCM error"))
                 .when(pushService).sendToToken("token-2", "공지", "내용");
 
@@ -86,10 +90,33 @@ class AdminPushServiceTest {
         assertThat(count).isEqualTo(2);
     }
 
+    @Test
+    @DisplayName("동일한 FCM 토큰을 가진 디바이스가 여러 개여도 알림은 1회만 발송한다")
+    void broadcastWithDuplicateTokens_sendsOnce() {
+        // given
+        UserDevice device1 = createDevice("token-dup");
+        UserDevice device2 = createDeviceWithUserId(2L, "token-dup");
+        UserDevice device3 = createDevice("token-unique");
+        given(userDeviceRepository.findAllByIsActiveTrueAndPushNotificationAgreedTrueAndFcmTokenIsNotNull(any(Pageable.class)))
+                .willReturn(new SliceImpl<>(List.of(device1, device2, device3), PageRequest.of(0, 500), false));
+
+        // when
+        int count = adminPushService.broadcastPush("공지", "내용");
+
+        // then
+        then(pushService).should(times(1)).sendToToken("token-dup", "공지", "내용");
+        then(pushService).should(times(1)).sendToToken("token-unique", "공지", "내용");
+        assertThat(count).isEqualTo(2);
+    }
+
     private UserDevice createDevice(String fcmToken) {
+        return createDeviceWithUserId(1L, fcmToken);
+    }
+
+    private UserDevice createDeviceWithUserId(Long userId, String fcmToken) {
         UserDevice device = UserDevice.builder()
-                .userId(1L)
-                .deviceId("device-" + fcmToken)
+                .userId(userId)
+                .deviceId("device-" + userId + "-" + fcmToken)
                 .fcmToken(fcmToken)
                 .deviceType("iOS")
                 .deviceName("Test Device")


### PR DESCRIPTION
   ## 🚀 Description

   FCM 알림이 동일 토큰에 중복 발송되는 문제를 해결하고, 기존 발송 로직의 안정성 문제를 함께 개선합니다.

   ### 변경 사항

   **1. 토큰 중복 발송 방지**
   - `FcmPushService.sendToUser()`, `AdminPushService.broadcastPush()`에서 `Set<String>` 기반 토큰 중복 제거

   **2. deactivateDevice self-invocation 프록시 우회 수정**
   - `FcmPushService` 내부의 `this.deactivateDevice()` 호출은 Spring 프록시를 타지 않아 `@Transactional(REQUIRES_NEW)`가 무효
   - `UserDeviceWriteService.deactivateDeviceById()`로 위임하여 트랜잭션 정상 동작

   **3. RuntimeException 전파 방지**
   - `handleFcmException()`에서 throw하던 RuntimeException 제거
   - 스케줄러에서 한 알림 실패 시 배치 전체가 롤백되는 문제 해결

   **4. FCM 토큰 로그 마스킹**
   - 로그에 토큰 전체 노출 → 뒤 8자리만 노출하는 `maskToken()` 적용

   **5. broadcastPush Slice 기반 페이지네이션**
   - 전체 디바이스 메모리 로드 → 500건 단위 배치 처리
   - 로그 카운터를 고유 토큰 수 기준으로 수정

   **6. 토큰 유효성 검증 강화**
   - `isEmpty()` → `isBlank()`로 변경하여 공백 문자열 토큰 필터링

   ### 흐름도

   ```mermaid
   flowchart TD
       A[sendToUser 호출] --> B[활성 디바이스 목록 조회]
       B --> C{디바이스 존재?}
       C -- No --> D[로그 경고 후 종료]
       C -- Yes --> E[Set sentTokens 초기화]
       E --> F{다음 디바이스}
       F --> G{토큰 유효? not blank}
       G -- No --> F
       G -- Yes --> H{sentTokens.add 성공?}
       H -- No 중복 --> F
       H -- Yes 신규 --> I[FCM 발송]
       I --> J{발송 성공?}
       J -- Yes --> F
       J -- No --> K[handleFcmException]
       K --> L{UNREGISTERED / INVALID?}
       L -- Yes --> M[UserDeviceWriteService.deactivateDeviceById]
       L -- No --> N[로그 기록 후 계속]
       M --> F
       N --> F
   ```

   ### 변경 파일

   | 파일 | 변경 내용 |
   |------|-----------|
   | `FcmPushService.java` | 토큰 중복 제거, self-invocation 제거, RuntimeException 방지, 토큰 마스킹, isBlank |
   | `AdminPushService.java` | Slice 페이지네이션, 토큰 중복 제거, 로그 카운터 수정 |
   | `UserDeviceWriteService.java` | `deactivateDeviceById()` 메서드 추가 |
   | `UserDeviceRepository.java` | Slice 기반 조회 메서드 추가 |
   | `FcmPushServiceTest.java` | 신규 - 토큰 중복 제거 테스트 3건 |
   | `AdminPushServiceTest.java` | 중복 토큰 테스트 추가, Slice mock 전환 |

   ## 📢 Notes
   - 기존 `FcmPushService.deactivateDevice()` (self-invocation) 삭제 → `UserDeviceWriteService`에 위임
   - `handleFcmException()`에서 더 이상 예외를 throw하지 않으므로, 호출하는 스케줄러의 try-catch는 `sendToTokenInternal`의 RuntimeException catch에서 처리됨