### PR TITLE
반복 인스턴스 알림이 3가지 수정 범위에서 발송에 반영되지 않던 문제 수정

### DIFF
--- a/src/main/java/basakan/fryday/controller/todo/response/TodoDetailResponse.java
+++ b/src/main/java/basakan/fryday/controller/todo/response/TodoDetailResponse.java
@@ -24,8 +24,27 @@ public class TodoDetailResponse {
     private final Boolean overrideIsAlarm;
     private final LocalTime overrideAlarmTime;
 
+    /** 반복 인스턴스의 알림 적용 상태. 비반복 투두는 null */
+    private final AlarmSource alarmSource;
+
     private final TodoAlarmInfo alarm;
     private final RecurrenceInfo recurrence;
+
+    public enum AlarmSource {
+        INHERIT,   // Master 반복 알림 적용 중
+        OVERRIDE,  // 개별 알림 적용 중
+        NONE       // 알림 없음 (개별적으로 껐거나 Master 알림이 없음)
+    }
+
+    private static AlarmSource resolveAlarmSource(Todo todo, Recurrence recurrence) {
+        if (recurrence == null) {
+            return null;
+        }
+        if (todo.getOverrideIsAlarm() == null) {
+            return recurrence.isAlarmEnabled() ? AlarmSource.INHERIT : AlarmSource.NONE;
+        }
+        return todo.getOverrideIsAlarm() ? AlarmSource.OVERRIDE : AlarmSource.NONE;
+    }
 
     @Getter
     @Builder
@@ -84,8 +103,9 @@ public class TodoDetailResponse {
                         ? todo.getOverrideMemo() : todo.getMemo())
                 .date(todo.getDate())
                 .isOverridden(todo.isOverridden())
-                .overrideIsAlarm(todo.isOverridden() ? todo.getOverrideIsAlarm() : null)
-                .overrideAlarmTime(todo.isOverridden() ? todo.getOverrideAlarmTime() : null)
+                .overrideIsAlarm(todo.getOverrideIsAlarm())
+                .overrideAlarmTime(todo.getOverrideAlarmTime())
+                .alarmSource(resolveAlarmSource(todo, recurrence))
                 .alarm(TodoAlarmInfo.from(todoAlarm))
                 .recurrence(RecurrenceInfo.from(recurrence))
                 .build();

--- a/src/main/java/basakan/fryday/domain/todo/Todo.java
+++ b/src/main/java/basakan/fryday/domain/todo/Todo.java
@@ -136,13 +136,32 @@ public class Todo extends BaseEntity {
      * 반복 인스턴스를 개별 수정(override)한다. 각 인자는 부분 수정 규약을 따른다.
      *   - null: 해당 필드를 변경하지 않음(기존 override/상속 값 유지)
      *   - 빈 문자열(title/memo): 값을 삭제. 빈 override 로 남겨 마스터 값을 다시 상속하지 않음
+     *   - 알림은 isAlarm 기준 3-state: null=상속 유지, true=개별 알림(alarmTime), false=알림 사용 안 함
      */
     public void applyOverride(String title, String memo, Boolean isAlarm, LocalTime alarmTime) {
         if (title != null) this.overrideTitle = title;
         if (memo != null) this.overrideMemo = memo;
-        if (isAlarm != null) this.overrideIsAlarm = isAlarm;
-        if (alarmTime != null) this.overrideAlarmTime = alarmTime;
-        this.isOverridden = true;
+        if (isAlarm != null) {
+            this.overrideIsAlarm = isAlarm;
+            this.overrideAlarmTime = isAlarm ? alarmTime : null;
+        }
+        this.isOverridden = hasAnyOverride();
+    }
+
+    private boolean hasAnyOverride() {
+        return overrideTitle != null || overrideMemo != null || overrideIsAlarm != null;
+    }
+
+    public boolean inheritsAlarm() {
+        return overrideIsAlarm == null;
+    }
+
+    /** 이 회차의 유효 알림 시각. null이면 알림이 없다. */
+    public LocalTime resolveEffectiveAlarmTime(LocalTime masterNotificationTime) {
+        if (overrideIsAlarm == null) {
+            return masterNotificationTime;
+        }
+        return overrideIsAlarm ? overrideAlarmTime : null;
     }
 
     /** override 값을 base 필드에 이관하고 반복 연결을 끊어 독립 Todo로 전환 */

--- a/src/main/java/basakan/fryday/repository/todo/TodoAlarmRepository.java
+++ b/src/main/java/basakan/fryday/repository/todo/TodoAlarmRepository.java
@@ -37,6 +37,11 @@ public interface TodoAlarmRepository extends JpaRepository<TodoAlarm, Long> {
     @Query("DELETE FROM TodoAlarm ta WHERE ta.todo.id = :todoId")
     void deleteByTodoId(Long todoId);
 
+    /** 발송 이력(SENT/FAILED)은 남기고 대기 중인 알림만 제거한다. */
+    @Modifying(flushAutomatically = true)
+    @Query("DELETE FROM TodoAlarm ta WHERE ta.todo.id = :todoId AND ta.status = 'PENDING'")
+    void deletePendingByTodoId(@Param("todoId") Long todoId);
+
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("DELETE FROM TodoAlarm ta WHERE ta.todo.id IN " +
             "(SELECT t.id FROM Todo t WHERE t.recurrenceId = :recurrenceId AND t.date >= :fromDate)")

--- a/src/main/java/basakan/fryday/service/todo/RecurrenceInstanceService.java
+++ b/src/main/java/basakan/fryday/service/todo/RecurrenceInstanceService.java
@@ -16,7 +16,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,10 +26,13 @@ import java.util.List;
 @RequiredArgsConstructor
 public class RecurrenceInstanceService {
 
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+
     private final TodoRepository todoRepository;
     private final RecurrenceRepository recurrenceRepository;
     private final TodoAlarmRepository todoAlarmRepository;
     private final RecurrenceOccurrenceCalculator occurrenceCalculator;
+    private final TodoAlarmSynchronizer alarmSynchronizer;
 
     @Transactional
     public void edit(long instanceId, RecurrenceScope scope, Payload payload, long userId) {
@@ -58,11 +63,32 @@ public class RecurrenceInstanceService {
 
     // ── Edit ──────────────────────────────────────────────────────────────────
 
-    /** spec 4.3: 해당 instance의 override 필드만 갱신 */
+    /** spec 4.2: 해당 instance의 override 필드 갱신 + 개별 알림을 발송 행에 반영 */
     private void editThis(long instanceId, Payload payload, long userId) {
         Todo instance = findActiveInstance(instanceId, userId);
+        validateAlarmOverride(payload, instance);
+
         instance.applyOverride(payload.getTitle(), payload.getMemo(),
                 payload.getIsAlarmEnabled(), payload.getAlarmTime());
+
+        if (payload.getIsAlarmEnabled() != null) {
+            // override가 확정된 상태이므로 Master 시각은 판정에 쓰이지 않는다
+            alarmSynchronizer.sync(instance, userId, instance.resolveEffectiveAlarmTime(null));
+        }
+    }
+
+    /** 개별 알림 설정 시 시각 필수, 지난 시각 거부 */
+    private void validateAlarmOverride(Payload payload, Todo instance) {
+        if (!Boolean.TRUE.equals(payload.getIsAlarmEnabled())) {
+            return;
+        }
+        if (payload.getAlarmTime() == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+        LocalDateTime notifyAt = LocalDateTime.of(instance.getDate(), payload.getAlarmTime());
+        if (notifyAt.isBefore(LocalDateTime.now(KOREA_ZONE))) {
+            throw new BusinessException(ErrorCode.ALARM_TIME_IN_PAST);
+        }
     }
 
     /** spec 4.4: 기존 Master 종료 → 새 Master 생성 → T 이후 인스턴스 재생성 */
@@ -108,7 +134,7 @@ public class RecurrenceInstanceService {
         // STEP 3: T 이후 인스턴스를 새 규칙에 비춰 재배치한다.
         //         지우고 다시 만들면 displayOrder·알람·완료 상태가 날아가므로,
         //         새 규칙에 여전히 해당하는 회차는 그대로 두고 소속만 옮긴다.
-        realignInstances(oldMaster.getId(), savedNewMaster, T, payload);
+        realignInstances(oldMaster.getId(), savedNewMaster, T, payload, userId);
     }
 
     /** spec 4.5: Master 직접 수정 — override 있는 인스턴스는 건드리지 않음 */
@@ -140,7 +166,7 @@ public class RecurrenceInstanceService {
 
             // 오늘 이후 인스턴스를 새 규칙에 비춰 재배치한다 (과거 완료 이력은 보존).
             // Master가 그대로이므로 소속을 옮길 필요는 없고, 규칙에서 벗어난 회차만 정리한다.
-            realignInstances(master.getId(), master, realignFrom, payload);
+            realignInstances(master.getId(), master, realignFrom, payload, userId);
         } else {
             // 내용만 변경: Master 업데이트 + 비override 인스턴스 일괄 반영
             master.updateContent(payload.getTitle(), payload.getMemo(),
@@ -152,7 +178,24 @@ public class RecurrenceInstanceService {
             if (payload.getMemo() != null) {
                 todoRepository.bulkUpdateMemoByRecurrenceId(master.getId(), payload.getMemo());
             }
+            if (hasAlarmChange(payload)) {
+                propagateAlarmsToInheritingInstances(master, userId, LocalDate.now());
+            }
         }
+    }
+
+    /** Master 알림 변경을 오늘 이후의 상속(비override) 회차 발송 행에 전파한다. */
+    private void propagateAlarmsToInheritingInstances(Recurrence master, long userId, LocalDate fromDate) {
+        List<Todo> instances = todoRepository.findAllByRecurrenceIdAndDateGte(master.getId(), fromDate);
+        for (Todo instance : instances) {
+            if (instance.inheritsAlarm()) {
+                alarmSynchronizer.sync(instance, userId, master.getNotificationTime());
+            }
+        }
+    }
+
+    private boolean hasAlarmChange(Payload payload) {
+        return payload.getIsAlarmEnabled() != null || payload.getAlarmTime() != null;
     }
 
     // ── Delete ─────────────────────────────────────────────────────────────────
@@ -279,7 +322,7 @@ public class RecurrenceInstanceService {
      * @param newMaster          새 규칙. sourceRecurrenceId와 다르면 살아남은 회차의 소속을 옮긴다
      */
     private void realignInstances(Long sourceRecurrenceId, Recurrence newMaster,
-                                  LocalDate fromDate, Payload payload) {
+                                  LocalDate fromDate, Payload payload, long userId) {
         List<Todo> candidates = todoRepository.findAllByRecurrenceIdAndDateGte(sourceRecurrenceId, fromDate);
 
         List<Long> keptIds = new ArrayList<>();
@@ -289,6 +332,9 @@ public class RecurrenceInstanceService {
             if (matchesRule(newMaster, instance.getDate())) {
                 keptIds.add(instance.getId());
                 applyContentChange(instance, payload);
+                if (hasAlarmChange(payload) && instance.inheritsAlarm()) {
+                    alarmSynchronizer.sync(instance, userId, newMaster.getNotificationTime());
+                }
             } else {
                 droppedIds.add(instance.getId());
             }

--- a/src/main/java/basakan/fryday/service/todo/TodoAlarmService.java
+++ b/src/main/java/basakan/fryday/service/todo/TodoAlarmService.java
@@ -49,6 +49,11 @@ public class TodoAlarmService {
                             todoAlarmRepository.save(newAlarm);
                         }
                 );
+
+        // 반복 인스턴스라면 이 경로도 개별 알림 설정이므로 override 상태를 함께 기록한다
+        if (todo.getRecurrenceId() != null) {
+            todo.applyOverride(null, null, true, notifyAt.toLocalTime());
+        }
     }
 
     public void deleteTodoAlarm(Long todoId, Long userId) {
@@ -60,5 +65,10 @@ public class TodoAlarmService {
         }
 
         todoAlarmRepository.deleteByTodoId(todoId);
+
+        // 반복 인스턴스의 개별 알림 삭제는 Master 복귀가 아닌 '사용 안 함'으로 남긴다 (spec 4.2.2)
+        if (todo.getRecurrenceId() != null) {
+            todo.applyOverride(null, null, false, null);
+        }
     }
 }

--- a/src/main/java/basakan/fryday/service/todo/TodoAlarmSynchronizer.java
+++ b/src/main/java/basakan/fryday/service/todo/TodoAlarmSynchronizer.java
@@ -1,0 +1,55 @@
+package basakan.fryday.service.todo;
+
+import basakan.fryday.common.ErrorCode;
+import basakan.fryday.common.exception.BusinessException;
+import basakan.fryday.domain.todo.Todo;
+import basakan.fryday.domain.todo.TodoAlarm;
+import basakan.fryday.repository.todo.TodoAlarmRepository;
+import basakan.fryday.service.user.UserReadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+
+/**
+ * 회차의 유효 알림 시각에 맞춰 발송 행(todo_alarms)을 맞추는 단일 지점.
+ * <p>
+ * 유효 시각이 없거나 이미 지났으면 대기 중(PENDING) 행을 지워 잘못된 시각의 발송을 막는다.
+ * SENT/FAILED 행은 발송 이력이므로 어떤 경우에도 건드리지 않는다. 미래 시각이면 upsert한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class TodoAlarmSynchronizer {
+
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+
+    private final TodoAlarmRepository todoAlarmRepository;
+    private final UserReadService userReadService;
+
+    public void sync(Todo instance, Long userId, LocalTime effectiveTime) {
+        if (!instance.getCategory().getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.TODO_NOT_FOUND);
+        }
+
+        if (effectiveTime == null) {
+            todoAlarmRepository.deletePendingByTodoId(instance.getId());
+            return;
+        }
+
+        LocalDateTime notifyAt = LocalDateTime.of(instance.getDate(), effectiveTime);
+        if (notifyAt.isBefore(LocalDateTime.now(KOREA_ZONE))) {
+            todoAlarmRepository.deletePendingByTodoId(instance.getId());
+            return;
+        }
+
+        todoAlarmRepository.findByTodoId(instance.getId())
+                .ifPresentOrElse(
+                        alarm -> alarm.changeTime(notifyAt),
+                        () -> todoAlarmRepository.save(
+                                TodoAlarm.create(instance, userReadService.findById(userId), notifyAt))
+                );
+    }
+
+}

--- a/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
+++ b/src/test/java/basakan/fryday/controller/todo/TodoControllerTest.java
@@ -1170,6 +1170,7 @@ class TodoControllerTest extends RestDocsSupport {
                 .categoryId(1L)
                 .memo("꼼꼼하게 확인 필요")
                 .date(LocalDate.of(2026, 1, 8))
+                .alarmSource(TodoDetailResponse.AlarmSource.INHERIT)
                 .alarm(alarmInfo)
                 .recurrence(recurrenceInfo)
                 .build();
@@ -1199,8 +1200,9 @@ class TodoControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.memo").type(JsonFieldType.STRING).description("메모 (override 적용 값)").optional(),
                                 fieldWithPath("data.date").type(JsonFieldType.STRING).description("날짜"),
                                 fieldWithPath("data.overridden").type(JsonFieldType.BOOLEAN).description("이번 인스턴스만 개별 수정된 경우 true"),
-                                fieldWithPath("data.overrideIsAlarm").type(JsonFieldType.BOOLEAN).description("인스턴스 알람 활성화 override 값 (isOverridden=false이면 null)").optional(),
-                                fieldWithPath("data.overrideAlarmTime").type(JsonFieldType.STRING).description("인스턴스 알람 시간 override 값 (isOverridden=false이면 null)").optional(),
+                                fieldWithPath("data.overrideIsAlarm").type(JsonFieldType.BOOLEAN).description("인스턴스 알람 override 상태 (null: Master 상속 / true: 개별 알림 / false: 알림 사용 안 함)").optional(),
+                                fieldWithPath("data.overrideAlarmTime").type(JsonFieldType.STRING).description("개별 알림 시각 (overrideIsAlarm=true일 때만 값 존재)").optional(),
+                                fieldWithPath("data.alarmSource").type(JsonFieldType.STRING).description("반복 인스턴스의 알림 적용 상태 (INHERIT: 반복 알림 적용 중 / OVERRIDE: 개별 알림 적용 중 / NONE: 알림 없음). 비반복 투두는 null").optional(),
 
                                 // 알림 정보 (Optional)
                                 fieldWithPath("data.alarm").type(JsonFieldType.OBJECT).description("알림 설정 정보").optional(),

--- a/src/test/java/basakan/fryday/service/todo/AlarmOverrideReproTest.java
+++ b/src/test/java/basakan/fryday/service/todo/AlarmOverrideReproTest.java
@@ -1,0 +1,344 @@
+package basakan.fryday.service.todo;
+
+import basakan.fryday.common.ErrorCode;
+import basakan.fryday.common.config.JpaConfig;
+import basakan.fryday.common.exception.BusinessException;
+import basakan.fryday.controller.todo.request.InstanceEditRequest.Payload;
+import basakan.fryday.domain.category.Category;
+import basakan.fryday.domain.category.CategoryColor;
+import basakan.fryday.domain.todo.EndType;
+import basakan.fryday.domain.todo.Recurrence;
+import basakan.fryday.domain.todo.RecurrenceScope;
+import basakan.fryday.domain.todo.RecurrenceType;
+import basakan.fryday.domain.todo.Todo;
+import basakan.fryday.domain.todo.TodoAlarm;
+import basakan.fryday.domain.user.AuthProvider;
+import basakan.fryday.domain.user.User;
+import basakan.fryday.repository.CategoryRepository;
+import basakan.fryday.repository.auth.UserJpaRepository;
+import basakan.fryday.repository.todo.RecurrenceRepository;
+import basakan.fryday.repository.todo.TodoAlarmRepository;
+import basakan.fryday.repository.todo.TodoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * spec 4.2.2 알림 정책 재현: 인스턴스 개별 알림(override)과 Master 알림 변경이
+ * 실제 발송 대상인 todo_alarms 행에 반영되는지 검증한다.
+ */
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(
+        properties = {
+                "spring.datasource.url=jdbc:h2:mem:alarm_override_repro;MODE=MySQL;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE;DB_CLOSE_DELAY=-1",
+                "spring.datasource.driver-class-name=org.h2.Driver",
+                "spring.datasource.username=sa",
+                "spring.datasource.password=",
+                "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+                "spring.jpa.hibernate.ddl-auto=create-drop",
+                "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,"
+                        + "org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration"
+        }
+)
+@Import({
+        JpaConfig.class,
+        RecurrenceInstanceService.class,
+        RecurrenceOccurrenceCalculator.class,
+        TodoAlarmSynchronizer.class,
+        basakan.fryday.service.user.UserReadService.class
+})
+@DisplayName("알림 override 재현 테스트")
+class AlarmOverrideReproTest {
+
+    private static final LocalTime MASTER_TIME = LocalTime.of(9, 0);
+    private static final LocalTime NEW_TIME = LocalTime.of(15, 0);
+
+    @Autowired private RecurrenceInstanceService service;
+    @Autowired private TodoAlarmSynchronizer synchronizer;
+    @Autowired private UserJpaRepository userJpaRepository;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private RecurrenceRepository recurrenceRepository;
+    @Autowired private TodoRepository todoRepository;
+    @Autowired private TodoAlarmRepository todoAlarmRepository;
+
+    private User user;
+    private Long userId;
+    private Category category;
+    private Recurrence master;
+    private Todo todayInstance;
+    private Todo futureInstance;
+    private LocalDate today;
+    private LocalDate future;
+
+    @BeforeEach
+    void setUp() {
+        user = userJpaRepository.save(User.createNewUser(AuthProvider.APPLE, "alarm-repro-" + System.nanoTime(), "alarm@t.com"));
+        userId = user.getId();
+
+        category = categoryRepository.save(
+                Category.builder().name("업무").color(CategoryColor.BR).userId(userId).displayOrder(1L).build()
+        );
+
+        today = LocalDate.now();
+        future = today.plusDays(3);
+
+        master = recurrenceRepository.save(Recurrence.builder()
+                .userId(userId)
+                .categoryId(category.getId())
+                .description("반복 작업")
+                .type(RecurrenceType.DAILY)
+                .frequencyValues(null)
+                .startDate(today.minusDays(10))
+                .endDate(null)
+                .endType(EndType.NONE)
+                .notificationTime(MASTER_TIME)
+                .lastGeneratedDate(today)
+                .build()
+        );
+
+        todayInstance = todoRepository.save(Todo.builder()
+                .description("반복 작업")
+                .category(category)
+                .date(today)
+                .displayOrder(1L)
+                .recurrenceId(master.getId())
+                .build()
+        );
+
+        futureInstance = todoRepository.save(Todo.builder()
+                .description("반복 작업")
+                .category(category)
+                .date(future)
+                .displayOrder(1L)
+                .recurrenceId(master.getId())
+                .build()
+        );
+
+        todoAlarmRepository.save(TodoAlarm.create(todayInstance, user, today.atTime(MASTER_TIME)));
+        todoAlarmRepository.save(TodoAlarm.create(futureInstance, user, future.atTime(MASTER_TIME)));
+    }
+
+    private Payload payload(String memo, Boolean isAlarmEnabled, LocalTime alarmTime) {
+        Payload p = new Payload();
+        if (memo != null) ReflectionTestUtils.setField(p, "memo", memo);
+        if (isAlarmEnabled != null) ReflectionTestUtils.setField(p, "isAlarmEnabled", isAlarmEnabled);
+        if (alarmTime != null) ReflectionTestUtils.setField(p, "alarmTime", alarmTime);
+        return p;
+    }
+
+    private Optional<TodoAlarm> alarmOf(Todo instance) {
+        return todoAlarmRepository.findByTodoId(instance.getId());
+    }
+
+    // ── D3: THIS — 개별 알림이 TodoAlarm 행에 반영되어야 한다 ──────────────────
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("[THIS] 개별 알림 시각 변경 시 해당 인스턴스의 TodoAlarm.notifyAt이 바뀐다")
+    void editThis_alarmTimeChange_updatesTodoAlarmRow() {
+        service.edit(futureInstance.getId(), RecurrenceScope.THIS, payload(null, true, NEW_TIME), userId);
+
+        assertThat(alarmOf(futureInstance)).isPresent();
+        assertThat(alarmOf(futureInstance).get().getNotifyAt())
+                .as("개별 알림 시각이 실제 발송 행에 반영되어야 함")
+                .isEqualTo(future.atTime(NEW_TIME));
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("[THIS] 알림 행이 없던 인스턴스에 개별 알림 설정 시 TodoAlarm이 생성된다")
+    void editThis_alarmEnable_createsTodoAlarmRow() {
+        Todo noAlarmInstance = todoRepository.save(Todo.builder()
+                .description("반복 작업")
+                .category(category)
+                .date(today.plusDays(5))
+                .displayOrder(1L)
+                .recurrenceId(master.getId())
+                .build()
+        );
+
+        service.edit(noAlarmInstance.getId(), RecurrenceScope.THIS, payload(null, true, NEW_TIME), userId);
+
+        assertThat(alarmOf(noAlarmInstance)).as("개별 알림 설정 시 발송 행 생성").isPresent();
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("[THIS] 알림 끄기(isAlarmEnabled=false) 시 TodoAlarm이 삭제되고 '사용 안 함'이 저장된다")
+    void editThis_alarmDisable_deletesTodoAlarmRow() {
+        service.edit(futureInstance.getId(), RecurrenceScope.THIS, payload(null, false, null), userId);
+
+        assertThat(alarmOf(futureInstance)).as("알림을 껐으면 발송 행이 없어야 함").isEmpty();
+
+        Todo reloaded = todoRepository.findById(futureInstance.getId()).orElseThrow();
+        assertThat(reloaded.getOverrideIsAlarm())
+                .as("Master 복귀가 아닌 '사용 안 함' 상태로 저장 (spec 4.2.2)")
+                .isFalse();
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("[THIS] 지난 시각의 개별 알림은 ALARM_TIME_IN_PAST로 거부된다")
+    void editThis_pastAlarmTime_rejected() {
+        Todo pastInstance = todoRepository.save(Todo.builder()
+                .description("반복 작업")
+                .category(category)
+                .date(today.minusDays(1))
+                .displayOrder(1L)
+                .recurrenceId(master.getId())
+                .build()
+        );
+
+        assertThatThrownBy(() ->
+                service.edit(pastInstance.getId(), RecurrenceScope.THIS, payload(null, true, MASTER_TIME), userId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ALARM_TIME_IN_PAST);
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("[THIS] 빈 payload는 아무 override도 만들지 않는다")
+    void editThis_emptyPayload_doesNotCreateOverride() {
+        service.edit(futureInstance.getId(), RecurrenceScope.THIS, payload(null, null, null), userId);
+
+        Todo reloaded = todoRepository.findById(futureInstance.getId()).orElseThrow();
+        assertThat(reloaded.isOverridden()).as("변경 없는 수정은 override를 만들면 안 됨").isFalse();
+        assertThat(alarmOf(futureInstance).get().getNotifyAt())
+                .as("알림도 그대로")
+                .isEqualTo(future.atTime(MASTER_TIME));
+    }
+
+    // ── D4: ALL / THIS_AND_FUTURE — Master 시각 변경이 기존 회차에 전파되어야 한다 ──
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("[ALL] Master 알림 시각 변경 시 상속 중인 기존 회차의 TodoAlarm.notifyAt이 갱신된다")
+    void editAll_alarmTimeChange_propagatesToExistingRows() {
+        service.edit(todayInstance.getId(), RecurrenceScope.ALL, payload(null, true, NEW_TIME), userId);
+
+        assertThat(recurrenceRepository.findById(master.getId()).orElseThrow().getNotificationTime())
+                .as("Master 시각 갱신").isEqualTo(NEW_TIME);
+        assertThat(alarmOf(futureInstance).get().getNotifyAt())
+                .as("상속 중인 미래 회차의 발송 시각도 갱신되어야 함")
+                .isEqualTo(future.atTime(NEW_TIME));
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("[ALL] 개별 알림이 설정된 회차는 Master 시각 변경의 영향을 받지 않는다")
+    void editAll_alarmTimeChange_preservesOverriddenInstance() {
+        LocalTime customTime = LocalTime.of(20, 0);
+        Todo overridden = todoRepository.findById(futureInstance.getId()).orElseThrow();
+        overridden.applyOverride(null, null, true, customTime);
+        todoRepository.saveAndFlush(overridden);
+        TodoAlarm customAlarm = alarmOf(futureInstance).orElseThrow();
+        customAlarm.changeTime(future.atTime(customTime));
+        todoAlarmRepository.saveAndFlush(customAlarm);
+
+        service.edit(todayInstance.getId(), RecurrenceScope.ALL, payload(null, true, NEW_TIME), userId);
+
+        assertThat(alarmOf(futureInstance).get().getNotifyAt())
+                .as("개별 알림 회차는 Master 전파에서 제외 (spec 4.2.2)")
+                .isEqualTo(future.atTime(customTime));
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("[ALL] Master 알림 해제 시 상속 중인 회차의 TodoAlarm이 삭제된다")
+    void editAll_alarmDisable_removesInheritedRows() {
+        service.edit(todayInstance.getId(), RecurrenceScope.ALL, payload(null, false, null), userId);
+
+        assertThat(recurrenceRepository.findById(master.getId()).orElseThrow().isAlarmEnabled())
+                .as("Master 알림 해제").isFalse();
+        assertThat(alarmOf(futureInstance))
+                .as("상속 중이던 회차의 발송 행 제거")
+                .isEmpty();
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("[T&F] 알림 시각 변경 시 이후 회차의 TodoAlarm.notifyAt이 새 시각으로 갱신된다")
+    void editThisAndFuture_alarmTimeChange_propagatesToFutureRows() {
+        service.edit(todayInstance.getId(), RecurrenceScope.THIS_AND_FUTURE, payload(null, true, NEW_TIME), userId);
+
+        Todo reloadedFuture = todoRepository.findById(futureInstance.getId()).orElseThrow();
+        Recurrence newMaster = recurrenceRepository.findById(reloadedFuture.getRecurrenceId()).orElseThrow();
+        assertThat(newMaster.getNotificationTime()).as("새 Master 시각").isEqualTo(NEW_TIME);
+        assertThat(alarmOf(futureInstance).get().getNotifyAt())
+                .as("이후 회차의 발송 시각 갱신")
+                .isEqualTo(future.atTime(NEW_TIME));
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("[ALL] 재파생 시각이 이미 지났으면 기존 PENDING 알림을 삭제해 오발송을 막는다")
+    void editAll_pastEffectiveTime_removesStalePendingAlarm() {
+        // 오늘 회차에 20:00 PENDING 알림이 걸려 있고, Master 시각을 이미 지난 00:00으로 변경
+        service.edit(todayInstance.getId(), RecurrenceScope.ALL, payload(null, true, LocalTime.MIDNIGHT), userId);
+
+        assertThat(alarmOf(todayInstance))
+                .as("이미 지난 시각으로 바뀐 회차의 옛 PENDING 알림은 남아서 울리면 안 됨")
+                .isEmpty();
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("[ALL] 재파생 시각이 지났어도 이미 발송된(SENT) 알림 이력은 보존한다")
+    void editAll_pastEffectiveTime_preservesSentHistory() {
+        TodoAlarm sent = alarmOf(todayInstance).orElseThrow();
+        sent.markAsSent();
+        todoAlarmRepository.saveAndFlush(sent);
+
+        service.edit(todayInstance.getId(), RecurrenceScope.ALL, payload(null, true, LocalTime.MIDNIGHT), userId);
+
+        assertThat(alarmOf(todayInstance)).as("SENT 이력은 삭제하지 않음").isPresent();
+        assertThat(alarmOf(todayInstance).get().getStatus()).isEqualTo(TodoAlarm.AlarmStatus.SENT);
+    }
+
+    @Test
+    @DisplayName("Synchronizer.sync는 인스턴스 소유자가 아닌 userId를 거부한다")
+    void sync_rejectsForeignUserId() {
+        User other = userJpaRepository.save(
+                User.createNewUser(AuthProvider.APPLE, "alarm-foreign-" + System.nanoTime(), "foreign@t.com"));
+
+        assertThatThrownBy(() -> synchronizer.sync(
+                todoRepository.findById(futureInstance.getId()).orElseThrow(),
+                other.getId(), NEW_TIME))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("[ALL] 제목만 override된 회차의 알림은 계속 Master를 상속한다 (교차오염 검증)")
+    void editAll_titleOverriddenInstance_stillInheritsAlarm() {
+        Todo titleOverridden = todoRepository.findById(futureInstance.getId()).orElseThrow();
+        titleOverridden.applyOverride("개별 제목", null, null, null);
+        todoRepository.saveAndFlush(titleOverridden);
+
+        service.edit(todayInstance.getId(), RecurrenceScope.ALL, payload(null, true, NEW_TIME), userId);
+
+        assertThat(alarmOf(futureInstance).get().getNotifyAt())
+                .as("알림은 개별 수정한 적 없으므로 Master 변경을 따라와야 함")
+                .isEqualTo(future.atTime(NEW_TIME));
+    }
+}

--- a/src/test/java/basakan/fryday/service/todo/RecurrenceInstanceServiceIntegrationTest.java
+++ b/src/test/java/basakan/fryday/service/todo/RecurrenceInstanceServiceIntegrationTest.java
@@ -54,7 +54,9 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 @Import({
         JpaConfig.class,
         RecurrenceInstanceService.class,
-        RecurrenceOccurrenceCalculator.class
+        RecurrenceOccurrenceCalculator.class,
+        TodoAlarmSynchronizer.class,
+        basakan.fryday.service.user.UserReadService.class
 })
 @DisplayName("RecurrenceInstanceService 통합")
 class RecurrenceInstanceServiceIntegrationTest {


### PR DESCRIPTION
## 변경 이유

반복 투두 인스턴스 수정(이 투두만 / 이 투두 포함 이후 모든 / 모든 투두)에서 알림 값이 override 컬럼에만 저장되고 실제 발송 테이블(todo_alarms)에는 반영되지 않았습니다.

- 이 투두만: 개별 알림을 바꿔도 Master 시각에 울리고, 꺼도 계속 울림
- 이후 모든/모든 투두: Master 알림 시각을 바꿔도 이미 생성된 회차는 옛 시각에 발송 (#117의 지연 생성 전환 이후 유실→고정으로 성격만 바뀐 채 남아 있던 문제)

클라이언트는 이미 3분기 payload에 알림을 실어 보내고 있으므로 서버만 고치면 앱 배포 없이 동작합니다.

## 변경 내용

- **TodoAlarmSynchronizer(신규)**: 유효 알림 규칙(null=Master 상속 / true=개별 알림 / false=사용 안 함)을 단일 지점으로 정의하고 발송 행을 동기화
- **이 투두만(THIS)**: 개별 알림 upsert/삭제 + 지난 시각 400 검증. 개별 알림 삭제는 Master 복귀가 아닌 '사용 안 함'으로 저장 (spec 4.2.2)
- **이후 모든/모든 투두(T&F/ALL)**: Master 시각 변경을 상속 중인 기존 회차에 전파, 개별 알림 회차는 제외
- **오발송 방지**: 재파생 시각이 이미 지났으면 PENDING 행만 삭제, SENT/FAILED 이력 보존
- **경로 정합**: 필드별 알림 API(POST/DELETE /todos/{id}/alarm)도 반복 인스턴스면 override 상태 기록
- **응답 추가**: 상세 조회에 alarmSource(INHERIT/OVERRIDE/NONE) — 클라이언트의 확인 팝업·'미설정' 표시 판정 근거 (additive, 구버전 앱 영향 없음)
- **방어**: sync 진입 시 인스턴스 소유자 검증

DB 스키마 변경·마이그레이션 없음 (기존 override 컬럼의 해석만 변경).

## 테스트 결과

- 알림 통합 테스트 13건 신규 (AlarmOverrideReproTest): 3분기 반영 / 개별 알림 회차 보존 / 사용 안 함 저장 / 지난 시각 PENDING 삭제·SENT 보존 / 소유자 검증 / 빈 payload no-op
- TDD로 진행: 결함 재현 실패 확인 후 구현
- 전체 테스트 및 빌드(REST Docs 포함) 통과. develop의 #118(메모 수정)과 병합 후에도 전체 GREEN

## 리뷰 결과

backend/security 리뷰 완료:
- (치명) 지난 시각 재파생 시 옛 PENDING 알림 잔존 → PENDING 한정 삭제로 수정
- (중요) Synchronizer의 소유권 무검증 → 진입 가드 추가
- (중요) IDOR 회귀 없음, bulk flush/clear 순서 문제 없음 확인
- 보류 항목(알림 로직 이원화 정리, 전파 N+1, Clock 주입)은 후속 작업으로 분리