### PR TITLE
반복 메모 개별 수정 정책 정합성 수정 및 마스터 전체 수정 유실 버그 수정

### DIFF
--- a/src/main/java/basakan/fryday/controller/todo/request/InstanceEditRequest.java
+++ b/src/main/java/basakan/fryday/controller/todo/request/InstanceEditRequest.java
@@ -26,6 +26,9 @@ public class InstanceEditRequest {
     @NoArgsConstructor
     public static class Payload {
         // content 필드
+        // title/memo 는 부분 수정(partial patch) 규약을 따른다.
+        //   - null(또는 필드 생략): 해당 필드를 변경하지 않음(기존 값 유지)
+        //   - 빈 문자열(""): 값을 삭제. 반복 인스턴스는 빈 override 로 기록되어 마스터 값을 다시 상속하지 않음
         private String title;
         private String memo;
         private Boolean isAlarmEnabled;

--- a/src/main/java/basakan/fryday/controller/todo/request/MemoRequest.java
+++ b/src/main/java/basakan/fryday/controller/todo/request/MemoRequest.java
@@ -8,6 +8,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class MemoRequest {
 
+    /**
+     * 설정할 메모 값 전체. null 또는 빈 문자열이면 메모를 비운다.
+     * 반복 인스턴스에 적용하면 개별 override 로 저장되어 마스터 메모를 다시 상속하지 않는다.
+     */
     @Size(max = 100, message = "메모는 최대 100자까지 가능합니다.")
     private String memo;
 

--- a/src/main/java/basakan/fryday/domain/todo/Todo.java
+++ b/src/main/java/basakan/fryday/domain/todo/Todo.java
@@ -132,6 +132,11 @@ public class Todo extends BaseEntity {
         this.isOverridden = true;
     }
 
+    /**
+     * 반복 인스턴스를 개별 수정(override)한다. 각 인자는 부분 수정 규약을 따른다.
+     *   - null: 해당 필드를 변경하지 않음(기존 override/상속 값 유지)
+     *   - 빈 문자열(title/memo): 값을 삭제. 빈 override 로 남겨 마스터 값을 다시 상속하지 않음
+     */
     public void applyOverride(String title, String memo, Boolean isAlarm, LocalTime alarmTime) {
         if (title != null) this.overrideTitle = title;
         if (memo != null) this.overrideMemo = memo;

--- a/src/main/java/basakan/fryday/domain/todo/Todo.java
+++ b/src/main/java/basakan/fryday/domain/todo/Todo.java
@@ -123,6 +123,15 @@ public class Todo extends BaseEntity {
         this.description = description;
     }
 
+    /**
+     * 반복 인스턴스의 메모만 개별 수정(override)한다.
+     * 삭제/빈 값은 빈 문자열 override로 남겨, 마스터 메모를 다시 상속하지 않도록 한다.
+     */
+    public void applyMemoOverride(String memo) {
+        this.overrideMemo = (memo != null) ? memo : "";
+        this.isOverridden = true;
+    }
+
     public void applyOverride(String title, String memo, Boolean isAlarm, LocalTime alarmTime) {
         if (title != null) this.overrideTitle = title;
         if (memo != null) this.overrideMemo = memo;

--- a/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
@@ -109,11 +109,12 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     @Query("UPDATE Todo t SET t.recurrenceId = :recurrenceId WHERE t.id = :todoId AND t.deletedAt IS NULL AND t.category.userId = :userId")
     int updateRecurrenceIdByIdAndUserId(@Param("todoId") Long todoId, @Param("userId") Long userId, @Param("recurrenceId") Long recurrenceId);
 
-    @Modifying(clearAutomatically = true)
+    // flushAutomatically: editAll에서 직전 master.updateContent(dirty)가 clear로 유실되지 않도록 벌크 실행 전 flush
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE Todo t SET t.description = :description WHERE t.recurrenceId = :recurrenceId AND t.isOverridden = false AND t.deletedAt IS NULL")
     int bulkUpdateDescriptionByRecurrenceId(@Param("recurrenceId") Long recurrenceId, @Param("description") String description);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE Todo t SET t.memo = :memo WHERE t.recurrenceId = :recurrenceId AND t.isOverridden = false AND t.deletedAt IS NULL")
     int bulkUpdateMemoByRecurrenceId(@Param("recurrenceId") Long recurrenceId, @Param("memo") String memo);
 

--- a/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/TodoRepository.java
@@ -98,10 +98,6 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     int updateDescriptionByIdAndUserId(@Param("todoId") Long todoId, @Param("userId") Long userId, @Param("description") String description);
 
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE Todo t SET t.memo = :memo WHERE t.id = :todoId AND t.deletedAt IS NULL AND t.category.userId = :userId")
-    int updateMemoByIdAndUserId(@Param("todoId") Long todoId, @Param("userId") Long userId, @Param("memo") String memo);
-
-    @Modifying(clearAutomatically = true)
     @Query("UPDATE Todo t SET t.date = :date WHERE t.id = :todoId AND t.deletedAt IS NULL AND t.recurrenceId IS NULL AND t.category.userId = :userId")
     int updateDateByIdAndUserIdForNonRecurring(@Param("todoId") Long todoId, @Param("userId") Long userId, @Param("date") LocalDate date);
 

--- a/src/main/java/basakan/fryday/service/todo/TodoService.java
+++ b/src/main/java/basakan/fryday/service/todo/TodoService.java
@@ -71,13 +71,28 @@ public class TodoService {
 
     @Transactional
     public MemoResponse updateMemo(Long todoId, Long userId, MemoRequest request) {
-        int updated = todoRepository.updateMemoByIdAndUserId(todoId, userId, request.getMemo());
-        if (updated == 0) {
+        Todo todo = todoRepository.findById(todoId)
+                .filter(t -> !t.isDeleted())
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        if (!todo.getCategory().getUserId().equals(userId)) {
             throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
         }
-        Todo todo = todoRepository.findById(todoId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
-        return MemoResponse.from(todo.getId(), todo.getMemo());
+
+        if (todo.getRecurrenceId() != null) {
+            // 반복 인스턴스: base memo를 직접 덮어쓰면 상속 메모가 오염되고, 마스터 전체 수정 시
+            // 재상속되므로 개별 override로 기록한다.
+            todo.applyMemoOverride(request.getMemo());
+        } else {
+            todo.updateMemo(request.getMemo());
+        }
+
+        return MemoResponse.from(todo.getId(), resolveEffectiveMemo(todo));
+    }
+
+    private String resolveEffectiveMemo(Todo todo) {
+        return todo.isOverridden() && todo.getOverrideMemo() != null
+                ? todo.getOverrideMemo() : todo.getMemo();
     }
 
     @Transactional

--- a/src/test/java/basakan/fryday/controller/todo/RecurrenceInstanceControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/todo/RecurrenceInstanceControllerTest.java
@@ -91,9 +91,9 @@ class RecurrenceInstanceControllerTest extends RestDocsSupport {
                                 fieldWithPath("payload").type(JsonFieldType.OBJECT)
                                         .description("수정할 내용. content 필드와 rule 필드를 함께 사용할 수 있음"),
                                 fieldWithPath("payload.title").type(JsonFieldType.STRING)
-                                        .description("[content] 변경할 제목").optional(),
+                                        .description("[content] 변경할 제목. null이면 미변경, 빈 문자열이면 삭제").optional(),
                                 fieldWithPath("payload.memo").type(JsonFieldType.STRING)
-                                        .description("[content] 변경할 메모").optional(),
+                                        .description("[content] 변경할 메모. null이면 미변경, 빈 문자열이면 삭제").optional(),
                                 fieldWithPath("payload.isAlarmEnabled").type(JsonFieldType.BOOLEAN)
                                         .description("[content] 알람 활성화 여부").optional(),
                                 fieldWithPath("payload.alarmTime").type(JsonFieldType.STRING)
@@ -147,9 +147,9 @@ class RecurrenceInstanceControllerTest extends RestDocsSupport {
                                 fieldWithPath("payload").type(JsonFieldType.OBJECT)
                                         .description("수정할 내용"),
                                 fieldWithPath("payload.title").type(JsonFieldType.STRING)
-                                        .description("[content] 변경할 제목").optional(),
+                                        .description("[content] 변경할 제목. null이면 미변경, 빈 문자열이면 삭제").optional(),
                                 fieldWithPath("payload.memo").type(JsonFieldType.STRING)
-                                        .description("[content] 변경할 메모").optional(),
+                                        .description("[content] 변경할 메모. null이면 미변경, 빈 문자열이면 삭제").optional(),
                                 fieldWithPath("payload.isAlarmEnabled").type(JsonFieldType.BOOLEAN)
                                         .description("[content] 알람 활성화 여부").optional(),
                                 fieldWithPath("payload.alarmTime").type(JsonFieldType.STRING)
@@ -200,9 +200,9 @@ class RecurrenceInstanceControllerTest extends RestDocsSupport {
                                 fieldWithPath("payload").type(JsonFieldType.OBJECT)
                                         .description("수정할 내용. content 필드와 rule 필드를 함께 사용할 수 있음"),
                                 fieldWithPath("payload.title").type(JsonFieldType.STRING)
-                                        .description("[content] 변경할 제목").optional(),
+                                        .description("[content] 변경할 제목. null이면 미변경, 빈 문자열이면 삭제").optional(),
                                 fieldWithPath("payload.memo").type(JsonFieldType.STRING)
-                                        .description("[content] 변경할 메모").optional(),
+                                        .description("[content] 변경할 메모. null이면 미변경, 빈 문자열이면 삭제").optional(),
                                 fieldWithPath("payload.isAlarmEnabled").type(JsonFieldType.BOOLEAN)
                                         .description("[content] 알람 활성화 여부").optional(),
                                 fieldWithPath("payload.alarmTime").type(JsonFieldType.STRING)

--- a/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
@@ -264,7 +264,8 @@ class TodoControllerTest extends RestDocsSupport {
                                 parameterWithName("todoId").description("메모를 수정할 투두 ID")
                         ),
                         requestFields(
-                                fieldWithPath("memo").type(JsonFieldType.STRING).description("수정할 메모 내용")
+                                fieldWithPath("memo").type(JsonFieldType.STRING)
+                                        .description("설정할 메모 전체 값. null/빈 문자열이면 비움")
                         ),
                         responseFields(
                                 fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),

--- a/src/test/java/basakan/fryday/service/todo/RecurrenceInstanceServiceIntegrationTest.java
+++ b/src/test/java/basakan/fryday/service/todo/RecurrenceInstanceServiceIntegrationTest.java
@@ -231,4 +231,116 @@ class RecurrenceInstanceServiceIntegrationTest {
                 .as("재생성된 회차의 displayOrder가 유지되어야 한다")
                 .isEqualTo(2L);
     }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("개별 수정한 메모는 scope=ALL 내용 수정 후에도 유지되고, 나머지 회차만 새 메모를 반영한다")
+    void editThisMemo_survivesEditAll() {
+        User user = userJpaRepository.save(User.createNewUser(AuthProvider.APPLE, "memo-keep-sub", "memo-keep@t.com"));
+        Long userId = user.getId();
+
+        Category category = categoryRepository.save(
+                Category.builder().name("업무").color(CategoryColor.BR).userId(userId).displayOrder(1L).build()
+        );
+
+        LocalDate today = LocalDate.now();
+        LocalDate dayA = today.plusDays(1);
+        LocalDate dayB = today.plusDays(2);
+
+        Recurrence master = recurrenceRepository.save(Recurrence.builder()
+                .userId(userId)
+                .categoryId(category.getId())
+                .description("반복 작업")
+                .memo("마스터 메모")
+                .type(RecurrenceType.DAILY)
+                .frequencyValues(null)
+                .startDate(today)
+                .endType(EndType.NONE)
+                .lastGeneratedDate(today)
+                .build()
+        );
+
+        // 상속 메모를 가진 두 회차. dayA만 개별 수정한다.
+        Todo overridden = todoRepository.save(Todo.builder()
+                .description("반복 작업").category(category).date(dayA)
+                .displayOrder(1L).recurrenceId(master.getId()).memo("마스터 메모").build()
+        );
+        Todo plain = todoRepository.save(Todo.builder()
+                .description("반복 작업").category(category).date(dayB)
+                .displayOrder(1L).recurrenceId(master.getId()).memo("마스터 메모").build()
+        );
+
+        // 1) dayA 회차만 메모 개별 수정 (override 기록)
+        Payload editThis = new Payload();
+        ReflectionTestUtils.setField(editThis, "memo", "개별 메모");
+        recurrenceInstanceService.edit(overridden.getId(), RecurrenceScope.THIS, editThis, userId);
+
+        // 2) scope=ALL 내용 수정으로 마스터 메모 변경
+        Payload editAll = new Payload();
+        ReflectionTestUtils.setField(editAll, "memo", "새 마스터 메모");
+        recurrenceInstanceService.edit(plain.getId(), RecurrenceScope.ALL, editAll, userId);
+
+        // then - 개별 수정 회차는 override 유지 (마스터 메모 재상속 안 함)
+        Todo reloadedOverridden = todoRepository.findById(overridden.getId()).orElseThrow();
+        assertThat(reloadedOverridden.isOverridden()).isTrue();
+        assertThat(reloadedOverridden.getOverrideMemo())
+                .as("개별 수정 메모는 마스터 전체 수정에도 유지된다")
+                .isEqualTo("개별 메모");
+
+        // 개별 수정 안 된 회차만 새 마스터 메모를 반영 (override 회차와 대비)
+        Todo reloadedPlain = todoRepository.findById(plain.getId()).orElseThrow();
+        assertThat(reloadedPlain.getMemo())
+                .as("개별 수정 안 된 회차는 새 마스터 메모를 반영한다")
+                .isEqualTo("새 마스터 메모");
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("개별 삭제(빈 메모)한 회차는 scope=ALL 수정 후에도 마스터 메모를 재상속하지 않는다")
+    void editThisEmptyMemo_notReinheritedAfterEditAll() {
+        User user = userJpaRepository.save(User.createNewUser(AuthProvider.APPLE, "memo-del-sub", "memo-del@t.com"));
+        Long userId = user.getId();
+
+        Category category = categoryRepository.save(
+                Category.builder().name("업무").color(CategoryColor.BR).userId(userId).displayOrder(1L).build()
+        );
+
+        LocalDate today = LocalDate.now();
+        LocalDate day = today.plusDays(1);
+
+        Recurrence master = recurrenceRepository.save(Recurrence.builder()
+                .userId(userId)
+                .categoryId(category.getId())
+                .description("반복 작업")
+                .memo("마스터 메모")
+                .type(RecurrenceType.DAILY)
+                .frequencyValues(null)
+                .startDate(today)
+                .endType(EndType.NONE)
+                .lastGeneratedDate(today)
+                .build()
+        );
+
+        Todo instance = todoRepository.save(Todo.builder()
+                .description("반복 작업").category(category).date(day)
+                .displayOrder(1L).recurrenceId(master.getId()).memo("마스터 메모").build()
+        );
+
+        // 1) 메모 개별 삭제 (빈 문자열 → 빈 override)
+        Payload delete = new Payload();
+        ReflectionTestUtils.setField(delete, "memo", "");
+        recurrenceInstanceService.edit(instance.getId(), RecurrenceScope.THIS, delete, userId);
+
+        // 2) scope=ALL 내용 수정으로 마스터 메모 변경
+        Payload editAll = new Payload();
+        ReflectionTestUtils.setField(editAll, "memo", "새 마스터 메모");
+        recurrenceInstanceService.edit(instance.getId(), RecurrenceScope.ALL, editAll, userId);
+
+        // then - 빈 override 유지, 마스터 메모 재상속 안 함
+        Todo reloaded = todoRepository.findById(instance.getId()).orElseThrow();
+        assertThat(reloaded.isOverridden()).isTrue();
+        assertThat(reloaded.getOverrideMemo())
+                .as("빈 override는 마스터 전체 수정에도 유지된다")
+                .isEmpty();
+    }
 }

--- a/src/test/java/basakan/fryday/service/todo/RecurrenceInstanceServiceIntegrationTest.java
+++ b/src/test/java/basakan/fryday/service/todo/RecurrenceInstanceServiceIntegrationTest.java
@@ -343,4 +343,48 @@ class RecurrenceInstanceServiceIntegrationTest {
                 .as("빈 override는 마스터 전체 수정에도 유지된다")
                 .isEmpty();
     }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("scope=ALL 내용 수정 시 마스터 메모 변경이 유실되지 않고 저장된다")
+    void editAll_contentChange_persistsMasterMemo() {
+        User user = userJpaRepository.save(User.createNewUser(AuthProvider.APPLE, "master-memo-sub", "master-memo@t.com"));
+        Long userId = user.getId();
+
+        Category category = categoryRepository.save(
+                Category.builder().name("업무").color(CategoryColor.BR).userId(userId).displayOrder(1L).build()
+        );
+
+        LocalDate today = LocalDate.now();
+        LocalDate day = today.plusDays(1);
+
+        Recurrence master = recurrenceRepository.save(Recurrence.builder()
+                .userId(userId)
+                .categoryId(category.getId())
+                .description("반복 작업")
+                .memo("마스터 메모")
+                .type(RecurrenceType.DAILY)
+                .frequencyValues(null)
+                .startDate(today)
+                .endType(EndType.NONE)
+                .lastGeneratedDate(today)
+                .build()
+        );
+
+        Todo instance = todoRepository.save(Todo.builder()
+                .description("반복 작업").category(category).date(day)
+                .displayOrder(1L).recurrenceId(master.getId()).memo("마스터 메모").build()
+        );
+
+        // scope=ALL 내용 수정 (메모 벌크 갱신이 뒤따른다)
+        Payload editAll = new Payload();
+        ReflectionTestUtils.setField(editAll, "memo", "새 마스터 메모");
+        recurrenceInstanceService.edit(instance.getId(), RecurrenceScope.ALL, editAll, userId);
+
+        // 벌크의 컨텍스트 clear로 인해 유실되지 않고 Recurrence 엔티티에도 반영되어야 한다.
+        // (미래 회차가 새 메모를 상속하려면 마스터에 저장돼 있어야 함)
+        assertThat(recurrenceRepository.findById(master.getId()).orElseThrow().getMemo())
+                .as("scope=ALL 내용 수정은 마스터 엔티티에도 반영되어야 한다")
+                .isEqualTo("새 마스터 메모");
+    }
 }

--- a/src/test/java/basakan/fryday/service/todo/TodoServiceTest.java
+++ b/src/test/java/basakan/fryday/service/todo/TodoServiceTest.java
@@ -7,6 +7,8 @@ import basakan.fryday.domain.category.CategoryColor;
 import basakan.fryday.domain.todo.Recurrence;
 import basakan.fryday.domain.todo.RecurrenceType;
 import basakan.fryday.domain.todo.Todo;
+import basakan.fryday.controller.todo.request.MemoRequest;
+import basakan.fryday.controller.todo.response.MemoResponse;
 import basakan.fryday.repository.CategoryRepository;
 import basakan.fryday.repository.todo.RecurrenceRepository;
 import basakan.fryday.repository.todo.TodoAlarmRepository;
@@ -368,6 +370,85 @@ class TodoServiceTest {
             assertThatThrownBy(() -> todoService.moveToToday(TODO_ID, USER_ID))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.TODO_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateMemo")
+    class UpdateMemo {
+
+        @Test
+        @DisplayName("일반 투두 - base memo를 직접 갱신하고 override는 남기지 않는다")
+        void 일반투두_base_memo_갱신() {
+            // given
+            Todo todo = Todo.builder()
+                    .description("일반 할 일")
+                    .category(category)
+                    .date(today)
+                    .displayOrder(1L)
+                    .memo("기존 메모")
+                    .build();
+            ReflectionTestUtils.setField(todo, "id", TODO_ID);
+            given(todoRepository.findById(TODO_ID)).willReturn(Optional.of(todo));
+
+            // when
+            MemoResponse result = todoService.updateMemo(TODO_ID, USER_ID, new MemoRequest("새 메모"));
+
+            // then
+            assertThat(result.getMemo()).isEqualTo("새 메모");
+            assertThat(todo.getMemo()).isEqualTo("새 메모");
+            assertThat(todo.isOverridden()).isFalse();
+            assertThat(todo.getOverrideMemo()).isNull();
+        }
+
+        @Test
+        @DisplayName("반복 인스턴스 - base memo는 두고 override로 기록한다")
+        void 반복인스턴스_override_기록() {
+            // given - 상속받은 base memo를 가진 반복 인스턴스
+            Todo instance = Todo.builder()
+                    .description("반복 할 일")
+                    .category(category)
+                    .date(today)
+                    .displayOrder(1L)
+                    .recurrenceId(10L)
+                    .memo("마스터 메모")
+                    .build();
+            ReflectionTestUtils.setField(instance, "id", TODO_ID);
+            given(todoRepository.findById(TODO_ID)).willReturn(Optional.of(instance));
+
+            // when
+            MemoResponse result = todoService.updateMemo(TODO_ID, USER_ID, new MemoRequest("개별 메모"));
+
+            // then - override에만 저장, base(상속) memo는 보존
+            assertThat(result.getMemo()).isEqualTo("개별 메모");
+            assertThat(instance.getOverrideMemo()).isEqualTo("개별 메모");
+            assertThat(instance.isOverridden()).isTrue();
+            assertThat(instance.getMemo()).isEqualTo("마스터 메모");
+        }
+
+        @Test
+        @DisplayName("반복 인스턴스 - 메모 삭제(null)는 빈 override로 남겨 마스터 메모를 재상속하지 않는다")
+        void 반복인스턴스_삭제는_빈_override() {
+            // given
+            Todo instance = Todo.builder()
+                    .description("반복 할 일")
+                    .category(category)
+                    .date(today)
+                    .displayOrder(1L)
+                    .recurrenceId(10L)
+                    .memo("마스터 메모")
+                    .build();
+            ReflectionTestUtils.setField(instance, "id", TODO_ID);
+            given(todoRepository.findById(TODO_ID)).willReturn(Optional.of(instance));
+
+            // when - memo=null (삭제 의도)
+            MemoResponse result = todoService.updateMemo(TODO_ID, USER_ID, new MemoRequest(null));
+
+            // then - 빈 문자열 override → 응답은 빈 값, 마스터 메모 재상속 안 함
+            assertThat(result.getMemo()).isEmpty();
+            assertThat(instance.getOverrideMemo()).isEmpty();
+            assertThat(instance.isOverridden()).isTrue();
+            assertThat(instance.getMemo()).isEqualTo("마스터 메모");
         }
     }
 }


### PR DESCRIPTION
## 개요

반복 Todo 메모 정책(4.2.3)이 코드에 온전히 반영됐는지 점검하다 발견한 **두 개의 버그**를 수정하고, 관련 규약을 명시했습니다.

1. 일반 메모 수정 API가 반복 인스턴스의 개별 수정을 유실시키던 문제
2. `scope=ALL` 내용 수정이 마스터(Recurrence) 엔티티에 반영되지 않던 문제

---

## 1. 일반 메모 API가 반복 인스턴스 개별 수정을 유실시킴

**What** — `PATCH /api/todos/{id}/memo`로 반복 인스턴스 메모를 수정하면, 그 값이 마스터 전체 수정 시 **덮어써져 사라졌습니다.**

**Why (원인)** — 반복 인스턴스는 메모를 두 칸에 나눠 저장합니다: 상속값을 담는 `memo`(base)와 개별 수정값을 담는 `overrideMemo`(+`isOverridden`). 마스터 전체 수정은 `is_overridden = false`인 회차만 갱신합니다. 그런데 기존 `updateMemo`는 반복 인스턴스인지 따지지 않고 **base 칸을 직접** 덮어쓰고 `isOverridden`을 세우지 않아, 겉보기엔 수정된 듯 보여도 이후 마스터 전체 수정에 걸려 재상속됐습니다.

**How (해결)** — `updateMemo`가 엔티티를 로드해 분기하도록 변경:
- 반복 인스턴스 → `applyMemoOverride`로 **override에 기록**(base 상속값 보존, `isOverridden=true`). 삭제(null/빈 값)는 빈 문자열 override로 정규화해 재상속을 막음.
- 일반 Todo → 기존대로 base 갱신.

부수적으로 유일한 사용처가 사라진 `updateMemoByIdAndUserId` 벌크 쿼리를 제거했습니다.

## 2. `scope=ALL` 내용 수정이 마스터 엔티티에 반영 안 됨

**What** — 반복을 `scope=ALL`로 메모/제목 수정하면 현재 회차는 바뀌지만, **이후 새로 생성되는 미래 회차는 옛 메모를 상속**했습니다.

**Why (원인)** — `editAll`은 `master.updateContent(...)`로 Recurrence를 dirty 상태로 만든 뒤 `bulkUpdate...ByRecurrenceId`(Todo 대상, `clearAutomatically=true`)를 실행합니다. Hibernate는 벌크 쿼리 전에 무관한 `recurrence` 테이블 변경은 flush하지 않고 컨텍스트를 clear해버려, master 변경이 **flush되지 못하고 유실**됐습니다. 현재 회차는 벌크 쿼리로 직접 갱신되니 정상처럼 보였던 게 문제를 가렸습니다.

**How (해결)** — 두 벌크 쿼리에 `flushAutomatically = true`를 추가해, clear 전에 master 변경이 먼저 flush되도록 했습니다. (이미 `reassignRecurrenceId`에서 쓰던 패턴)

---

## 규약 명시 (docs)

`null`(미변경/비움)과 빈 문자열(삭제)의 의미가 코드에 강제/문서화돼 있지 않아, 개별 수정/삭제가 클라이언트 전송값에 따라 정책을 어길 수 있었습니다. 규약을 코드 주석과 API 문서에 명시:
- 개별 인스턴스 수정(부분 수정): `null`=미변경, `""`=삭제
- 일반 메모(값 전체 교체): `null`/`""`=비움
- 반영 위치: `InstanceEditRequest.Payload`, `Todo.applyOverride`, `MemoRequest` javadoc, REST Docs 필드 설명

## 테스트

- `TodoServiceTest.updateMemo` — 일반/반복/삭제(빈 override) 분기 검증
- `RecurrenceInstanceServiceIntegrationTest` — (실제 H2 DB) 개별 수정·삭제 메모가 마스터 전체 수정 후에도 재상속되지 않음 + 마스터 메모가 유실 없이 저장됨(회귀 테스트)
