### PR TITLE
#114 feat: 캘린더 그릇 정책 변경에 따라 국자 타입 추가

### DIFF
--- a/src/main/java/basakan/fryday/domain/BowlType.java
+++ b/src/main/java/basakan/fryday/domain/BowlType.java
@@ -3,11 +3,14 @@ package basakan.fryday.domain;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDate;
+
 @Getter
 @RequiredArgsConstructor
 public enum BowlType {
 
     EMPTY("EMPTY", "빈 그릇"),
+    COOKING("COOKING", "국자"),
     LESS("LESS", "적은 그릇"),
     MORE("MORE", "많은 그릇"),
     FULL("FULL", "꽉 찬 그릇"),
@@ -16,7 +19,12 @@ public enum BowlType {
     private final String code;
     private final String description;
 
-    public static BowlType calculate(int total, int completed) {
+    public static BowlType calculate(int total, int completed, LocalDate targetDate, LocalDate today) {
+        // 미래 날짜는 아직 그릇을 보여주지 않는다 (투두 유무와 무관)
+        if (targetDate.isAfter(today)) {
+            return null;
+        }
+
         if (total == 0) {
             return EMPTY;
         }
@@ -25,6 +33,12 @@ public enum BowlType {
             return FULL;
         }
 
+        // 자정이 지나지 않은 당일은 진행 중이므로 국자로 표시
+        if (targetDate.equals(today)) {
+            return COOKING;
+        }
+
+        // 자정이 지난 지난날(마감)
         if (completed == 0) {
             return BURNT;
         }

--- a/src/main/java/basakan/fryday/service/DailyResultService.java
+++ b/src/main/java/basakan/fryday/service/DailyResultService.java
@@ -11,12 +11,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class DailyResultService {
+
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
 
     private final TodoRepository todoRepository;
 
@@ -27,13 +30,15 @@ public class DailyResultService {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "시작일은 종료일보다 이후일 수 없습니다.");
         }
 
+        LocalDate today = LocalDate.now(KOREA_ZONE);
+
         return startDate.datesUntil(endDate.plusDays(1))
                 .map(date -> {
                     List<Todo> todos = todoRepository.findAllByUserIdAndDate(userId, date);
                     int total = todos.size();
                     int completed = (int) todos.stream().filter(Todo::isCompleted).count();
-                    BowlType bowlType = BowlType.calculate(total, completed);
-                    return DailyResultResponse.of(date, bowlType.getCode());
+                    BowlType bowlType = BowlType.calculate(total, completed, date, today);
+                    return DailyResultResponse.of(date, bowlType != null ? bowlType.getCode() : null);
                 })
                 .collect(Collectors.toList());
     }

--- a/src/test/java/basakan/fryday/controller/DailyResultControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/DailyResultControllerTest.java
@@ -110,7 +110,7 @@ class DailyResultControllerTest extends RestDocsSupport {
                                 fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
 
                                 fieldWithPath("data[].date").type(JsonFieldType.STRING).description("날짜"),
-                                fieldWithPath("data[].bowlType").type(JsonFieldType.STRING).description("그릇 타입 (EMPTY, LESS, MORE, FULL, BURNT"),
+                                fieldWithPath("data[].bowlType").type(JsonFieldType.STRING).description("그릇 타입 (EMPTY, COOKING, LESS, MORE, FULL, BURNT)"),
                                 fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간")
                                 )
                 ));

--- a/src/test/java/basakan/fryday/domain/BowlTypeTest.java
+++ b/src/test/java/basakan/fryday/domain/BowlTypeTest.java
@@ -1,0 +1,70 @@
+package basakan.fryday.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BowlTypeTest {
+
+    private static final LocalDate TODAY = LocalDate.of(2026, 5, 29);
+    private static final LocalDate PAST = TODAY.minusDays(1);
+    private static final LocalDate FUTURE = TODAY.plusDays(1);
+
+    @Test
+    @DisplayName("미래 날짜는 투두 유무와 무관하게 그릇이 없다(null)")
+    void nullWhenFuture() {
+        assertThat(BowlType.calculate(0, 0, FUTURE, TODAY)).isNull();
+        assertThat(BowlType.calculate(4, 0, FUTURE, TODAY)).isNull();
+        assertThat(BowlType.calculate(4, 2, FUTURE, TODAY)).isNull();
+        assertThat(BowlType.calculate(4, 4, FUTURE, TODAY)).isNull();
+    }
+
+    @Test
+    @DisplayName("투두가 없으면 당일/지난날 무관하게 빈 그릇")
+    void emptyWhenNoTodos() {
+        assertThat(BowlType.calculate(0, 0, TODAY, TODAY)).isEqualTo(BowlType.EMPTY);
+        assertThat(BowlType.calculate(0, 0, PAST, TODAY)).isEqualTo(BowlType.EMPTY);
+    }
+
+    @Test
+    @DisplayName("모두 완료하면 당일/지난날 무관하게 꽉 찬 그릇")
+    void fullWhenAllCompleted() {
+        assertThat(BowlType.calculate(3, 3, TODAY, TODAY)).isEqualTo(BowlType.FULL);
+        assertThat(BowlType.calculate(3, 3, PAST, TODAY)).isEqualTo(BowlType.FULL);
+    }
+
+    @Test
+    @DisplayName("당일은 진행 중이면 일부 완료 여부와 무관하게 국자")
+    void cookingWhenTodayInProgress() {
+        assertThat(BowlType.calculate(4, 1, TODAY, TODAY)).isEqualTo(BowlType.COOKING);
+        assertThat(BowlType.calculate(4, 3, TODAY, TODAY)).isEqualTo(BowlType.COOKING);
+    }
+
+    @Test
+    @DisplayName("당일에 투두가 있고 완료 0개여도 국자")
+    void cookingWhenTodayNothingCompleted() {
+        assertThat(BowlType.calculate(4, 0, TODAY, TODAY)).isEqualTo(BowlType.COOKING);
+    }
+
+    @Test
+    @DisplayName("지난날에 투두가 있고 완료 0개면 타버린 그릇")
+    void burntWhenPastNothingCompleted() {
+        assertThat(BowlType.calculate(4, 0, PAST, TODAY)).isEqualTo(BowlType.BURNT);
+    }
+
+    @Test
+    @DisplayName("지난날에 완료율 50% 미만이면 적은 그릇")
+    void lessWhenPastUnderHalf() {
+        assertThat(BowlType.calculate(4, 1, PAST, TODAY)).isEqualTo(BowlType.LESS);
+    }
+
+    @Test
+    @DisplayName("지난날에 완료율 50% 이상이면 많은 그릇")
+    void moreWhenPastHalfOrMore() {
+        assertThat(BowlType.calculate(4, 2, PAST, TODAY)).isEqualTo(BowlType.MORE);
+        assertThat(BowlType.calculate(4, 3, PAST, TODAY)).isEqualTo(BowlType.MORE);
+    }
+}


### PR DESCRIPTION
## 📌 Related Issue
- close: #114 

## 🚀 Description
## 변경 내용
  캘린더 그릇 정책 변경에 따라 **국자(COOKING)** 타입을 추가하고, 날짜 상태별로 그릇을 계산하도록 수정했습니다.

  - **미래 날짜**: 투두 유무와 무관하게 그릇 미노출 (`bowlType=null`)
  - **당일(진행 중)**: 투두 없음 → EMPTY, 모두 완료 → FULL, 그 외 진행 중 → **COOKING**
  - **지난날(마감)**: 완료 0개 → BURNT, 50% 미만 → LESS, 50% 이상 → MORE, 모두 완료 → FULL

  `BowlType.calculate`에 날짜 컨텍스트(targetDate, today)를 추가했고, 날짜 비교는 Asia/Seoul 기준입니다.
  기존엔 프론트에서만 미래 그릇을 가렸으나, 백엔드에서도 방어하도록 했습니다.

## 📢 Notes

