### PR TITLE
fix: 반복 회차 생성 방식 통일 및 관련 버그 수정

### DIFF
--- a/src/main/java/basakan/fryday/repository/todo/RecurrenceRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/RecurrenceRepository.java
@@ -1,6 +1,5 @@
 package basakan.fryday.repository.todo;
 
-import basakan.fryday.domain.todo.EndType;
 import basakan.fryday.domain.todo.Recurrence;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,9 +9,6 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface RecurrenceRepository extends JpaRepository<Recurrence, Long> {
-
-    @Query("SELECT r FROM Recurrence r WHERE r.endType = :none AND r.lastGeneratedDate < :thresholdDate AND r.isDeleted = false")
-    List<Recurrence> findRecurrencesToExtend(@Param("none") EndType none, @Param("thresholdDate") LocalDate thresholdDate);
 
     @Query("SELECT r FROM Recurrence r WHERE r.userId = :userId " +
            "AND r.isDeleted = false " +

--- a/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
@@ -40,9 +40,6 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     @Query("SELECT t FROM Todo t WHERE t.recurrenceId = :recurrenceId AND t.date >= :fromDate AND t.deletedAt IS NULL")
     List<Todo> findAllByRecurrenceIdAndDateGte(@Param("recurrenceId") Long recurrenceId, @Param("fromDate") LocalDate fromDate);
 
-    @Query("SELECT CASE WHEN COUNT(t) > 0 THEN TRUE ELSE FALSE END FROM Todo t WHERE t.recurrenceId = :recurrenceId AND t.date = :date")
-    boolean existsByRecurrenceIdAndDate(@Param("recurrenceId") Long recurrenceId, @Param("date") LocalDate date);
-
     @Query("SELECT t FROM Todo t WHERE t.recurrenceId = :recurrenceId AND t.date = :date")
     java.util.Optional<Todo> findByRecurrenceIdAndDate(@Param("recurrenceId") Long recurrenceId, @Param("date") LocalDate date);
 
@@ -124,9 +121,16 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     @Query("UPDATE Todo t SET t.memo = :memo WHERE t.recurrenceId = :recurrenceId AND t.isOverridden = false AND t.deletedAt IS NULL")
     int bulkUpdateMemoByRecurrenceId(@Param("recurrenceId") Long recurrenceId, @Param("memo") String memo);
 
+    /** 규칙 분기(fork) 시 살아남은 인스턴스를 새 Master로 옮긴다. */
     @Modifying(flushAutomatically = true, clearAutomatically = true)
-    @Query("DELETE FROM Todo t WHERE t.recurrenceId = :recurrenceId AND t.date >= :fromDate")
-    int hardDeleteByRecurrenceIdAndDateGte(@Param("recurrenceId") Long recurrenceId, @Param("fromDate") LocalDate fromDate);
+    @Query("UPDATE Todo t SET t.recurrenceId = :newRecurrenceId " +
+            "WHERE t.id IN :ids")
+    int reassignRecurrenceId(@Param("ids") List<Long> ids, @Param("newRecurrenceId") Long newRecurrenceId);
+
+    /** 규칙에서 벗어난 인스턴스를 일괄 soft delete 한다. */
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("UPDATE Todo t SET t.deletedAt = :now WHERE t.id IN :ids AND t.deletedAt IS NULL")
+    int softDeleteByIds(@Param("ids") List<Long> ids, @Param("now") LocalDate now);
 
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Todo t WHERE t.category.id IN " +

--- a/src/main/java/basakan/fryday/scheduler/RecurrenceOccurrenceMaterializeScheduler.java
+++ b/src/main/java/basakan/fryday/scheduler/RecurrenceOccurrenceMaterializeScheduler.java
@@ -9,6 +9,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 
 /**
@@ -19,12 +20,14 @@ import java.util.List;
 @RequiredArgsConstructor
 public class RecurrenceOccurrenceMaterializeScheduler {
 
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+
     private final UserJpaRepository userJpaRepository;
     private final RecurrenceOccurrenceMaterializeService materializeService;
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void materializeTodayRecurrenceOccurrences() {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(KOREA_ZONE);
         log.info("Recurrence Occurrence Materialization start: {}", today);
 
         List<User> users = userJpaRepository.findAll();

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceInstanceService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceInstanceService.java
@@ -4,12 +4,10 @@ import basakan.fryday.common.ErrorCode;
 import basakan.fryday.common.exception.BusinessException;
 import basakan.fryday.controller.todo.request.InstanceEditRequest.Payload;
 import basakan.fryday.domain.todo.RecurrenceScope;
-import basakan.fryday.domain.category.Category;
 import basakan.fryday.domain.todo.EndType;
 import basakan.fryday.domain.todo.Recurrence;
 import basakan.fryday.domain.todo.RecurrenceType;
 import basakan.fryday.domain.todo.Todo;
-import basakan.fryday.repository.CategoryRepository;
 import basakan.fryday.repository.todo.RecurrenceRepository;
 import basakan.fryday.repository.todo.TodoAlarmRepository;
 import basakan.fryday.repository.todo.TodoRepository;
@@ -19,10 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -30,7 +26,6 @@ public class RecurrenceInstanceService {
 
     private final TodoRepository todoRepository;
     private final RecurrenceRepository recurrenceRepository;
-    private final CategoryRepository categoryRepository;
     private final TodoAlarmRepository todoAlarmRepository;
     private final RecurrenceOccurrenceCalculator occurrenceCalculator;
 
@@ -110,13 +105,10 @@ public class RecurrenceInstanceService {
 
         Recurrence savedNewMaster = recurrenceRepository.save(newMaster);
 
-        // STEP 3: T 이후 기존 인스턴스 일괄 soft delete (delete 전 displayOrder 보존)
-        Map<LocalDate, Long> preservedOrders = todoRepository.findAllByRecurrenceIdAndDateGte(oldMaster.getId(), T)
-                .stream().collect(Collectors.toMap(Todo::getDate, Todo::getDisplayOrder));
-        todoRepository.bulkSoftDeleteByRecurrenceIdAndDateGte(oldMaster.getId(), T, LocalDate.now());
-
-        // STEP 4: M_new 기준으로 T부터 새 인스턴스 배치 생성
-        generateInstances(savedNewMaster, T, 365, preservedOrders);
+        // STEP 3: T 이후 인스턴스를 새 규칙에 비춰 재배치한다.
+        //         지우고 다시 만들면 displayOrder·알람·완료 상태가 날아가므로,
+        //         새 규칙에 여전히 해당하는 회차는 그대로 두고 소속만 옮긴다.
+        realignInstances(oldMaster.getId(), savedNewMaster, T, payload);
     }
 
     /** spec 4.5: Master 직접 수정 — override 있는 인스턴스는 건드리지 않음 */
@@ -144,16 +136,11 @@ public class RecurrenceInstanceService {
                     resolveNotificationTime(payload, master.getNotificationTime()));
 
             LocalDate today = LocalDate.now();
-            LocalDate generateFrom = newStartDate.isAfter(today) ? newStartDate : today;
-            master.updateLastGeneratedDate(generateFrom);
+            LocalDate realignFrom = newStartDate.isAfter(today) ? newStartDate : today;
 
-            // 오늘 이후 인스턴스 물리 삭제 (과거 완료 이력 보존, delete 전 displayOrder 보존)
-            Map<LocalDate, Long> preservedOrders = todoRepository.findAllByRecurrenceIdAndDateGte(master.getId(), today)
-                    .stream().collect(Collectors.toMap(Todo::getDate, Todo::getDisplayOrder));
-            // FK(todo_alarms.todo_id) 위반 방지: todo 삭제 전 알림부터 제거
-            todoAlarmRepository.deleteByRecurrenceIdAndDateGte(master.getId(), today);
-            todoRepository.hardDeleteByRecurrenceIdAndDateGte(master.getId(), today);
-            generateInstances(master, generateFrom, 365, preservedOrders);
+            // 오늘 이후 인스턴스를 새 규칙에 비춰 재배치한다 (과거 완료 이력은 보존).
+            // Master가 그대로이므로 소속을 옮길 필요는 없고, 규칙에서 벗어난 회차만 정리한다.
+            realignInstances(master.getId(), master, realignFrom, payload);
         } else {
             // 내용만 변경: Master 업데이트 + 비override 인스턴스 일괄 반영
             master.updateContent(payload.getTitle(), payload.getMemo(),
@@ -280,49 +267,68 @@ public class RecurrenceInstanceService {
         recurrenceRepository.delete(recurrence);
     }
 
-    // ── generateInstances ──────────────────────────────────────────────────────
+    // ── realignInstances ───────────────────────────────────────────────────────
 
     /**
-     * spec 6: master 기준으로 startDate부터 limitDays 범위 내 인스턴스 배치 생성.
-     * 이미 존재하는 날짜(삭제 포함)는 SKIP.
+     * fromDate 이후의 기존 인스턴스를 새 규칙에 비춰 재배치한다.
+     * 지우고 다시 만드는 대신 차이만 반영한다. 새 규칙에도 해당하는 회차는 행을 그대로 두므로
+     * displayOrder·알람·override·완료 상태가 자연히 유지되고, 규칙에서 벗어난 회차만 정리된다.
+     * 새로 규칙에 들어온 날짜는 조회 시점에 생성된다(지연 생성).
+     *
+     * @param sourceRecurrenceId 재배치 대상 인스턴스가 현재 매달려 있는 Master
+     * @param newMaster          새 규칙. sourceRecurrenceId와 다르면 살아남은 회차의 소속을 옮긴다
      */
-    public List<Todo> generateInstances(Recurrence master, LocalDate startDate, int limitDays) {
-        return generateInstances(master, startDate, limitDays, Map.of());
+    private void realignInstances(Long sourceRecurrenceId, Recurrence newMaster,
+                                  LocalDate fromDate, Payload payload) {
+        List<Todo> candidates = todoRepository.findAllByRecurrenceIdAndDateGte(sourceRecurrenceId, fromDate);
+
+        List<Long> keptIds = new ArrayList<>();
+        List<Long> droppedIds = new ArrayList<>();
+
+        for (Todo instance : candidates) {
+            if (matchesRule(newMaster, instance.getDate())) {
+                keptIds.add(instance.getId());
+                applyContentChange(instance, payload);
+            } else {
+                droppedIds.add(instance.getId());
+            }
+        }
+
+        if (!droppedIds.isEmpty()) {
+            todoRepository.softDeleteByIds(droppedIds, LocalDate.now());
+        }
+
+        if (!keptIds.isEmpty() && !newMaster.getId().equals(sourceRecurrenceId)) {
+            todoRepository.reassignRecurrenceId(keptIds, newMaster.getId());
+        }
     }
 
-    public List<Todo> generateInstances(Recurrence master, LocalDate startDate, int limitDays,
-                                        Map<LocalDate, Long> preservedOrders) {
-        LocalDate endLimit = startDate.plusDays(limitDays);
-        LocalDate toDate = (master.getEndType() == EndType.UNTIL && master.getEndDate() != null
-                && master.getEndDate().isBefore(endLimit))
-                ? master.getEndDate()
-                : endLimit;
+    /** 새 규칙의 기간과 주기 양쪽을 만족하는 날짜인지 판정한다. */
+    private boolean matchesRule(Recurrence master, LocalDate date) {
+        if (date.isBefore(master.getStartDate())) {
+            return false;
+        }
+        if (master.getEndType() == EndType.UNTIL && master.getEndDate() != null
+                && date.isAfter(master.getEndDate())) {
+            return false;
+        }
+        return occurrenceCalculator.isMatch(master, date);
+    }
 
-        Category category = categoryRepository.findById(master.getCategoryId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
-
-        List<LocalDate> occurrenceDates = occurrenceCalculator.calculateOccurrences(master, startDate, toDate);
-
-        return occurrenceDates.stream()
-                .filter(date -> !todoRepository.existsByRecurrenceIdAndDate(master.getId(), date))
-                .map(date -> {
-                    long displayOrder = preservedOrders.containsKey(date)
-                            ? preservedOrders.get(date)
-                            : Optional.ofNullable(todoRepository.findMaxDisplayOrder(master.getUserId(), date))
-                                    .map(max -> max + 1).orElse(1L);
-
-                    Todo todo = Todo.builder()
-                            .description(master.getDescription())
-                            .category(category)
-                            .date(date)
-                            .displayOrder(displayOrder)
-                            .recurrenceId(master.getId())
-                            .memo(master.getMemo())
-                            .build();
-
-                    return todoRepository.save(todo);
-                })
-                .toList();
+    /**
+     * 살아남은 회차에 내용 변경을 반영한다.
+     * 사용자가 개별 수정한(override) 회차는 건드리지 않는다.
+     */
+    private void applyContentChange(Todo instance, Payload payload) {
+        if (instance.isOverridden()) {
+            return;
+        }
+        if (payload.getTitle() != null) {
+            instance.updateDescription(payload.getTitle());
+        }
+        if (payload.getMemo() != null) {
+            instance.updateMemo(payload.getMemo());
+        }
     }
 
     // ── 공통 헬퍼 ──────────────────────────────────────────────────────────────

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceOccurrenceMaterializeService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceOccurrenceMaterializeService.java
@@ -2,108 +2,50 @@ package basakan.fryday.service.todo;
 
 import basakan.fryday.common.ErrorCode;
 import basakan.fryday.common.exception.BusinessException;
-import basakan.fryday.domain.category.Category;
 import basakan.fryday.domain.todo.Recurrence;
 import basakan.fryday.domain.todo.Todo;
-import basakan.fryday.domain.todo.TodoAlarm;
-import basakan.fryday.domain.user.User;
-import basakan.fryday.repository.CategoryRepository;
 import basakan.fryday.repository.todo.RecurrenceRepository;
-import basakan.fryday.repository.todo.TodoAlarmRepository;
-import basakan.fryday.repository.todo.TodoRepository;
-import basakan.fryday.service.user.UserReadService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
+/**
+ * 반복 회차 생성을 지시하는 오케스트레이션.
+ * <p>
+ * 회차 1건씩의 트랜잭션 분리는 {@link RecurrenceOccurrenceWriter}가 담당한다.
+ * 여기에 트랜잭션을 걸면 writer의 {@code REQUIRES_NEW}가 같은 트랜잭션에 흡수되어
+ * 회차 하나의 실패가 나머지까지 되돌리므로, 이 클래스는 의도적으로 트랜잭션을 열지 않는다.
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class RecurrenceOccurrenceMaterializeService {
 
     private final RecurrenceRepository recurrenceRepository;
-    private final TodoRepository todoRepository;
-    private final CategoryRepository categoryRepository;
-    private final RecurrenceOccurrenceCalculator occurrenceCalculator;
-    private final TodoAlarmRepository todoAlarmRepository;
-    private final UserReadService userReadService;
+    private final RecurrenceOccurrenceWriter occurrenceWriter;
 
     /**
-     * 특정 반복 투두의 특정 날짜 인스턴스를 생성 (이미 존재하면 생성하지 않음)
+     * 특정 사용자의 특정 날짜 회차를 생성한다. 목록 조회 경로에서 호출한다.
+     *
+     * @param categoryId 지정하면 해당 카테고리의 반복만 대상으로 한다
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public Todo materializeOccurrenceIfNotExists(Long userId, Long recurrenceId, LocalDate occurrenceDate) {
-        Recurrence recurrence = recurrenceRepository.findById(recurrenceId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+    public void materializeOccurrencesForDate(Long userId, LocalDate date, Long categoryId) {
+        List<Recurrence> recurrences = recurrenceRepository.findByUserIdAndDateRange(userId, date);
 
-        if (recurrence.getUserId() != userId) {
-            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        for (Recurrence recurrence : recurrences) {
+            if (categoryId != null && recurrence.getCategoryId() != categoryId) {
+                continue;
+            }
+            materializeQuietly(userId, recurrence.getId(), date);
         }
-
-        // 이미 존재하는지 확인 (삭제된 인스턴스도 포함 — 재생성 방지)
-        boolean alreadyExists = todoRepository.existsByRecurrenceIdAndDate(recurrenceId, occurrenceDate);
-        if (alreadyExists) {
-            // 살아있는 인스턴스만 반환, 삭제된 경우 null (재생성 방지이지만 반환값은 null)
-            return todoRepository.findByRecurrenceIdAndDate(recurrenceId, occurrenceDate)
-                    .filter(t -> !t.isDeleted())
-                    .orElse(null);
-        }
-
-        // 발생일 계산으로 실제로 발생하는 날짜인지 확인
-        List<LocalDate> occurrenceDates = occurrenceCalculator.calculateOccurrences(
-                recurrence, occurrenceDate, occurrenceDate
-        );
-
-        if (occurrenceDates.isEmpty() || !occurrenceDates.contains(occurrenceDate)) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
-        }
-
-        Category category = categoryRepository.findById(recurrence.getCategoryId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
-
-        Long maxOrder = todoRepository.findMaxDisplayOrder(userId, occurrenceDate);
-        long displayOrder = (maxOrder == null) ? 1 : maxOrder + 1;
-
-        Todo todo = Todo.builder()
-                .description(recurrence.getDescription())
-                .category(category)
-                .date(occurrenceDate)
-                .displayOrder(displayOrder)
-                .recurrenceId(recurrence.getId())
-                .memo(recurrence.getMemo())
-                .build();
-
-        Todo savedTodo = todoRepository.save(todo);
-
-        if (recurrence.isAlarmEnabled()) {
-            todoAlarmRepository.findByTodoId(savedTodo.getId())
-                    .ifPresentOrElse(
-                            existingAlarm -> {
-                                LocalDateTime notifyAt = LocalDateTime.of(occurrenceDate, recurrence.getNotificationTime());
-                                existingAlarm.changeTime(notifyAt);
-                            },
-                            () -> {
-                                User user = userReadService.findById(userId);
-                                LocalDateTime notifyAt = LocalDateTime.of(occurrenceDate, recurrence.getNotificationTime());
-                                TodoAlarm todoAlarm = TodoAlarm.create(savedTodo, user, notifyAt);
-                                todoAlarmRepository.save(todoAlarm);
-                            }
-                    );
-        }
-
-        return savedTodo;
     }
 
     /**
-     * 특정 사용자의 오늘 날짜 인스턴스를 생성
+     * 특정 사용자의 오늘 회차를 생성한다. 자정 스케줄러에서 호출한다.
      */
-    @Transactional
     public void materializeTodayOccurrences(Long userId, LocalDate today) {
         List<Recurrence> recurrences = recurrenceRepository.findByUserIdAndDateRange(userId, today);
 
@@ -112,38 +54,32 @@ public class RecurrenceOccurrenceMaterializeService {
         }
 
         int createdCount = 0;
-
         for (Recurrence recurrence : recurrences) {
-            try {
-                List<LocalDate> occurrenceDates = occurrenceCalculator.calculateOccurrences(
-                        recurrence, today, today
-                );
-
-                if (occurrenceDates.isEmpty() || !occurrenceDates.contains(today)) {
-                    continue;
-                }
-
-                // 이미 존재하면 스킵 (삭제된 인스턴스도 포함)
-                if (todoRepository.existsByRecurrenceIdAndDate(recurrence.getId(), today)) {
-                    continue;
-                }
-
-                try {
-                    materializeOccurrenceIfNotExists(userId, recurrence.getId(), today);
-                    createdCount++;
-                } catch (BusinessException e) {
-                    if (e.getErrorCode() == ErrorCode.INVALID_INPUT_VALUE) {
-                        continue;
-                    }
-                    throw e;
-                }
-            } catch (Exception e) {
-                log.error("반복 투두 생성 실패 - recurrenceId: {}, date: {}", recurrence.getId(), today, e);
+            if (materializeQuietly(userId, recurrence.getId(), today) != null) {
+                createdCount++;
             }
         }
 
         if (createdCount > 0) {
             log.info("반복 투두 생성 완료 - userId: {}, date: {}, count: {}", userId, today, createdCount);
+        }
+    }
+
+    /**
+     * 회차 1건 생성. 그 날짜에 발생하지 않는 규칙은 조용히 넘어가고,
+     * 예상 못 한 예외는 남은 회차 처리를 막지 않도록 로깅만 한다.
+     */
+    private Todo materializeQuietly(Long userId, Long recurrenceId, LocalDate date) {
+        try {
+            return occurrenceWriter.materializeIfAbsent(userId, recurrenceId, date);
+        } catch (BusinessException e) {
+            if (e.getErrorCode() == ErrorCode.INVALID_INPUT_VALUE) {
+                return null;
+            }
+            throw e;
+        } catch (Exception e) {
+            log.error("반복 투두 생성 실패 - recurrenceId: {}, date: {}. 스킵하고 계속 진행", recurrenceId, date, e);
+            return null;
         }
     }
 }

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceOccurrenceWriter.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceOccurrenceWriter.java
@@ -1,0 +1,108 @@
+package basakan.fryday.service.todo;
+
+import basakan.fryday.common.ErrorCode;
+import basakan.fryday.common.exception.BusinessException;
+import basakan.fryday.domain.category.Category;
+import basakan.fryday.domain.todo.Recurrence;
+import basakan.fryday.domain.todo.Todo;
+import basakan.fryday.domain.todo.TodoAlarm;
+import basakan.fryday.domain.user.User;
+import basakan.fryday.repository.CategoryRepository;
+import basakan.fryday.repository.todo.RecurrenceRepository;
+import basakan.fryday.repository.todo.TodoAlarmRepository;
+import basakan.fryday.repository.todo.TodoRepository;
+import basakan.fryday.service.user.UserReadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 반복 회차 1건을 실제 Todo로 기록하는 쓰기 담당.
+ * <p>
+ * 회차 1건의 실패가 나머지 회차로 번지지 않아야 하므로 {@code REQUIRES_NEW}로 트랜잭션을 분리한다.
+ * 이 격리는 프록시를 거칠 때만 성립하기 때문에, 반복문을 도는 오케스트레이션
+ * ({@link RecurrenceOccurrenceMaterializeService})과 반드시 다른 빈으로 둔다.
+ */
+@Service
+@RequiredArgsConstructor
+public class RecurrenceOccurrenceWriter {
+
+    private final RecurrenceRepository recurrenceRepository;
+    private final TodoRepository todoRepository;
+    private final CategoryRepository categoryRepository;
+    private final TodoAlarmRepository todoAlarmRepository;
+    private final RecurrenceOccurrenceCalculator occurrenceCalculator;
+    private final UserReadService userReadService;
+
+    /**
+     * 특정 반복 규칙의 특정 날짜 회차를 생성한다. 이미 있으면 만들지 않는다.
+     *
+     * @return 살아있는 회차. 이미 삭제된 회차면 {@code null}(재생성하지 않는다)
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Todo materializeIfAbsent(Long userId, Long recurrenceId, LocalDate occurrenceDate) {
+        Recurrence recurrence = recurrenceRepository.findById(recurrenceId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        if (recurrence.getUserId() != userId) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
+
+        // 행이 있으면 이미 처리된 날짜다. 삭제된 회차는 되살리지 않으므로 null을 돌려준다.
+        // 존재 확인과 반환값 조회를 한 번에 끝내기 위해 exists 대신 조회 한 번으로 판단한다.
+        Optional<Todo> existing = todoRepository.findByRecurrenceIdAndDate(recurrenceId, occurrenceDate);
+        if (existing.isPresent()) {
+            return existing.filter(t -> !t.isDeleted()).orElse(null);
+        }
+
+        // 실제로 발생하는 날짜인지 확인
+        List<LocalDate> occurrenceDates = occurrenceCalculator.calculateOccurrences(
+                recurrence, occurrenceDate, occurrenceDate
+        );
+        if (occurrenceDates.isEmpty() || !occurrenceDates.contains(occurrenceDate)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        Category category = categoryRepository.findById(recurrence.getCategoryId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+
+        Long maxOrder = todoRepository.findMaxDisplayOrder(userId, occurrenceDate);
+        long displayOrder = (maxOrder == null) ? 1 : maxOrder + 1;
+
+        Todo todo = Todo.builder()
+                .description(recurrence.getDescription())
+                .category(category)
+                .date(occurrenceDate)
+                .displayOrder(displayOrder)
+                .recurrenceId(recurrence.getId())
+                .memo(recurrence.getMemo())
+                .build();
+
+        Todo savedTodo = todoRepository.save(todo);
+
+        if (recurrence.isAlarmEnabled()) {
+            attachAlarm(userId, savedTodo, occurrenceDate, recurrence);
+        }
+
+        return savedTodo;
+    }
+
+    private void attachAlarm(Long userId, Todo todo, LocalDate occurrenceDate, Recurrence recurrence) {
+        LocalDateTime notifyAt = LocalDateTime.of(occurrenceDate, recurrence.getNotificationTime());
+
+        todoAlarmRepository.findByTodoId(todo.getId())
+                .ifPresentOrElse(
+                        existingAlarm -> existingAlarm.changeTime(notifyAt),
+                        () -> {
+                            User user = userReadService.findById(userId);
+                            todoAlarmRepository.save(TodoAlarm.create(todo, user, notifyAt));
+                        }
+                );
+    }
+}

--- a/src/main/java/basakan/fryday/service/todo/TodoService.java
+++ b/src/main/java/basakan/fryday/service/todo/TodoService.java
@@ -20,9 +20,7 @@ import basakan.fryday.repository.todo.TodoAlarmRepository;
 import basakan.fryday.repository.todo.TodoRepository;
 import basakan.fryday.repository.todo.RecurrenceRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -30,7 +28,6 @@ import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TodoService {
@@ -230,31 +227,6 @@ public class TodoService {
         }
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void materializeRecurrenceOccurrences(Long userId, LocalDate date, Long categoryId) {
-        List<Recurrence> recurrences = recurrenceRepository.findByUserIdAndDateRange(userId, date);
-
-        if (categoryId != null) {
-            recurrences = recurrences.stream()
-                    .filter(r -> r.getCategoryId() == categoryId)
-                    .collect(Collectors.toList());
-        }
-
-        for (Recurrence recurrence : recurrences) {
-            try {
-                materializeService.materializeOccurrenceIfNotExists(userId, recurrence.getId(), date);
-            } catch (BusinessException e) {
-                if (e.getErrorCode() == ErrorCode.INVALID_INPUT_VALUE) {
-                    continue;
-                }
-                throw e;
-            } catch (Exception e) {
-                log.error("반복 투두 materialize 중 예상치 못한 예외 발생 - recurrenceId: {}, date: {}. 스킵하고 계속 진행",
-                        recurrence.getId(), date, e);
-            }
-        }
-    }
-
     @Transactional(readOnly = true)
     public List<TodoListResponse> getTodoListInternal(Long userId, LocalDate date, Long categoryId) {
         List<Todo> todos;
@@ -274,7 +246,7 @@ public class TodoService {
     }
 
     public List<TodoListResponse> getTodoList(Long userId, LocalDate date, Long categoryId) {
-        materializeRecurrenceOccurrences(userId, date, categoryId);
+        materializeService.materializeOccurrencesForDate(userId, date, categoryId);
         return getTodoListInternal(userId, date, categoryId);
     }
 

--- a/src/test/java/basakan/fryday/service/todo/RecurrenceInstanceServiceIntegrationTest.java
+++ b/src/test/java/basakan/fryday/service/todo/RecurrenceInstanceServiceIntegrationTest.java
@@ -25,10 +25,13 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -65,8 +68,8 @@ class RecurrenceInstanceServiceIntegrationTest {
 
     @Test
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    @DisplayName("scope=ALL 규칙 변경 시 알림이 걸린 미래 인스턴스도 FK 위반 없이 정리된다")
-    void editAll_withRuleChange_cleansUpAlarmsBeforeHardDelete() {
+    @DisplayName("scope=ALL 규칙 변경 시 새 규칙에도 해당하는 회차는 알림과 함께 유지된다")
+    void editAll_withRuleChange_keepsStillMatchingInstances() {
         User user = userJpaRepository.save(User.createNewUser(AuthProvider.APPLE, "fk-bug-sub", "fk@t.com"));
         Long userId = user.getId();
 
@@ -110,9 +113,122 @@ class RecurrenceInstanceServiceIntegrationTest {
                 recurrenceInstanceService.edit(futureInstance.getId(), RecurrenceScope.ALL, payload, userId)
         ).doesNotThrowAnyException();
 
-        // 기존 알림은 todo와 함께 정리되어야 한다 (FK 위반 방지)
-        assertThat(todoAlarmRepository.findById(alarmId)).isEmpty();
-        // 기존 future 인스턴스는 물리 삭제되어 새 인스턴스가 그 자리를 채운다
-        assertThat(todoRepository.findById(futureInstance.getId())).isEmpty();
+        // DAILY 규칙은 그대로이고 종료일만 늘어났으므로 이 회차는 여전히 규칙에 해당한다.
+        // 지우고 다시 만들지 않으므로 행과 알림이 그대로 살아있어야 한다.
+        assertThat(todoRepository.findById(futureInstance.getId()))
+                .as("새 규칙에도 해당하는 회차는 유지되어야 한다")
+                .isPresent()
+                .get()
+                .satisfies(t -> assertThat(t.isDeleted()).isFalse());
+
+        assertThat(todoAlarmRepository.findById(alarmId))
+                .as("회차가 유지되므로 알림도 함께 유지되어야 한다")
+                .isPresent();
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("scope=ALL 규칙 변경 시 새 규칙에서 벗어난 회차는 정리된다")
+    void editAll_withRuleChange_dropsInstancesOutsideNewRule() {
+        User user = userJpaRepository.save(User.createNewUser(AuthProvider.APPLE, "drop-sub", "drop@t.com"));
+        Long userId = user.getId();
+
+        Category category = categoryRepository.save(
+                Category.builder().name("업무").color(CategoryColor.BR).userId(userId).displayOrder(1L).build()
+        );
+
+        LocalDate today = LocalDate.now();
+        LocalDate target = today.plusDays(3);
+
+        Recurrence master = recurrenceRepository.save(Recurrence.builder()
+                .userId(userId)
+                .categoryId(category.getId())
+                .description("매일 보고")
+                .type(RecurrenceType.DAILY)
+                .frequencyValues(null)
+                .startDate(today)
+                .endType(EndType.NONE)
+                .lastGeneratedDate(today)
+                .build()
+        );
+
+        Todo instance = todoRepository.save(Todo.builder()
+                .description("매일 보고")
+                .category(category)
+                .date(target)
+                .displayOrder(1L)
+                .recurrenceId(master.getId())
+                .build()
+        );
+
+        // 종료일을 target 이전으로 당겨 이 회차가 규칙에서 벗어나게 만든다
+        Payload payload = new Payload();
+        ReflectionTestUtils.setField(payload, "endDate", target.minusDays(1));
+
+        recurrenceInstanceService.edit(instance.getId(), RecurrenceScope.ALL, payload, userId);
+
+        assertThat(todoRepository.findAllByUserIdAndDate(userId, target))
+                .as("새 규칙에서 벗어난 회차는 목록에서 사라져야 한다")
+                .isEmpty();
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("THIS_AND_FUTURE 수정 후에도 이후 회차의 알림과 순서가 유지된다")
+    void editThisAndFuture_preservesAlarmAndDisplayOrder() {
+        User user = userJpaRepository.save(User.createNewUser(AuthProvider.APPLE, "alarm-loss-sub", "alarm@t.com"));
+        Long userId = user.getId();
+
+        Category category = categoryRepository.save(
+                Category.builder().name("운동").color(CategoryColor.BR).userId(userId).displayOrder(1L).build()
+        );
+
+        LocalDate today = LocalDate.now();
+        LocalDate target = today.plusDays(3);
+
+        Recurrence master = recurrenceRepository.save(Recurrence.builder()
+                .userId(userId)
+                .categoryId(category.getId())
+                .description("스트레칭")
+                .type(RecurrenceType.DAILY)
+                .frequencyValues(null)
+                .startDate(today)
+                .endType(EndType.NONE)
+                .notificationTime(LocalTime.of(9, 0))
+                .lastGeneratedDate(today)
+                .build()
+        );
+
+        // 알림이 걸린 미래 회차. displayOrder는 목록 두 번째 자리
+        Todo instance = todoRepository.save(Todo.builder()
+                .description("스트레칭")
+                .category(category)
+                .date(target)
+                .displayOrder(2L)
+                .recurrenceId(master.getId())
+                .build()
+        );
+        todoAlarmRepository.save(TodoAlarm.create(instance, user, target.atTime(9, 0)));
+
+        Payload payload = new Payload();
+        ReflectionTestUtils.setField(payload, "title", "가벼운 스트레칭");
+
+        recurrenceInstanceService.edit(instance.getId(), RecurrenceScope.THIS_AND_FUTURE, payload, userId);
+
+        // 수정 후에도 해당 날짜에 살아있는 회차가 하나 있어야 한다
+        List<Todo> survivors = todoRepository.findAllByUserIdAndDate(userId, target);
+        assertThat(survivors).hasSize(1);
+
+        Todo survivor = survivors.get(0);
+
+        // 알림이 유지되어야 한다 — 현재는 generateInstances가 TodoAlarm을 만들지 않아 실패한다
+        assertThat(todoAlarmRepository.findByTodoId(survivor.getId()))
+                .as("반복 수정 후에도 이후 회차의 알림이 유지되어야 한다")
+                .isPresent();
+
+        // 목록 내 순서가 유지되어야 한다
+        assertThat(survivor.getDisplayOrder())
+                .as("재생성된 회차의 displayOrder가 유지되어야 한다")
+                .isEqualTo(2L);
     }
 }

--- a/src/test/java/basakan/fryday/service/todo/RecurrenceServiceIntegrationTest.java
+++ b/src/test/java/basakan/fryday/service/todo/RecurrenceServiceIntegrationTest.java
@@ -50,6 +50,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         JpaConfig.class,
         RecurrenceService.class,
         TodoService.class,
+        RecurrenceOccurrenceWriter.class,
         RecurrenceOccurrenceMaterializeService.class,
         RecurrenceOccurrenceCalculator.class,
         UserReadService.class
@@ -66,7 +67,7 @@ class RecurrenceServiceIntegrationTest {
     @Autowired
     private TodoService todoService;
     @Autowired
-    private RecurrenceOccurrenceMaterializeService materializeService;
+    private RecurrenceOccurrenceWriter occurrenceWriter;
 
     @Autowired
     private UserJpaRepository userJpaRepository;
@@ -113,7 +114,7 @@ class RecurrenceServiceIntegrationTest {
 
         assertThat(todoRepository.findAllByUserIdAndDate(userId, ANCHOR)).isEmpty();
 
-        Todo materialized = materializeService.materializeOccurrenceIfNotExists(userId, recurrenceId, ANCHOR);
+        Todo materialized = occurrenceWriter.materializeIfAbsent(userId, recurrenceId, ANCHOR);
 
         assertThat(materialized.getDate()).isEqualTo(ANCHOR);
         assertThat(materialized.getRecurrenceId()).isEqualTo(recurrenceId);
@@ -148,7 +149,7 @@ class RecurrenceServiceIntegrationTest {
         Long recurrenceId = refreshedAnchor.getRecurrenceId();
 
         // SECOND_DAY 인스턴스 생성
-        materializeService.materializeOccurrenceIfNotExists(userId, recurrenceId, SECOND_DAY);
+        occurrenceWriter.materializeIfAbsent(userId, recurrenceId, SECOND_DAY);
         Todo secondDayTodo = todoRepository.findAllByUserIdAndDate(userId, SECOND_DAY).stream()
                 .filter(t -> recurrenceId.equals(t.getRecurrenceId()))
                 .findFirst()
@@ -161,10 +162,11 @@ class RecurrenceServiceIntegrationTest {
         assertThat(todoRepository.findAllByUserIdAndDate(userId, SECOND_DAY)).isEmpty();
 
         // 재생성 시도 → 삭제된 인스턴스가 DB에 존재하므로 null 반환 (SKIP)
-        Todo result = materializeService.materializeOccurrenceIfNotExists(userId, recurrenceId, SECOND_DAY);
+        Todo result = occurrenceWriter.materializeIfAbsent(userId, recurrenceId, SECOND_DAY);
         assertThat(result).isNull();
 
         // 여전히 목록에 노출되지 않음
         assertThat(todoRepository.findAllByUserIdAndDate(userId, SECOND_DAY)).isEmpty();
     }
+
 }


### PR DESCRIPTION
## 📌 Related Issue
- close: #

## 🚀 Description

반복 회차 생성 방식이 경로마다 달랐습니다 — 생성은 지연(조회·스케줄러가 만듦), 수정은 사전(365일치 즉시 생성). 저장량 때문에 지연으로 전환했다가(2026-01), 반복 수정 기능(#101)에서 사전 생성이 부분 부활한 상태였고, 이 혼재가 버그 3건을 만들었습니다.

**지연 생성으로 통일**했습니다. 사전 생성(윈도우) 복원도 검토했지만, 사전 생성의 장점인 읽기 멱등성과 스케줄러 여유가 이 서비스에선 실익이 적습니다 — 읽기 복제본·조회 캐싱을 쓰지 않아 GET이 쓰기를 해도 문제되지 않고, 스케줄러가 놓친 회차는 조회 경로가 백업으로 채웁니다. 반면 사전 생성은 미래 1년치를 상시 보유해야 합니다(저장량 문제로 2026-01에 지연으로 전환했던 이유). 이득이 적고 비용이 확실해 지연 생성으로 통일했습니다.

| | 지연 *(채택)* | 사전 |
|---|---|---|
| 읽기 경로 | GET이 쓰기 (비멱등) | 순수 SELECT |
| ↳ 이 서비스에서 | 복제본·캐싱 안 써서 무해 | 실익 없음 |
| 저장량 | 과거분만 | 미래 1년치 상시 |
| 스케줄러 누락 | 조회가 백업 | — |

### 1. 반복 규칙 수정 시 이후 회차의 알림·순서·개별수정이 유실됨

수정 경로가 미래 회차를 지우고 다시 만드는데, `generateInstances`가 `Todo`만 만들고 `TodoAlarm`은 안 만듭니다. 이후 조회에서 회차 행이 이미 있어 알람 생성 경로를 안 타므로, **알림 걸린 반복을 수정하면 이후 회차 알림이 영구 유실**됩니다.

지우고 다시 만드는 대신 **새 규칙에 맞는 회차는 두고 벗어난 것만 정리**하도록 바꿨습니다. 행을 보존하니 알림·`displayOrder`·override·완료상태가 자동 유지됩니다. 판정은 기존 `RecurrenceOccurrenceCalculator.isMatch`를 재사용했습니다.

버그 재현 테스트를 먼저 작성해 현재 코드에서 실패하는 것을 확인한 뒤 고쳤습니다.

### 2. 자정 스케줄러의 회차별 트랜잭션 격리가 무효였던 문제

회차 1건 실패가 번지지 않도록 `REQUIRES_NEW`를 걸어뒀지만, 같은 클래스 내 호출이라 프록시를 안 타 무효였습니다. 회차 하나가 실패하면 그 유저의 나머지까지 롤백됩니다. 순회(`MaterializeService`)와 회차 쓰기(`Writer`)를 다른 빈으로 분리해 격리가 구조로 보장되게 했습니다. (자기 주입으로 프록시를 강제하는 대안은 함정을 남기므로 제외.)

### 3. 스케줄러 기준 날짜가 서버 타임존에 의존

회차 생성 스케줄러만 `LocalDate.now()`로 존을 명시하지 않았습니다. 현재는 서버 타임존이 KST라 정상 동작하지만(운영 로그 8일 연속 확인), 다른 5개 스케줄러는 존을 명시하는데 이것만 서버 환경에 의존해 `KOREA_ZONE`을 명시했습니다.

### 그 외
- 미사용 쿼리 `findRecurrencesToExtend` 제거

## 📢 Notes

- **스키마 변경 없음.** 마이그레이션 불필요.
- **후속 과제로 분리**: `Recurrence.lastGeneratedDate` 제거(NOT NULL이라 DROP COLUMN 마이그레이션 순서 조율 필요), `(recurrence_id, date)` 유니크 제약(동시 중복 방지, 현재 빈도 낮아 보류).

### 알림 도메인 (담당자 확인 필요)
정리 중 발견했으나 담당 영역이라 손대지 않은 것들입니다.
1. **과거 날짜 알람 지각 발송** — `materializeIfAbsent`에 과거 시각 가드가 없어 과거 `notifyAt` 알람이 생기고 매분 스케줄러가 즉시 발송합니다.
2. **`overrideIsAlarm`/`overrideAlarmTime` 무효** — 저장·응답에만 쓰이고 실제 알림엔 반영 안 됨. "이 회차만 알림 끄기/시간 변경"이 동작하지 않습니다.
3. **`todo_alarms`에 `(status, notify_at)` 인덱스 없음** — 매분 풀스캔. 현재는 테이블이 작아 문제없습니다.
4. 사전 생성 방식으로 갈 경우 알림 테이블을 1년치 미리 채우고 `todo_alarms` 인덱스를 추가해야 합니다 — 위 결정에서 지연 생성을 택한 배경 중 하나입니다.

### 체크리스트
- [x] `./gradlew test` 통과
- [x] 알림 유실 버그 재현 테스트 (수정 전 실패 → 수정 후 통과)
