### PR TITLE
perf: 투두 조회 인덱스 추가

### DIFF
--- a/db/2026-08-04_add_indexes.sql
+++ b/db/2026-08-04_add_indexes.sql
@@ -1,0 +1,32 @@
+-- 조회 인덱스 추가 (2026-08-04)
+--
+-- prod는 ddl-auto: validate 이고 Hibernate의 validate는 인덱스를 검증하지 않는다.
+-- 따라서 엔티티의 @Index 선언과 별개로 운영 DB에는 이 스크립트를 직접 실행해야 한다.
+-- dev는 ddl-auto: update 라 앱 기동 시 자동 생성된다.
+--
+-- 운영 중 무중단 적용을 위해 ALGORITHM=INPLACE, LOCK=NONE 으로 온라인 DDL을 강제한다.
+-- 지원되지 않는 조건이면 즉시 에러가 나므로, 조용히 테이블을 잠그는 상황을 방지할 수 있다.
+
+ALTER TABLE todo
+    ADD INDEX idx_todo_category_date (category_id, date, deleted_at, display_order),
+    ALGORITHM = INPLACE, LOCK = NONE;
+
+ALTER TABLE todo
+    ADD INDEX idx_todo_recurrence_date (recurrence_id, date),
+    ALGORITHM = INPLACE, LOCK = NONE;
+
+ALTER TABLE category
+    ADD INDEX idx_category_user (user_id),
+    ALGORITHM = INPLACE, LOCK = NONE;
+
+ALTER TABLE recurrence
+    ADD INDEX idx_recurrence_user (user_id, is_deleted),
+    ALGORITHM = INPLACE, LOCK = NONE;
+
+ANALYZE TABLE todo, category, recurrence;
+
+-- 확인용
+-- SELECT table_name, index_name, GROUP_CONCAT(column_name ORDER BY seq_in_index) cols
+-- FROM information_schema.statistics
+-- WHERE table_schema = DATABASE() AND table_name IN ('todo','category','recurrence')
+-- GROUP BY table_name, index_name ORDER BY table_name, index_name;

--- a/db/2026-08-04_add_indexes.sql
+++ b/db/2026-08-04_add_indexes.sql
@@ -4,9 +4,21 @@
 -- 따라서 엔티티의 @Index 선언과 별개로 운영 DB에는 이 스크립트를 직접 실행해야 한다.
 -- dev는 ddl-auto: update 라 앱 기동 시 자동 생성된다.
 --
--- 운영 중 무중단 적용을 위해 ALGORITHM=INPLACE, LOCK=NONE 으로 온라인 DDL을 강제한다.
--- 지원되지 않는 조건이면 즉시 에러가 나므로, 조용히 테이블을 잠그는 상황을 방지할 수 있다.
+-- 위에서부터 한 문장씩 실행한다.
+-- MySQL은 ADD INDEX IF NOT EXISTS를 지원하지 않으므로, 재실행할 때는
+-- ①의 결과를 보고 없는 인덱스만 골라서 실행할 것.
+-- 이미 있는 인덱스에 실행하면 ERROR 1061이 나지만 데이터에는 영향이 없다.
 
+-- ① 현재 인덱스 확인
+SELECT table_name, index_name, GROUP_CONCAT(column_name ORDER BY seq_in_index) AS cols
+FROM information_schema.statistics
+WHERE table_schema = DATABASE()
+  AND table_name IN ('todo', 'category', 'recurrence')
+GROUP BY table_name, index_name
+ORDER BY table_name, index_name;
+
+
+-- ② 인덱스 생성
 ALTER TABLE todo
     ADD INDEX idx_todo_category_date (category_id, date, deleted_at, display_order),
     ALGORITHM = INPLACE, LOCK = NONE;
@@ -23,10 +35,15 @@ ALTER TABLE recurrence
     ADD INDEX idx_recurrence_user (user_id, is_deleted),
     ALGORITHM = INPLACE, LOCK = NONE;
 
+
+-- ③ 통계 갱신
 ANALYZE TABLE todo, category, recurrence;
 
--- 확인용
--- SELECT table_name, index_name, GROUP_CONCAT(column_name ORDER BY seq_in_index) cols
--- FROM information_schema.statistics
--- WHERE table_schema = DATABASE() AND table_name IN ('todo','category','recurrence')
--- GROUP BY table_name, index_name ORDER BY table_name, index_name;
+
+-- ④ 적용 결과 확인 (①과 동일한 쿼리)
+SELECT table_name, index_name, GROUP_CONCAT(column_name ORDER BY seq_in_index) AS cols
+FROM information_schema.statistics
+WHERE table_schema = DATABASE()
+  AND table_name IN ('todo', 'category', 'recurrence')
+GROUP BY table_name, index_name
+ORDER BY table_name, index_name;

--- a/src/main/java/basakan/fryday/domain/category/Category.java
+++ b/src/main/java/basakan/fryday/domain/category/Category.java
@@ -12,6 +12,9 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "category", indexes = {
+        @Index(name = "idx_category_user", columnList = "user_id")
+})
 public class Category extends BaseEntity {
 
     @Column(nullable = false)

--- a/src/main/java/basakan/fryday/domain/todo/Recurrence.java
+++ b/src/main/java/basakan/fryday/domain/todo/Recurrence.java
@@ -5,6 +5,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +18,9 @@ import java.time.LocalTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "recurrence", indexes = {
+        @Index(name = "idx_recurrence_user", columnList = "user_id, is_deleted")
+})
 public class Recurrence extends BaseEntity {
 
     @Column(nullable = false)

--- a/src/main/java/basakan/fryday/domain/todo/Todo.java
+++ b/src/main/java/basakan/fryday/domain/todo/Todo.java
@@ -14,6 +14,10 @@ import java.time.LocalTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "todo", indexes = {
+        @Index(name = "idx_todo_category_date", columnList = "category_id, date, deleted_at, display_order"),
+        @Index(name = "idx_todo_recurrence_date", columnList = "recurrence_id, date")
+})
 public class Todo extends BaseEntity {
 
     @Column(nullable = false)


### PR DESCRIPTION
## 📌 Related Issue
- close: #

## 🚀 Description

투두 조회 쪽에 인덱스가 하나도 없어서 4개 추가했습니다. `todo`에 있던 `category_id` 인덱스는 FK 때문에 InnoDB가 자동으로 만든 것입니다. 지금은 누적 투두가 1만 건도 안 돼서 체감이 안 되지만, `todo`는 유저×날짜로 계속 쌓이는 테이블이라 미리 잡아두는 게 나을 것 같았습니다.

특히 `existsByRecurrenceIdAndDate`가 문제였습니다. `todo.recurrence_id`가 FK가 아닌 순수 컬럼이라 인덱스가 없는데, 이게 `materializeRecurrenceOccurrences` 루프 안에서 호출돼서 반복 규칙 N개인 유저가 목록 한 번 조회하면 풀스캔이 N번 돕니다.

추가한 인덱스:
- `todo(category_id, date, deleted_at, display_order)`
- `todo(recurrence_id, date)`
- `category(user_id)`
- `recurrence(user_id, is_deleted)`

컬럼 순서는 등치 조건 → `IS NULL` → 정렬 순으로 뒀습니다. `todo` 쪽은 `category_id`·`date`가 등치고 `deleted_at IS NULL`이 그다음, 마지막 `display_order`는 정렬용이라 filesort를 없애려고 넣었습니다. 기존 FK 인덱스는 `category_id`까지만 커버해서 그 카테고리의 전체 기간 투두를 다 읽고 나서 `date`로 거르고 있었습니다. `recurrence`는 `start_date`·`end_date`가 범위 조건인 데다 `OR`로 묶여 있어서 인덱스에 넣어도 선택도에 도움이 안 될 것 같아 뺐습니다.

현재 운영 데이터가 가입자 187명 / 투두 9,884건이라 그대로 재면 차이가 안 드러납니다. 가입자 1만 명이 1년간 하루 한 개씩 쓰는 상황(누적 360만 건, 지금의 약 360배)을 가정해서 합성 데이터로 측정했습니다. MySQL 설정은 운영과 동일하게 맞췄습니다 (8.0.45, buffer pool 4G, instances 4).

`GET /api/todos`를 k6로 60초씩 돌린 결과입니다.

동시 요청 1개:

| | before | after |
|---|---:|---:|
| p50 | 2,409ms | 5ms |
| p95 | 3,521ms | 8ms |
| 처리량 | 0.4 req/s | 176 req/s |

동시 요청 3개:

| | before | after |
|---|---:|---:|
| p50 | 10,013ms | 6ms |
| p95 | 13,785ms | 9ms |
| 처리량 | 0.3 req/s | 464 req/s |

before는 요청이 3개로 늘어난 것만으로 p50이 2.4초에서 10초로 밀립니다. DB가 바로 포화돼서 요청이 큐에 쌓입니다. after는 5ms에서 6ms로 거의 변화가 없습니다.

쿼리 단위로는 `existsByRecurrenceIdAndDate` 500ms와 일별 목록 조회 870ms가 대부분을 차지했고, 둘 다 0.1ms 이하로 떨어졌습니다.

쓰기는 단건 INSERT 기준 10% 정도 느려지고 인덱스 용량이 60MB 늘어납니다. 조회가 훨씬 많은 워크로드라 괜찮다고 봤습니다.

## 📢 Notes

- **운영 DB엔 `db/2026-08-04_add_indexes.sql`을 직접 실행해야 합니다.** prod가 `ddl-auto: validate`인데 validate는 인덱스를 검증하지 않습니다. dev는 `update`라 기동 시 자동 생성됩니다.
- 스크립트에 `ALGORITHM=INPLACE, LOCK=NONE` 넣어놨습니다. 온라인 DDL이 안 되는 조건이면 조용히 잠그는 대신 에러가 나게 했습니다.
- 일별 목록 조회가 `ORDER BY display_order` 때문에 옵티마이저 플랜이 뒤집혀서 풀스캔을 타고 있었습니다. ORDER BY 빼면 4ms, 붙이면 870ms였는데 인덱스 넣으니 안정화됐습니다.
- `todo(category_id, ...)` 복합 인덱스를 만들면 FK용 자동 인덱스는 MySQL이 알아서 없애고 복합 인덱스가 FK를 서빙합니다.
- 측정에 쓴 시딩 SQL과 k6 스크립트는 이번 PR에 넣지 않았습니다. 필요하면 공유하겠습니다.
